### PR TITLE
Remove unused packages

### DIFF
--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -24,11 +24,9 @@ edition = "2018"
 [dependencies]
 byteorder = { version = "1" }
 rand = { version = "0.4" }
-rand_derive = { version = "0.3" }
 derivative = { version = "1" }
 
 failure = { version = "0.1.1" }
-failure_derive = { version = "0.1.1" }
 
 colored = { version = "1", optional = true }
 rayon = { version = "1", optional = true }


### PR DESCRIPTION
Remove some unused packages from `algebra`'s `Cargo.toml`. Should hopefully improve compile times.