### PR TITLE
Makes BigInteger print hex instead of wrong decimal

### DIFF
--- a/algebra/src/biginteger/macros.rs
+++ b/algebra/src/biginteger/macros.rs
@@ -215,7 +215,7 @@ macro_rules! bigint_impl {
         impl Display for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 for i in self.0.iter().rev() {
-                    write!(f, "{:020}", *i)?;
+                    write!(f, "{:016X}", *i)?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
Currently, the BigInteger print iterates over the u64 comprising the BigInteger, and prints them in decimal concatenated, left padded with zeros to 20 characters.

This pull request modifies this to a more useful representation in hexadecimal.