### PR TITLE
Change the ConstraintSystem Interface to reason about fields and not `PairingEngine`s

### DIFF
--- a/algebra/src/fields/models/fp2.rs
+++ b/algebra/src/fields/models/fp2.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub trait Fp2Parameters: 'static + Send + Sync {
-    type Fp: PrimeField + SquareRootField;
+    type Fp: PrimeField;
 
     const NONRESIDUE: Self::Fp;
 
@@ -160,7 +160,9 @@ impl<P: Fp2Parameters> Field for Fp2<P> {
     }
 }
 
-impl<'a, P: Fp2Parameters> SquareRootField for Fp2<P> {
+impl<'a, P: Fp2Parameters> SquareRootField for Fp2<P> 
+where P::Fp: SquareRootField
+{
     fn legendre(&self) -> LegendreSymbol {
         self.norm().legendre()
     }

--- a/dpc/src/common/field_converter.rs
+++ b/dpc/src/common/field_converter.rs
@@ -1,4 +1,4 @@
-use algebra::{utils::*, Group, PairingEngine};
+use algebra::{utils::*, Group, Field};
 use crate::Error;
 
 use crate::{
@@ -11,35 +11,35 @@ use crate::{
 };
 use digest::Digest as HashDigest;
 
-impl<E: PairingEngine, G: Group + ToEngineFr<E>> ToEngineFr<E> for PCParameters<G> {
+impl<ConstraintF: Field, G: Group + ToConstraintField<ConstraintF>> ToConstraintField<ConstraintF> for PCParameters<G> {
     #[inline]
-    fn to_engine_fr(&self) -> Result<Vec<E::Fr>, Error> {
+    fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
         Ok(Vec::new())
     }
 }
 
-impl<E: PairingEngine, G: Group + ToEngineFr<E>> ToEngineFr<E> for PHParameters<G> {
+impl<ConstraintF: Field, G: Group + ToConstraintField<ConstraintF>> ToConstraintField<ConstraintF> for PHParameters<G> {
     #[inline]
-    fn to_engine_fr(&self) -> Result<Vec<E::Fr>, Error> {
+    fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
         Ok(Vec::new())
     }
 }
 
-impl<E: PairingEngine, G: Group + ToEngineFr<E>, D: HashDigest> ToEngineFr<E>
+impl<ConstraintF: Field, G: Group + ToConstraintField<ConstraintF>, D: HashDigest> ToConstraintField<ConstraintF>
     for SchnorrSigParameters<G, D>
 {
     #[inline]
-    fn to_engine_fr(&self) -> Result<Vec<E::Fr>, Error> {
-        self.generator.to_engine_fr()
+    fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
+        self.generator.to_field_elements()
     }
 }
 
-impl<E: PairingEngine, H: FixedLengthCRH> ToEngineFr<E> for Digest<H>
+impl<ConstraintF: Field, H: FixedLengthCRH> ToConstraintField<ConstraintF> for Digest<H>
 where
-    H::Output: ToEngineFr<E>,
+    H::Output: ToConstraintField<ConstraintF>,
 {
     #[inline]
-    fn to_engine_fr(&self) -> Result<Vec<E::Fr>, Error> {
-        self.0.to_engine_fr()
+    fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
+        self.0.to_field_elements()
     }
 }

--- a/dpc/src/crypto_primitives/nizk/gm17.rs
+++ b/dpc/src/crypto_primitives/nizk/gm17.rs
@@ -9,20 +9,23 @@ use snark::{
     Circuit,
 };
 
-use algebra::utils::ToEngineFr;
+use algebra::utils::ToConstraintField;
 use std::marker::PhantomData;
 
 use super::NIZK;
 
 /// Note: V should serialize its contents to `Vec<E::Fr>` in the same order as
 /// during the constraint generation.
-pub struct Gm17<E: PairingEngine, C: Circuit<E>, V: ToEngineFr<E> + ?Sized> {
+pub struct Gm17<E: PairingEngine, C: Circuit<E::Fr>, V: ToConstraintField<E::Fr> + ?Sized> {
+    #[doc(hidden)]
     _engine:         PhantomData<E>,
+    #[doc(hidden)]
     _circuit:        PhantomData<C>,
+    #[doc(hidden)]
     _verifier_input: PhantomData<V>,
 }
 
-impl<E: PairingEngine, C: Circuit<E>, V: ToEngineFr<E> + ?Sized> NIZK for Gm17<E, C, V> {
+impl<E: PairingEngine, C: Circuit<E::Fr>, V: ToConstraintField<E::Fr> + ?Sized> NIZK for Gm17<E, C, V> {
     type Circuit = C;
     type AssignedCircuit = C;
     type ProvingParameters = Parameters<E>;
@@ -66,7 +69,7 @@ impl<E: PairingEngine, C: Circuit<E>, V: ToEngineFr<E> + ?Sized> NIZK for Gm17<E
     ) -> Result<bool, Error> {
         let verify_time = timer_start!(|| "{Groth-Maller 2017}::Verify");
         let conversion_time = timer_start!(|| "Convert input to E::Fr");
-        let input = input.to_engine_fr()?;
+        let input = input.to_field_elements()?;
         timer_end!(conversion_time);
         let verification = timer_start!(|| format!("Verify proof w/ input len: {}", input.len()));
         let result = verify_proof(&vk, proof, &input)?;

--- a/dpc/src/crypto_primitives/nizk/mod.rs
+++ b/dpc/src/crypto_primitives/nizk/mod.rs
@@ -67,8 +67,8 @@ mod test {
             }
         }
 
-        impl Circuit<Bls12_381> for R1CSCircuit {
-            fn synthesize<CS: ConstraintSystem<Bls12_381>>(
+        impl Circuit<Fr> for R1CSCircuit {
+            fn synthesize<CS: ConstraintSystem<Fr>>(
                 self,
                 cs: &mut CS,
             ) -> Result<(), SynthesisError> {

--- a/dpc/src/dpc/delegable_dpc/core_checks_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/core_checks_circuit.rs
@@ -1,4 +1,3 @@
-use algebra::PairingEngine;
 use crate::Error;
 use snark::{Circuit, ConstraintSystem, SynthesisError};
 
@@ -15,7 +14,7 @@ use crate::{
     ledger::LedgerDigest,
 };
 
-use algebra::utils::ToEngineFr;
+use algebra::utils::ToConstraintField;
 
 pub struct CoreChecksVerifierInput<C: DelegableDPCComponents> {
     // Commitment and CRH parameters
@@ -37,54 +36,54 @@ pub struct CoreChecksVerifierInput<C: DelegableDPCComponents> {
     pub memo:            [u8; 32],
 }
 
-impl<C: DelegableDPCComponents> ToEngineFr<C::E> for CoreChecksVerifierInput<C>
+impl<C: DelegableDPCComponents> ToConstraintField<C::CoreCheckF> for CoreChecksVerifierInput<C>
 where
-    <C::AddrC as CommitmentScheme>::Parameters: ToEngineFr<C::E>,
-    <C::AddrC as CommitmentScheme>::Output: ToEngineFr<C::E>,
+    <C::AddrC as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
+    <C::AddrC as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
 
-    <C::RecC as CommitmentScheme>::Parameters: ToEngineFr<C::E>,
-    <C::RecC as CommitmentScheme>::Output: ToEngineFr<C::E>,
+    <C::RecC as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
+    <C::RecC as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
 
-    <C::SnNonceH as FixedLengthCRH>::Parameters: ToEngineFr<C::E>,
+    <C::SnNonceH as FixedLengthCRH>::Parameters: ToConstraintField<C::CoreCheckF>,
 
-    <C::PredVkComm as CommitmentScheme>::Parameters: ToEngineFr<C::E>,
-    <C::PredVkComm as CommitmentScheme>::Output: ToEngineFr<C::E>,
+    <C::PredVkComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
+    <C::PredVkComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
 
-    <C::LocalDataComm as CommitmentScheme>::Parameters: ToEngineFr<C::E>,
-    <C::LocalDataComm as CommitmentScheme>::Output: ToEngineFr<C::E>,
+    <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
+    <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
 
-    <C::S as SignatureScheme>::Parameters: ToEngineFr<C::E>,
-    <C::S as SignatureScheme>::PublicKey: ToEngineFr<C::E>,
+    <C::S as SignatureScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
+    <C::S as SignatureScheme>::PublicKey: ToConstraintField<C::CoreCheckF>,
 
-    C::D: ToEngineFr<C::E>,
-    <C::D as LedgerDigest>::Parameters: ToEngineFr<C::E>,
+    C::D: ToConstraintField<C::CoreCheckF>,
+    <C::D as LedgerDigest>::Parameters: ToConstraintField<C::CoreCheckF>,
 {
-    fn to_engine_fr(&self) -> Result<Vec<<C::E as PairingEngine>::Fr>, Error> {
+    fn to_field_elements(&self) -> Result<Vec<C::CoreCheckF>, Error> {
         let mut v = Vec::new();
 
-        v.extend_from_slice(&self.comm_crh_sig_pp.addr_comm_pp.to_engine_fr()?);
-        v.extend_from_slice(&self.comm_crh_sig_pp.rec_comm_pp.to_engine_fr()?);
-        v.extend_from_slice(&self.comm_crh_sig_pp.local_data_comm_pp.to_engine_fr()?);
-        v.extend_from_slice(&self.comm_crh_sig_pp.pred_vk_comm_pp.to_engine_fr()?);
+        v.extend_from_slice(&self.comm_crh_sig_pp.addr_comm_pp.to_field_elements()?);
+        v.extend_from_slice(&self.comm_crh_sig_pp.rec_comm_pp.to_field_elements()?);
+        v.extend_from_slice(&self.comm_crh_sig_pp.local_data_comm_pp.to_field_elements()?);
+        v.extend_from_slice(&self.comm_crh_sig_pp.pred_vk_comm_pp.to_field_elements()?);
 
-        v.extend_from_slice(&self.comm_crh_sig_pp.sn_nonce_crh_pp.to_engine_fr()?);
+        v.extend_from_slice(&self.comm_crh_sig_pp.sn_nonce_crh_pp.to_field_elements()?);
 
-        v.extend_from_slice(&self.comm_crh_sig_pp.sig_pp.to_engine_fr()?);
+        v.extend_from_slice(&self.comm_crh_sig_pp.sig_pp.to_field_elements()?);
 
-        v.extend_from_slice(&self.ledger_pp.to_engine_fr()?);
-        v.extend_from_slice(&self.ledger_digest.to_engine_fr()?);
+        v.extend_from_slice(&self.ledger_pp.to_field_elements()?);
+        v.extend_from_slice(&self.ledger_digest.to_field_elements()?);
 
         for sn in &self.old_serial_numbers {
-            v.extend_from_slice(&sn.to_engine_fr()?);
+            v.extend_from_slice(&sn.to_field_elements()?);
         }
 
         for cm in &self.new_commitments {
-            v.extend_from_slice(&cm.to_engine_fr()?);
+            v.extend_from_slice(&cm.to_field_elements()?);
         }
 
-        v.extend_from_slice(&self.predicate_comm.to_engine_fr()?);
-        v.extend_from_slice(&ToEngineFr::<C::E>::to_engine_fr(self.memo.as_ref())?);
-        v.extend_from_slice(&self.local_data_comm.to_engine_fr()?);
+        v.extend_from_slice(&self.predicate_comm.to_field_elements()?);
+        v.extend_from_slice(&ToConstraintField::<C::CoreCheckF>::to_field_elements(self.memo.as_ref())?);
+        v.extend_from_slice(&self.local_data_comm.to_field_elements()?);
 
         Ok(v)
     }
@@ -250,8 +249,8 @@ impl<C: DelegableDPCComponents> CoreChecksCircuit<C> {
     }
 }
 
-impl<C: DelegableDPCComponents> Circuit<C::E> for CoreChecksCircuit<C> {
-    fn synthesize<CS: ConstraintSystem<C::E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+impl<C: DelegableDPCComponents> Circuit<C::CoreCheckF> for CoreChecksCircuit<C> {
+    fn synthesize<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         execute_core_checks_gadget::<C, CS>(
             cs,
             // Params

--- a/dpc/src/dpc/delegable_dpc/predicate_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/predicate_circuit.rs
@@ -7,7 +7,7 @@ use crate::{
 use snark_gadgets::{uint8::UInt8, utils::AllocGadget};
 use std::io::{Result as IoResult, Write};
 
-use algebra::{bytes::ToBytes, utils::ToEngineFr, PairingEngine};
+use algebra::{bytes::ToBytes, utils::ToConstraintField};
 
 // We'll use these interfaces to construct our circuit.
 use snark::{Circuit, ConstraintSystem, SynthesisError};
@@ -112,15 +112,15 @@ pub struct PredicateLocalData<C: DelegableDPCComponents> {
 }
 
 // Convert each component to bytes and pack into field elements.
-impl<C: DelegableDPCComponents> ToEngineFr<C::E> for PredicateLocalData<C>
+impl<C: DelegableDPCComponents> ToConstraintField<C::CoreCheckF> for PredicateLocalData<C>
 where
-    <C::LocalDataComm as CommitmentScheme>::Output: ToEngineFr<C::E>,
-    <C::LocalDataComm as CommitmentScheme>::Parameters: ToEngineFr<C::E>,
+    <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
+    <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
 {
-    fn to_engine_fr(&self) -> Result<Vec<<C::E as PairingEngine>::Fr>, Error> {
-        let mut v = ToEngineFr::<C::E>::to_engine_fr([self.position].as_ref())?;
-        v.extend_from_slice(&self.local_data_comm_pp.to_engine_fr()?);
-        v.extend_from_slice(&self.local_data_comm.to_engine_fr()?);
+    fn to_field_elements(&self) -> Result<Vec<C::CoreCheckF>, Error> {
+        let mut v = ToConstraintField::<C::CoreCheckF>::to_field_elements([self.position].as_ref())?;
+        v.extend_from_slice(&self.local_data_comm_pp.to_field_elements()?);
+        v.extend_from_slice(&self.local_data_comm.to_field_elements()?);
         Ok(v)
     }
 }
@@ -161,8 +161,8 @@ impl<C: DelegableDPCComponents> EmptyPredicateCircuit<C> {
     }
 }
 
-impl<C: DelegableDPCComponents> Circuit<C::E> for EmptyPredicateCircuit<C> {
-    fn synthesize<CS: ConstraintSystem<C::E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+impl<C: DelegableDPCComponents> Circuit<C::CoreCheckF> for EmptyPredicateCircuit<C> {
+    fn synthesize<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let _position = UInt8::alloc_input_vec(cs.ns(|| "Alloc position"), &[self.position])?;
 
         let _local_data_comm_pp =

--- a/dpc/src/dpc/delegable_dpc/proof_check_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/proof_check_circuit.rs
@@ -1,4 +1,4 @@
-use algebra::{bytes::ToBytes, to_bytes, PairingEngine};
+use algebra::{bytes::ToBytes, to_bytes};
 use crate::Error;
 use snark::{Circuit, ConstraintSystem, SynthesisError};
 
@@ -12,7 +12,7 @@ use crate::{
     gadgets::dpc::delegable_dpc::execute_proof_check_gadget,
 };
 
-use algebra::utils::ToEngineFr;
+use algebra::utils::ToConstraintField;
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: DelegableDPCComponents"))]
@@ -22,39 +22,39 @@ pub struct ProofCheckVerifierInput<C: DelegableDPCComponents> {
     pub local_data_comm: <C::LocalDataComm as CommitmentScheme>::Output,
 }
 
-impl<C: DelegableDPCComponents> ToEngineFr<C::ProofCheckE> for ProofCheckVerifierInput<C>
+impl<C: DelegableDPCComponents> ToConstraintField<C::ProofCheckF> for ProofCheckVerifierInput<C>
 where
-    <C::PredVkComm as CommitmentScheme>::Parameters: ToEngineFr<C::ProofCheckE>,
-    <C::PredVkComm as CommitmentScheme>::Output: ToEngineFr<C::ProofCheckE>,
+    <C::PredVkComm as CommitmentScheme>::Parameters: ToConstraintField<C::ProofCheckF>,
+    <C::PredVkComm as CommitmentScheme>::Output: ToConstraintField<C::ProofCheckF>,
 
-    <C::PredVkH as FixedLengthCRH>::Parameters: ToEngineFr<C::ProofCheckE>,
+    <C::PredVkH as FixedLengthCRH>::Parameters: ToConstraintField<C::ProofCheckF>,
 
-    <C::LocalDataComm as CommitmentScheme>::Parameters: ToEngineFr<C::E>,
-    <C::LocalDataComm as CommitmentScheme>::Output: ToEngineFr<C::E>,
+    <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
+    <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
 {
-    fn to_engine_fr(&self) -> Result<Vec<<C::ProofCheckE as PairingEngine>::Fr>, Error> {
+    fn to_field_elements(&self) -> Result<Vec<C::ProofCheckF>, Error> {
         let mut v = Vec::new();
 
-        v.extend_from_slice(&self.comm_crh_sig_pp.pred_vk_comm_pp.to_engine_fr()?);
-        v.extend_from_slice(&self.comm_crh_sig_pp.pred_vk_crh_pp.to_engine_fr()?);
+        v.extend_from_slice(&self.comm_crh_sig_pp.pred_vk_comm_pp.to_field_elements()?);
+        v.extend_from_slice(&self.comm_crh_sig_pp.pred_vk_crh_pp.to_field_elements()?);
 
         // First we convert the input for the predicates into `E::Fr` field elements
         let local_data_comm_pp_fe =
-            ToEngineFr::<C::E>::to_engine_fr(&self.comm_crh_sig_pp.local_data_comm_pp)
+            ToConstraintField::<C::CoreCheckF>::to_field_elements(&self.comm_crh_sig_pp.local_data_comm_pp)
                 .map_err(|_| SynthesisError::AssignmentMissing)?;
-        let local_data_comm_fe = ToEngineFr::<C::E>::to_engine_fr(&self.local_data_comm)
+        let local_data_comm_fe = ToConstraintField::<C::CoreCheckF>::to_field_elements(&self.local_data_comm)
             .map_err(|_| SynthesisError::AssignmentMissing)?;
 
         // Then we convert these field elements into bytes
         let pred_input_bytes = to_bytes![local_data_comm_pp_fe, local_data_comm_fe]
             .map_err(|_| SynthesisError::AssignmentMissing)?;
 
-        // Then we convert them into `C::ProofCheckE::Fr` elements.
-        v.extend_from_slice(&ToEngineFr::<C::ProofCheckE>::to_engine_fr(
+        // Then we convert them into `C::ProofCheckF::Fr` elements.
+        v.extend_from_slice(&ToConstraintField::<C::ProofCheckF>::to_field_elements(
             pred_input_bytes.as_slice(),
         )?);
 
-        v.extend_from_slice(&self.predicate_comm.to_engine_fr()?);
+        v.extend_from_slice(&self.predicate_comm.to_field_elements()?);
 
         Ok(v)
     }
@@ -140,12 +140,12 @@ impl<C: DelegableDPCComponents> ProofCheckCircuit<C> {
     }
 }
 
-impl<C: DelegableDPCComponents> Circuit<C::ProofCheckE> for ProofCheckCircuit<C>
+impl<C: DelegableDPCComponents> Circuit<C::ProofCheckF> for ProofCheckCircuit<C>
 where
-    <C::LocalDataComm as CommitmentScheme>::Output: ToEngineFr<C::E>,
-    <C::LocalDataComm as CommitmentScheme>::Parameters: ToEngineFr<C::E>,
+    <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
+    <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
 {
-    fn synthesize<CS: ConstraintSystem<C::ProofCheckE>>(
+    fn synthesize<CS: ConstraintSystem<C::ProofCheckF>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {

--- a/dpc/src/dpc/plain_dpc/instantiated.rs
+++ b/dpc/src/dpc/plain_dpc/instantiated.rs
@@ -3,6 +3,8 @@ use algebra::curves::{
     edwards_sw6::EdwardsProjective as EdwardsSW, sw6::SW6,
 };
 
+use algebra::fields::bls12_377::{fr::Fr as Bls12_377Fr, fq::Fq as Bls12_377Fq};
+
 use crate::crypto_primitives::{
     commitment::{blake2s::Blake2sCommitment, injective_map::PedersenCommCompressor},
     crh::{
@@ -93,8 +95,9 @@ pub struct Components;
 impl PlainDPCComponents for Components {
     const NUM_INPUT_RECORDS: usize = NUM_INPUT_RECORDS;
     const NUM_OUTPUT_RECORDS: usize = NUM_OUTPUT_RECORDS;
-    type E = CoreEngine;
-    type ProofCheckE = ProofCheckEngine;
+
+    type CoreCheckF = CoreCheckF;
+    type ProofCheckF = ProofCheckF;
 
     type AddrC = AddressComm;
     type RecC = RecordComm;
@@ -125,8 +128,10 @@ impl PlainDPCComponents for Components {
 
 // Native primitives
 pub type EdwardsCompressor = TECompressor;
-pub type CoreEngine = Bls12_377;
-pub type ProofCheckEngine = SW6;
+pub type CoreCheckPairing = Bls12_377;
+pub type ProofCheckPairing = SW6;
+pub type CoreCheckF = Bls12_377Fr;
+pub type ProofCheckF = Bls12_377Fq;
 
 pub type AddressComm = PedersenCommCompressor<EdwardsBls, EdwardsCompressor, AddressWindow>;
 pub type RecordComm = PedersenCommCompressor<EdwardsBls, EdwardsCompressor, RecordWindow>;
@@ -139,10 +144,10 @@ pub type PredVkCRH = PedersenCRHCompressor<EdwardsSW, EdwardsCompressor, PredVkH
 
 pub type Predicate = DPCPredicate<Components>;
 pub type CoreCheckNIZK =
-    Gm17<CoreEngine, CoreChecksCircuit<Components>, CoreChecksVerifierInput<Components>>;
+    Gm17<CoreCheckPairing, CoreChecksCircuit<Components>, CoreChecksVerifierInput<Components>>;
 pub type ProofCheckNIZK =
-    Gm17<ProofCheckEngine, ProofCheckCircuit<Components>, ProofCheckVerifierInput<Components>>;
-pub type PredicateNIZK<C> = Gm17<CoreEngine, EmptyPredicateCircuit<C>, PredicateLocalData<C>>;
+    Gm17<ProofCheckPairing, ProofCheckCircuit<Components>, ProofCheckVerifierInput<Components>>;
+pub type PredicateNIZK<C> = Gm17<CoreCheckPairing, EmptyPredicateCircuit<C>, PredicateLocalData<C>>;
 pub type PRF = Blake2s;
 
 pub type MerkleTreeDigest = Digest<MerkleTreeCRH>;
@@ -155,14 +160,14 @@ pub type EdwardsCompressorGadget = TECompressorGadget;
 pub type RecordCommGadget = PedersenCommitmentCompressorGadget<
     EdwardsBls,
     EdwardsCompressor,
-    CoreEngine,
+    CoreCheckF,
     EdwardsBlsGadget,
     EdwardsCompressorGadget,
 >;
 pub type AddressCommGadget = PedersenCommitmentCompressorGadget<
     EdwardsBls,
     EdwardsCompressor,
-    CoreEngine,
+    CoreCheckF,
     EdwardsBlsGadget,
     EdwardsCompressorGadget,
 >;
@@ -170,7 +175,7 @@ pub type PredicateCommGadget = Blake2sCommitmentGadget;
 pub type LocalDataCommGadget = PedersenCommitmentCompressorGadget<
     EdwardsBls,
     EdwardsCompressor,
-    CoreEngine,
+    CoreCheckF,
     EdwardsBlsGadget,
     EdwardsCompressorGadget,
 >;
@@ -178,21 +183,21 @@ pub type LocalDataCommGadget = PedersenCommitmentCompressorGadget<
 pub type SnNonceCRHGadget = PedersenCRHCompressorGadget<
     EdwardsBls,
     EdwardsCompressor,
-    CoreEngine,
+    CoreCheckF,
     EdwardsBlsGadget,
     EdwardsCompressorGadget,
 >;
 pub type MerkleTreeCRHGadget = PedersenCRHCompressorGadget<
     EdwardsBls,
     EdwardsCompressor,
-    CoreEngine,
+    CoreCheckF,
     EdwardsBlsGadget,
     EdwardsCompressorGadget,
 >;
 pub type PredVkCRHGadget = PedersenCRHCompressorGadget<
     EdwardsSW,
     EdwardsCompressor,
-    ProofCheckEngine,
+    ProofCheckF,
     EdwardsSWGadget,
     EdwardsCompressorGadget,
 >;
@@ -200,7 +205,7 @@ pub type PredVkCRHGadget = PedersenCRHCompressorGadget<
 pub type MerkleTreeWitnessGadget =
     IdealLedgerGadget<RecordComm, MerkleTreeCRH, MerkleTreeCRHGadget, RecordCommGadget>;
 pub type PRFGadget = Blake2sGadget;
-pub type PredicateNIZKGadget = Gm17VerifierGadget<CoreEngine, ProofCheckEngine, PairingGadget>;
+pub type PredicateNIZKGadget = Gm17VerifierGadget<CoreCheckPairing, ProofCheckF, PairingGadget>;
 //
 
 pub type MerkleTreeIdealLedger = IdealLedger<Tx, MerkleTreeCRH>;

--- a/dpc/src/dpc/plain_dpc/mod.rs
+++ b/dpc/src/dpc/plain_dpc/mod.rs
@@ -1,4 +1,5 @@
-use algebra::{to_bytes, PairingEngine};
+use algebra::bytes::{FromBytes, ToBytes};
+use algebra::{to_bytes, PrimeField};
 use crate::Error;
 use rand::{Rand, Rng};
 use std::marker::PhantomData;
@@ -9,7 +10,6 @@ use crate::{
     gadgets::{CommitmentGadget, FixedLengthCRHGadget, LCWGadget, NIZKVerifierGadget, PRFGadget},
     ledger::{Ledger, LedgerDigest, LedgerWitness},
 };
-use algebra::bytes::{FromBytes, ToBytes};
 
 pub mod address;
 use self::address::*;
@@ -49,41 +49,41 @@ pub trait PlainDPCComponents: 'static + Sized {
     const NUM_INPUT_RECORDS: usize;
     const NUM_OUTPUT_RECORDS: usize;
 
-    type E: PairingEngine<Fq = <Self::ProofCheckE as PairingEngine>::Fr>;
-    type ProofCheckE: PairingEngine;
+    type CoreCheckF: PrimeField;
+    type ProofCheckF: PrimeField;
 
-    // Commitment scheme for address contents. Invoked only over `Self::E`.
+    // Commitment scheme for address contents. Invoked only over `Self::CoreCheckF`.
     type AddrC: CommitmentScheme;
-    type AddrCGadget: CommitmentGadget<Self::AddrC, Self::E>;
+    type AddrCGadget: CommitmentGadget<Self::AddrC, Self::CoreCheckF>;
 
-    // Commitment scheme for record contents. Invoked only over `Self::E`.
+    // Commitment scheme for record contents. Invoked only over `Self::CoreCheckF`.
     type RecC: CommitmentScheme;
-    type RecCGadget: CommitmentGadget<Self::RecC, Self::E>;
+    type RecCGadget: CommitmentGadget<Self::RecC, Self::CoreCheckF>;
 
     // Ledger digest type.
     type D: LedgerDigest + Clone;
 
-    // CRH for computing the serial number nonce. Invoked only over `Self::E`.
+    // CRH for computing the serial number nonce. Invoked only over `Self::CoreCheckF`.
     type SnNonceH: FixedLengthCRH;
-    type SnNonceHGadget: FixedLengthCRHGadget<Self::SnNonceH, Self::E>;
+    type SnNonceHGadget: FixedLengthCRHGadget<Self::SnNonceH, Self::CoreCheckF>;
 
     // CRH for hashes of birth and death verification keys.
     // This is invoked only on the larger curve.
     type PredVkH: FixedLengthCRH;
-    type PredVkHGadget: FixedLengthCRHGadget<Self::PredVkH, Self::ProofCheckE>;
+    type PredVkHGadget: FixedLengthCRHGadget<Self::PredVkH, Self::ProofCheckF>;
 
     // Commitment scheme for committing to hashes of birth and death verification
     // keys
     type PredVkComm: CommitmentScheme;
     // Used to commit to hashes of vkeys on the smaller curve and to decommit hashes
     // of vkeys on the larger curve
-    type PredVkCommGadget: CommitmentGadget<Self::PredVkComm, Self::E>
-        + CommitmentGadget<Self::PredVkComm, Self::ProofCheckE>;
+    type PredVkCommGadget: CommitmentGadget<Self::PredVkComm, Self::CoreCheckF>
+        + CommitmentGadget<Self::PredVkComm, Self::ProofCheckF>;
 
     // Commitment scheme for committing to predicate input. Invoked inside
     // `Self::MainN` and every predicate NIZK.
     type LocalDataComm: CommitmentScheme;
-    type LocalDataCommGadget: CommitmentGadget<Self::LocalDataComm, Self::E>;
+    type LocalDataCommGadget: CommitmentGadget<Self::LocalDataComm, Self::CoreCheckF>;
 
     // NIZK for non-proof-verification checks
     type MainNIZK: NIZK<
@@ -108,20 +108,20 @@ pub trait PlainDPCComponents: 'static + Sized {
 
     // NIZK Verifier gadget for the "dummy predicate" that does nothing with its
     // input.
-    type PredicateNIZKGadget: NIZKVerifierGadget<Self::PredicateNIZK, Self::ProofCheckE>;
+    type PredicateNIZKGadget: NIZKVerifierGadget<Self::PredicateNIZK, Self::ProofCheckF>;
 
     type LCW: LedgerWitness<Self::D> + Clone;
     type LCWGadget: LCWGadget<
         Self::RecC,
         Self::D,
         Self::LCW,
-        Self::E,
-        CommitmentGadget = <Self::RecCGadget as CommitmentGadget<Self::RecC, Self::E>>::OutputGadget,
+        Self::CoreCheckF,
+        CommitmentGadget = <Self::RecCGadget as CommitmentGadget<Self::RecC, Self::CoreCheckF>>::OutputGadget,
     >;
 
-    // PRF for computing serial numbers. Invoked only over `Self::E`.
+    // PRF for computing serial numbers. Invoked only over `Self::CoreCheckF`.
     type P: PRF;
-    type PGadget: PRFGadget<Self::P, Self::E>;
+    type PGadget: PRFGadget<Self::P, Self::CoreCheckF>;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/dpc/src/dpc/plain_dpc/test.rs
+++ b/dpc/src/dpc/plain_dpc/test.rs
@@ -1,6 +1,7 @@
 use super::instantiated::*;
 use algebra::{
-    curves::{bls12_377::Bls12_377, sw6::SW6},
+    fields::bls12_377::fr::Fr,
+    fields::bls12_377::fq::Fq,
     to_bytes, ToBytes,
 };
 use rand::{SeedableRng, XorShiftRng};
@@ -132,7 +133,7 @@ fn test_execute_constraint_systems() {
 
     //////////////////////////////////////////////////////////////////////////
     // Check that the core check constraint system was satisfied.
-    let mut core_cs = TestConstraintSystem::<Bls12_377>::new();
+    let mut core_cs = TestConstraintSystem::<Fr>::new();
 
     execute_core_checks_gadget::<_, _>(
         &mut core_cs.ns(|| "Core checks"),
@@ -173,7 +174,7 @@ fn test_execute_constraint_systems() {
     assert!(core_cs.is_satisfied());
 
     // Check that the proof check constraint system was satisfied.
-    let mut pf_check_cs = TestConstraintSystem::<SW6>::new();
+    let mut pf_check_cs = TestConstraintSystem::<Fq>::new();
 
     let mut old_proof_and_vk = vec![];
     for i in 0..NUM_INPUT_RECORDS {

--- a/dpc/src/gadgets/commitment/injective_map.rs
+++ b/dpc/src/gadgets/commitment/injective_map.rs
@@ -1,4 +1,4 @@
-use algebra::PairingEngine;
+use algebra::{Field, PrimeField};
 
 use crate::gadgets::commitment::{
     pedersen::{
@@ -20,36 +20,36 @@ use std::marker::PhantomData;
 pub struct PedersenCommitmentCompressorGadget<
     G: Group,
     I: InjectiveMap<G>,
-    E: PairingEngine,
-    GG: GroupGadget<G, E>,
-    IG: InjectiveMapGadget<G, I, E, GG>,
+    ConstraintF: Field,
+    GG: GroupGadget<G, ConstraintF>,
+    IG: InjectiveMapGadget<G, I, ConstraintF, GG>,
 > {
     _compressor:        PhantomData<I>,
     _compressor_gadget: PhantomData<IG>,
-    _crh:               PedersenCommitmentGadget<G, E, GG>,
+    _crh:               PedersenCommitmentGadget<G, ConstraintF, GG>,
 }
 
-impl<G, I, E, GG, IG, W> CommitmentGadget<PedersenCommCompressor<G, I, W>, E>
-    for PedersenCommitmentCompressorGadget<G, I, E, GG, IG>
+impl<G, I, ConstraintF, GG, IG, W> CommitmentGadget<PedersenCommCompressor<G, I, W>, ConstraintF>
+    for PedersenCommitmentCompressorGadget<G, I, ConstraintF, GG, IG>
 where
     G: Group,
     I: InjectiveMap<G>,
-    E: PairingEngine,
-    GG: GroupGadget<G, E>,
-    IG: InjectiveMapGadget<G, I, E, GG>,
+    ConstraintF: PrimeField,
+    GG: GroupGadget<G, ConstraintF>,
+    IG: InjectiveMapGadget<G, I, ConstraintF, GG>,
     W: PedersenWindow,
 {
     type OutputGadget = IG::OutputGadget;
-    type ParametersGadget = PedersenCommitmentGadgetParameters<G, W, E>;
+    type ParametersGadget = PedersenCommitmentGadgetParameters<G, W, ConstraintF>;
     type RandomnessGadget = PedersenRandomnessGadget;
 
-    fn check_commitment_gadget<CS: ConstraintSystem<E>>(
+    fn check_commitment_gadget<CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],
         r: &Self::RandomnessGadget,
     ) -> Result<Self::OutputGadget, SynthesisError> {
-        let result = PedersenCommitmentGadget::<G, E, GG>::check_commitment_gadget(
+        let result = PedersenCommitmentGadget::<G, ConstraintF, GG>::check_commitment_gadget(
             cs.ns(|| "PedersenComm"),
             parameters,
             input,

--- a/dpc/src/gadgets/commitment/mod.rs
+++ b/dpc/src/gadgets/commitment/mod.rs
@@ -1,5 +1,5 @@
 use crate::crypto_primitives::CommitmentScheme;
-use algebra::PairingEngine;
+use algebra::Field;
 use snark::{ConstraintSystem, SynthesisError};
 use snark_gadgets::{
     uint8::UInt8,
@@ -11,17 +11,17 @@ pub mod blake2s;
 pub mod injective_map;
 pub mod pedersen;
 
-pub trait CommitmentGadget<C: CommitmentScheme, E: PairingEngine> {
-    type OutputGadget: EqGadget<E>
-        + ToBytesGadget<E>
-        + AllocGadget<C::Output, E>
+pub trait CommitmentGadget<C: CommitmentScheme, ConstraintF: Field> {
+    type OutputGadget: EqGadget<ConstraintF>
+        + ToBytesGadget<ConstraintF>
+        + AllocGadget<C::Output, ConstraintF>
         + Clone
         + Sized
         + Debug;
-    type ParametersGadget: AllocGadget<C::Parameters, E> + Clone;
-    type RandomnessGadget: AllocGadget<C::Randomness, E> + Clone;
+    type ParametersGadget: AllocGadget<C::Parameters, ConstraintF> + Clone;
+    type RandomnessGadget: AllocGadget<C::Randomness, ConstraintF> + Clone;
 
-    fn check_commitment_gadget<CS: ConstraintSystem<E>>(
+    fn check_commitment_gadget<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],

--- a/dpc/src/gadgets/crh/mod.rs
+++ b/dpc/src/gadgets/crh/mod.rs
@@ -1,4 +1,4 @@
-use algebra::PairingEngine;
+use algebra::Field;
 use std::fmt::Debug;
 
 use crate::crypto_primitives::crh::FixedLengthCRH;
@@ -12,18 +12,18 @@ use snark_gadgets::{
 pub mod injective_map;
 pub mod pedersen;
 
-pub trait FixedLengthCRHGadget<H: FixedLengthCRH, E: PairingEngine>: Sized {
-    type OutputGadget: ConditionalEqGadget<E>
-        + EqGadget<E>
-        + ToBytesGadget<E>
-        + CondSelectGadget<E>
-        + AllocGadget<H::Output, E>
+pub trait FixedLengthCRHGadget<H: FixedLengthCRH, ConstraintF: Field>: Sized {
+    type OutputGadget: ConditionalEqGadget<ConstraintF>
+        + EqGadget<ConstraintF>
+        + ToBytesGadget<ConstraintF>
+        + CondSelectGadget<ConstraintF>
+        + AllocGadget<H::Output, ConstraintF>
         + Debug
         + Clone
         + Sized;
-    type ParametersGadget: AllocGadget<H::Parameters, E> + Clone;
+    type ParametersGadget: AllocGadget<H::Parameters, ConstraintF> + Clone;
 
-    fn check_evaluation_gadget<CS: ConstraintSystem<E>>(
+    fn check_evaluation_gadget<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],

--- a/dpc/src/gadgets/dpc/delegable_dpc.rs
+++ b/dpc/src/gadgets/dpc/delegable_dpc.rs
@@ -10,7 +10,7 @@ use crate::{
     gadgets::verifier::NIZKVerifierGadget,
     ledger::{LedgerDigest, LedgerWitness},
 };
-use algebra::{to_bytes, utils::ToEngineFr, FpParameters, PairingEngine, PrimeField};
+use algebra::{to_bytes, utils::ToConstraintField, FpParameters, PrimeField};
 use snark::{ConstraintSystem, SynthesisError};
 use snark_gadgets::{
     uint8::UInt8,
@@ -23,7 +23,7 @@ use crate::gadgets::{
 use algebra::bytes::ToBytes;
 use snark_gadgets::boolean::Boolean;
 
-pub fn execute_core_checks_gadget<C: DelegableDPCComponents, CS: ConstraintSystem<C::E>>(
+pub fn execute_core_checks_gadget<C: DelegableDPCComponents, CS: ConstraintSystem<C::CoreCheckF>>(
     cs: &mut CS,
     // Parameters
     comm_crh_sig_parameters: &CommCRHSigPublicParameters<C>,
@@ -93,7 +93,7 @@ pub fn execute_core_checks_gadget<C: DelegableDPCComponents, CS: ConstraintSyste
 
 fn delegable_dpc_execute_gadget_helper<
     C,
-    CS: ConstraintSystem<C::E>,
+    CS: ConstraintSystem<C::CoreCheckF>,
     AddrC,
     RecC,
     SnNonceH,
@@ -155,16 +155,16 @@ where
     D: LedgerDigest,
     CW: LedgerWitness<D>,
     RecC::Output: Eq,
-    AddrCGadget: CommitmentGadget<AddrC, C::E>,
-    RecCGadget: CommitmentGadget<RecC, C::E>,
-    SnNonceHGadget: FixedLengthCRHGadget<SnNonceH, C::E>,
-    PGadget: PRFGadget<P, C::E>,
+    AddrCGadget: CommitmentGadget<AddrC, C::CoreCheckF>,
+    RecCGadget: CommitmentGadget<RecC, C::CoreCheckF>,
+    SnNonceHGadget: FixedLengthCRHGadget<SnNonceH, C::CoreCheckF>,
+    PGadget: PRFGadget<P, C::CoreCheckF>,
     LGadget: LCWGadget<
         RecC,
         D,
         CW,
-        C::E,
-        CommitmentGadget = <RecCGadget as CommitmentGadget<RecC, C::E>>::OutputGadget,
+        C::CoreCheckF,
+        CommitmentGadget = <RecCGadget as CommitmentGadget<RecC, C::CoreCheckF>>::OutputGadget,
     >,
 {
     let mut old_sns = Vec::with_capacity(old_records.len());
@@ -216,7 +216,7 @@ where
             )?;
 
         let pred_vk_comm_pp =
-            <C::PredVkCommGadget as CommitmentGadget<_, C::E>>::ParametersGadget::alloc_input(
+            <C::PredVkCommGadget as CommitmentGadget<_, C::CoreCheckF>>::ParametersGadget::alloc_input(
                 &mut cs.ns(|| "Declare Pred Vk COMM parameters"),
                 || Ok(&comm_crh_sig_parameters.pred_vk_comm_pp),
             )?;
@@ -634,19 +634,19 @@ where
         }
 
         let given_comm_rand =
-            <C::PredVkCommGadget as CommitmentGadget<_, C::E>>::RandomnessGadget::alloc(
+            <C::PredVkCommGadget as CommitmentGadget<_, C::CoreCheckF>>::RandomnessGadget::alloc(
                 &mut comm_cs.ns(|| "Commitment randomness"),
                 || Ok(predicate_rand),
             )?;
 
         let given_comm =
-            <C::PredVkCommGadget as CommitmentGadget<_, C::E>>::OutputGadget::alloc_input(
+            <C::PredVkCommGadget as CommitmentGadget<_, C::CoreCheckF>>::OutputGadget::alloc_input(
                 &mut comm_cs.ns(|| "Commitment output"),
                 || Ok(predicate_comm),
             )?;
 
         let candidate_commitment =
-            <C::PredVkCommGadget as CommitmentGadget<_, C::E>>::check_commitment_gadget(
+            <C::PredVkCommGadget as CommitmentGadget<_, C::CoreCheckF>>::check_commitment_gadget(
                 &mut comm_cs.ns(|| "Compute commitment"),
                 &pred_vk_comm_pp,
                 &input,
@@ -719,7 +719,7 @@ where
     Ok(())
 }
 
-pub fn execute_proof_check_gadget<C: DelegableDPCComponents, CS: ConstraintSystem<C::ProofCheckE>>(
+pub fn execute_proof_check_gadget<C: DelegableDPCComponents, CS: ConstraintSystem<C::ProofCheckF>>(
     cs: &mut CS,
     // Parameters
     comm_crh_sig_parameters: &CommCRHSigPublicParameters<C>,
@@ -737,19 +737,19 @@ pub fn execute_proof_check_gadget<C: DelegableDPCComponents, CS: ConstraintSyste
     local_data_comm: &<C::LocalDataComm as CommitmentScheme>::Output,
 ) -> Result<(), SynthesisError>
 where
-    <C::LocalDataComm as CommitmentScheme>::Output: ToEngineFr<C::E>,
-    <C::LocalDataComm as CommitmentScheme>::Parameters: ToEngineFr<C::E>,
+    <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
+    <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
 {
     // Declare public parameters.
     let (pred_vk_comm_pp, pred_vk_crh_pp) = {
         let cs = &mut cs.ns(|| "Declare Comm and CRH parameters");
 
-        let pred_vk_comm_pp = <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckE>>::ParametersGadget::alloc_input(
+        let pred_vk_comm_pp = <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckF>>::ParametersGadget::alloc_input(
             &mut cs.ns(|| "Declare Pred Vk COMM parameters"),
             || Ok(&comm_crh_sig_parameters.pred_vk_comm_pp),
         )?;
 
-        let pred_vk_crh_pp = <C::PredVkHGadget as FixedLengthCRHGadget<_, C::ProofCheckE>>::ParametersGadget::alloc_input(
+        let pred_vk_crh_pp = <C::PredVkHGadget as FixedLengthCRHGadget<_, C::ProofCheckF>>::ParametersGadget::alloc_input(
             &mut cs.ns(|| "Declare Pred Vk CRH parameters"),
             || Ok(&comm_crh_sig_parameters.pred_vk_crh_pp),
         )?;
@@ -761,11 +761,11 @@ where
     // Construct predicate input
     // ************************************************************************
 
-    // First we convert the input for the predicates into `E::Fr` field elements
+    // First we convert the input for the predicates into `CoreCheckF` field elements
     let local_data_comm_pp_fe =
-        ToEngineFr::<C::E>::to_engine_fr(&comm_crh_sig_parameters.local_data_comm_pp)
+        ToConstraintField::<C::CoreCheckF>::to_field_elements(&comm_crh_sig_parameters.local_data_comm_pp)
             .map_err(|_| SynthesisError::AssignmentMissing)?;
-    let local_data_comm_fe = ToEngineFr::<C::E>::to_engine_fr(local_data_comm)
+    let local_data_comm_fe = ToConstraintField::<C::CoreCheckF>::to_field_elements(local_data_comm)
         .map_err(|_| SynthesisError::AssignmentMissing)?;
 
     // Then we convert these field elements back into bytes
@@ -778,7 +778,7 @@ where
         &local_data_bytes,
     )?;
 
-    let e_fr_num_bits = <<C::E as PairingEngine>::Fr as PrimeField>::Params::MODULUS_BITS as usize;
+    let e_fr_num_bits = <C::CoreCheckF as PrimeField>::Params::MODULUS_BITS as usize;
     let e_fr_num_bits_nearest_64 =
         e_fr_num_bits / 64 * 64 + (if e_fr_num_bits % 64 == 0 { 0 } else { 64 });
 
@@ -887,18 +887,18 @@ where
         }
 
         let given_comm_rand =
-            <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckE>>::RandomnessGadget::alloc(
+            <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckF>>::RandomnessGadget::alloc(
                 &mut comm_cs.ns(|| "Commitment randomness"),
                 || Ok(predicate_rand),
             )?;
 
-        let given_comm = <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckE>>::OutputGadget::alloc_input(
+        let given_comm = <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckF>>::OutputGadget::alloc_input(
             &mut comm_cs.ns(|| "Commitment output"),
             || Ok(predicate_comm),
         )?;
 
         let candidate_commitment =
-            <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckE>>::check_commitment_gadget(
+            <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckF>>::check_commitment_gadget(
                 &mut comm_cs.ns(|| "Compute commitment"),
                 &pred_vk_comm_pp,
                 &input,

--- a/dpc/src/gadgets/prf/mod.rs
+++ b/dpc/src/gadgets/prf/mod.rs
@@ -1,4 +1,4 @@
-use algebra::PairingEngine;
+use algebra::Field;
 use std::fmt::Debug;
 
 use crate::crypto_primitives::prf::PRF;
@@ -11,12 +11,12 @@ use snark_gadgets::{
 
 pub mod blake2s;
 
-pub trait PRFGadget<P: PRF, E: PairingEngine> {
-    type OutputGadget: EqGadget<E> + ToBytesGadget<E> + AllocGadget<P::Output, E> + Clone + Debug;
+pub trait PRFGadget<P: PRF, ConstraintF: Field> {
+    type OutputGadget: EqGadget<ConstraintF> + ToBytesGadget<ConstraintF> + AllocGadget<P::Output, ConstraintF> + Clone + Debug;
 
-    fn new_seed<CS: ConstraintSystem<E>>(cs: CS, output: &P::Seed) -> Vec<UInt8>;
+    fn new_seed<CS: ConstraintSystem<ConstraintF>>(cs: CS, output: &P::Seed) -> Vec<UInt8>;
 
-    fn check_evaluation_gadget<CS: ConstraintSystem<E>>(
+    fn check_evaluation_gadget<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         seed: &[UInt8],
         input: &[UInt8],

--- a/dpc/src/gadgets/signature/mod.rs
+++ b/dpc/src/gadgets/signature/mod.rs
@@ -1,4 +1,4 @@
-use algebra::PairingEngine;
+use algebra::Field;
 use snark::{ConstraintSystem, SynthesisError};
 use snark_gadgets::{
     uint8::UInt8,
@@ -9,12 +9,12 @@ use crate::crypto_primitives::signature::SignatureScheme;
 
 pub mod schnorr;
 
-pub trait SigRandomizePkGadget<S: SignatureScheme, E: PairingEngine> {
-    type ParametersGadget: AllocGadget<S::Parameters, E> + Clone;
+pub trait SigRandomizePkGadget<S: SignatureScheme, ConstraintF: Field> {
+    type ParametersGadget: AllocGadget<S::Parameters, ConstraintF> + Clone;
 
-    type PublicKeyGadget: ToBytesGadget<E> + EqGadget<E> + AllocGadget<S::PublicKey, E> + Clone;
+    type PublicKeyGadget: ToBytesGadget<ConstraintF> + EqGadget<ConstraintF> + AllocGadget<S::PublicKey, ConstraintF> + Clone;
 
-    fn check_randomization_gadget<CS: ConstraintSystem<E>>(
+    fn check_randomization_gadget<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         public_key: &Self::PublicKeyGadget,

--- a/dpc/src/gadgets/verifier/gm17.rs
+++ b/dpc/src/gadgets/verifier/gm17.rs
@@ -1,5 +1,5 @@
 use crate::{crypto_primitives::nizk::gm17::Gm17, gadgets::verifier::NIZKVerifierGadget};
-use algebra::{utils::ToEngineFr, AffineCurve, PairingEngine};
+use algebra::{Field, utils::ToConstraintField, AffineCurve, PairingEngine};
 use snark::{
     gm17::{Proof, VerifyingKey},
     Circuit, ConstraintSystem, SynthesisError,
@@ -17,8 +17,8 @@ use std::{borrow::Borrow, marker::PhantomData};
 #[derivative(Clone(bound = "P::G1Gadget: Clone, P::G2Gadget: Clone"))]
 pub struct ProofGadget<
     PairingE: PairingEngine,
-    ConstraintE: PairingEngine,
-    P: PairingGadget<PairingE, ConstraintE>,
+    ConstraintF: Field,
+    P: PairingGadget<PairingE, ConstraintF>,
 > {
     pub a: P::G1Gadget,
     pub b: P::G2Gadget,
@@ -32,8 +32,8 @@ pub struct ProofGadget<
 ))]
 pub struct VerifyingKeyGadget<
     PairingE: PairingEngine,
-    ConstraintE: PairingEngine,
-    P: PairingGadget<PairingE, ConstraintE>,
+    ConstraintF: Field,
+    P: PairingGadget<PairingE, ConstraintF>,
 > {
     pub h_g2:       P::G2Gadget,
     pub g_alpha_g1: P::G1Gadget,
@@ -45,14 +45,14 @@ pub struct VerifyingKeyGadget<
 
 impl<
         PairingE: PairingEngine,
-        ConstraintE: PairingEngine,
-        P: PairingGadget<PairingE, ConstraintE>,
-    > VerifyingKeyGadget<PairingE, ConstraintE, P>
+        ConstraintF: Field,
+        P: PairingGadget<PairingE, ConstraintF>,
+    > VerifyingKeyGadget<PairingE, ConstraintF, P>
 {
-    pub fn prepare<CS: ConstraintSystem<ConstraintE>>(
+    pub fn prepare<CS: ConstraintSystem<ConstraintF>>(
         &self,
         mut cs: CS,
-    ) -> Result<PreparedVerifyingKeyGadget<PairingE, ConstraintE, P>, SynthesisError> {
+    ) -> Result<PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>, SynthesisError> {
         let mut cs = cs.ns(|| "Preparing verifying key");
         let g_alpha_pc = P::prepare_g1(&mut cs.ns(|| "Prepare g_alpha_g1"), &self.g_alpha_g1)?;
         let h_beta_pc = P::prepare_g2(&mut cs.ns(|| "Prepare h_beta_g2"), &self.h_beta_g2)?;
@@ -79,8 +79,8 @@ impl<
 ))]
 pub struct PreparedVerifyingKeyGadget<
     PairingE: PairingEngine,
-    ConstraintE: PairingEngine,
-    P: PairingGadget<PairingE, ConstraintE>,
+    ConstraintF: Field,
+    P: PairingGadget<PairingE, ConstraintF>,
 > {
     pub g_alpha:    P::G1Gadget,
     pub h_beta:     P::G2Gadget,
@@ -92,28 +92,28 @@ pub struct PreparedVerifyingKeyGadget<
     pub query:      Vec<P::G1Gadget>,
 }
 
-pub struct Gm17VerifierGadget<PairingE, ConstraintE, P>
+pub struct Gm17VerifierGadget<PairingE, ConstraintF, P>
 where
     PairingE: PairingEngine,
-    ConstraintE: PairingEngine,
-    P: PairingGadget<PairingE, ConstraintE>,
+    ConstraintF: Field,
+    P: PairingGadget<PairingE, ConstraintF>,
 {
     _pairing_engine: PhantomData<PairingE>,
-    _engine:         PhantomData<ConstraintE>,
+    _engine:         PhantomData<ConstraintF>,
     _pairing_gadget: PhantomData<P>,
 }
 
-impl<PairingE, ConstraintE, P, C, V> NIZKVerifierGadget<Gm17<PairingE, C, V>, ConstraintE>
-    for Gm17VerifierGadget<PairingE, ConstraintE, P>
+impl<PairingE, ConstraintF, P, C, V> NIZKVerifierGadget<Gm17<PairingE, C, V>, ConstraintF>
+    for Gm17VerifierGadget<PairingE, ConstraintF, P>
 where
     PairingE: PairingEngine,
-    ConstraintE: PairingEngine,
-    C: Circuit<PairingE>,
-    V: ToEngineFr<PairingE>,
-    P: PairingGadget<PairingE, ConstraintE>,
+    ConstraintF: Field,
+    C: Circuit<PairingE::Fr>,
+    V: ToConstraintField<PairingE::Fr>,
+    P: PairingGadget<PairingE, ConstraintF>,
 {
-    type VerificationKeyGadget = VerifyingKeyGadget<PairingE, ConstraintE, P>;
-    type ProofGadget = ProofGadget<PairingE, ConstraintE, P>;
+    type VerificationKeyGadget = VerifyingKeyGadget<PairingE, ConstraintF, P>;
+    type ProofGadget = ProofGadget<PairingE, ConstraintF, P>;
 
     fn check_verify<'a, CS, I, T>(
         mut cs: CS,
@@ -122,9 +122,9 @@ where
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintE>,
+        CS: ConstraintSystem<ConstraintF>,
         I: Iterator<Item = &'a T>,
-        T: 'a + ToBitsGadget<ConstraintE> + ?Sized,
+        T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
     {
         let pvk = vk.prepare(&mut cs.ns(|| "Prepare vk"))?;
         // e(A*G^{alpha}, B*H^{beta}) = e(G^{alpha}, H^{beta}) * e(G^{psi}, H^{gamma}) *
@@ -202,15 +202,15 @@ where
     }
 }
 
-impl<PairingE, ConstraintE, P> AllocGadget<VerifyingKey<PairingE>, ConstraintE>
-    for VerifyingKeyGadget<PairingE, ConstraintE, P>
+impl<PairingE, ConstraintF, P> AllocGadget<VerifyingKey<PairingE>, ConstraintF>
+    for VerifyingKeyGadget<PairingE, ConstraintF, P>
 where
     PairingE: PairingEngine,
-    ConstraintE: PairingEngine,
-    P: PairingGadget<PairingE, ConstraintE>,
+    ConstraintF: Field,
+    P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn alloc<FN, T, CS: ConstraintSystem<ConstraintE>>(
+    fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -260,7 +260,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintE>>(
+    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -312,15 +312,15 @@ where
     }
 }
 
-impl<PairingE, ConstraintE, P> AllocGadget<Proof<PairingE>, ConstraintE>
-    for ProofGadget<PairingE, ConstraintE, P>
+impl<PairingE, ConstraintF, P> AllocGadget<Proof<PairingE>, ConstraintF>
+    for ProofGadget<PairingE, ConstraintF, P>
 where
     PairingE: PairingEngine,
-    ConstraintE: PairingEngine,
-    P: PairingGadget<PairingE, ConstraintE>,
+    ConstraintF: Field,
+    P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn alloc<FN, T, CS: ConstraintSystem<ConstraintE>>(
+    fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -338,7 +338,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintE>>(
+    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -358,15 +358,15 @@ where
     }
 }
 
-impl<PairingE, ConstraintE, P> ToBytesGadget<ConstraintE>
-    for VerifyingKeyGadget<PairingE, ConstraintE, P>
+impl<PairingE, ConstraintF, P> ToBytesGadget<ConstraintF>
+    for VerifyingKeyGadget<PairingE, ConstraintF, P>
 where
     PairingE: PairingEngine,
-    ConstraintE: PairingEngine,
-    P: PairingGadget<PairingE, ConstraintE>,
+    ConstraintF: Field,
+    P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn to_bytes<CS: ConstraintSystem<ConstraintE>>(
+    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -399,7 +399,7 @@ where
         Ok(bytes)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintE>>(
+    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -413,8 +413,9 @@ mod test {
 
     use super::*;
     use algebra::{
-        curves::{bls12_377::Bls12_377, sw6::SW6},
+        curves::bls12_377::Bls12_377,
         fields::bls12_377::Fr,
+        fields::bls12_377::Fq,
         BitIterator, PrimeField,
     };
     use rand::{thread_rng, Rng};
@@ -423,18 +424,18 @@ mod test {
         test_constraint_system::TestConstraintSystem, utils::AllocGadget,
     };
 
-    type TestProofSystem = Gm17<Bls12_377, Bench<Bls12_377>, Fr>;
-    type TestVerifierGadget = Gm17VerifierGadget<Bls12_377, SW6, Bls12_377PairingGadget>;
-    type TestProofGadget = ProofGadget<Bls12_377, SW6, Bls12_377PairingGadget>;
-    type TestVkGadget = VerifyingKeyGadget<Bls12_377, SW6, Bls12_377PairingGadget>;
+    type TestProofSystem = Gm17<Bls12_377, Bench<Fr>, Fr>;
+    type TestVerifierGadget = Gm17VerifierGadget<Bls12_377, Fq, Bls12_377PairingGadget>;
+    type TestProofGadget = ProofGadget<Bls12_377, Fq, Bls12_377PairingGadget>;
+    type TestVkGadget = VerifyingKeyGadget<Bls12_377, Fq, Bls12_377PairingGadget>;
 
-    struct Bench<E: PairingEngine> {
-        inputs:          Vec<Option<E::Fr>>,
+    struct Bench<F: Field> {
+        inputs:          Vec<Option<F>>,
         num_constraints: usize,
     }
 
-    impl<E: PairingEngine> Circuit<E> for Bench<E> {
-        fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    impl<F: Field> Circuit<F> for Bench<F> {
+        fn synthesize<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
             assert!(self.inputs.len() >= 2);
             assert!(self.num_constraints >= self.inputs.len());
 
@@ -481,7 +482,7 @@ mod test {
             inputs.push(Some(rng.gen()));
         }
         let params = {
-            let c = Bench::<Bls12_377> {
+            let c = Bench::<Fr> {
                 inputs: vec![None; num_inputs],
                 num_constraints,
             };
@@ -502,7 +503,7 @@ mod test {
             };
 
             // assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
-            let mut cs = TestConstraintSystem::<SW6>::new();
+            let mut cs = TestConstraintSystem::<Fq>::new();
 
             let inputs: Vec<_> = inputs.into_iter().map(|input| input.unwrap()).collect();
             let mut input_gadgets = Vec::new();
@@ -527,7 +528,7 @@ mod test {
             let proof_gadget =
                 TestProofGadget::alloc(cs.ns(|| "Proof"), || Ok(proof.clone())).unwrap();
             println!("Time to verify!\n\n\n\n");
-            <TestVerifierGadget as NIZKVerifierGadget<TestProofSystem, SW6>>::check_verify(
+            <TestVerifierGadget as NIZKVerifierGadget<TestProofSystem, Fq>>::check_verify(
                 cs.ns(|| "Verify"),
                 &vk_gadget,
                 input_gadgets.iter(),

--- a/dpc/src/gadgets/verifier/mod.rs
+++ b/dpc/src/gadgets/verifier/mod.rs
@@ -1,4 +1,4 @@
-use algebra::PairingEngine;
+use algebra::Field;
 use snark::{ConstraintSystem, SynthesisError};
 
 use crate::crypto_primitives::nizk::NIZK;
@@ -6,10 +6,10 @@ use snark_gadgets::utils::{AllocGadget, ToBitsGadget, ToBytesGadget};
 
 pub mod gm17;
 
-pub trait NIZKVerifierGadget<N: NIZK, E: PairingEngine> {
-    type VerificationKeyGadget: AllocGadget<N::VerificationParameters, E> + ToBytesGadget<E>;
+pub trait NIZKVerifierGadget<N: NIZK, ConstraintF: Field> {
+    type VerificationKeyGadget: AllocGadget<N::VerificationParameters, ConstraintF> + ToBytesGadget<ConstraintF>;
 
-    type ProofGadget: AllocGadget<N::Proof, E>;
+    type ProofGadget: AllocGadget<N::Proof, ConstraintF>;
 
     fn check_verify<'a, CS, I, T>(
         cs: CS,
@@ -18,7 +18,7 @@ pub trait NIZKVerifierGadget<N: NIZK, E: PairingEngine> {
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError>
     where
-        CS: ConstraintSystem<E>,
+        CS: ConstraintSystem<ConstraintF>,
         I: Iterator<Item = &'a T>,
-        T: 'a + ToBitsGadget<E> + ?Sized;
+        T: 'a + ToBitsGadget<ConstraintF> + ?Sized;
 }

--- a/dpc/src/predicates/plain_dpc/predicate_circuit.rs
+++ b/dpc/src/predicates/plain_dpc/predicate_circuit.rs
@@ -1,6 +1,6 @@
 use crate::plain_dpc::*;
 use crate::dpc::Record;
-use crate::common::ToEngineFr;
+use crate::common::ToConstraintField;
 use algebra::bytes::ToBytes;
 use std::io::{Write, Result as IoResult};
 use crate::crypto_primitives::{CommitmentScheme, PRF};

--- a/snark-gadgets/src/bits/boolean.rs
+++ b/snark-gadgets/src/bits/boolean.rs
@@ -1,4 +1,4 @@
-use algebra::{BitIterator, Field, FpParameters, PairingEngine, PrimeField};
+use algebra::{BitIterator, Field, FpParameters, PrimeField};
 
 use crate::{
     bits::uint8::UInt8,
@@ -27,10 +27,10 @@ impl AllocatedBit {
 
     /// Performs an XOR operation over the two operands, returning
     /// an `AllocatedBit`.
-    pub fn xor<E, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
+    pub fn xor<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -40,11 +40,11 @@ impl AllocatedBit {
                 if a.value.get()? ^ b.value.get()? {
                     result_value = Some(true);
 
-                    Ok(E::Fr::one())
+                    Ok(ConstraintF::one())
                 } else {
                     result_value = Some(false);
 
-                    Ok(E::Fr::zero())
+                    Ok(ConstraintF::zero())
                 }
             },
         )?;
@@ -79,10 +79,10 @@ impl AllocatedBit {
 
     /// Performs an AND operation over the two operands, returning
     /// an `AllocatedBit`.
-    pub fn and<E, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
+    pub fn and<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -92,11 +92,11 @@ impl AllocatedBit {
                 if a.value.get()? & b.value.get()? {
                     result_value = Some(true);
 
-                    Ok(E::Fr::one())
+                    Ok(ConstraintF::one())
                 } else {
                     result_value = Some(false);
 
-                    Ok(E::Fr::zero())
+                    Ok(ConstraintF::zero())
                 }
             },
         )?;
@@ -118,19 +118,19 @@ impl AllocatedBit {
 
     /// Performs an OR operation over the two operands, returning
     /// an `AllocatedBit`.
-    pub fn or<E, CS>(cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
+    pub fn or<ConstraintF, CS>(cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         Self::conditionally_select(cs, &Boolean::from(*a), a, b)
     }
 
     /// Calculates `a AND (NOT b)`.
-    pub fn and_not<E, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
+    pub fn and_not<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -140,11 +140,11 @@ impl AllocatedBit {
                 if a.value.get()? & !b.value.get()? {
                     result_value = Some(true);
 
-                    Ok(E::Fr::one())
+                    Ok(ConstraintF::one())
                 } else {
                     result_value = Some(false);
 
-                    Ok(E::Fr::zero())
+                    Ok(ConstraintF::zero())
                 }
             },
         )?;
@@ -165,10 +165,10 @@ impl AllocatedBit {
     }
 
     /// Calculates `(NOT a) AND (NOT b)`.
-    pub fn nor<E, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
+    pub fn nor<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -178,11 +178,11 @@ impl AllocatedBit {
                 if !a.value.get()? & !b.value.get()? {
                     result_value = Some(true);
 
-                    Ok(E::Fr::one())
+                    Ok(ConstraintF::one())
                 } else {
                     result_value = Some(false);
 
-                    Ok(E::Fr::zero())
+                    Ok(ConstraintF::zero())
                 }
             },
         )?;
@@ -211,8 +211,8 @@ impl PartialEq for AllocatedBit {
 
 impl Eq for AllocatedBit {}
 
-impl<E: PairingEngine> AllocGadget<bool, E> for AllocatedBit {
-    fn alloc<F, T, CS: ConstraintSystem<E>>(
+impl<ConstraintF: Field> AllocGadget<bool, ConstraintF> for AllocatedBit {
+    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -226,9 +226,9 @@ impl<E: PairingEngine> AllocGadget<bool, E> for AllocatedBit {
             || {
                 value = Some(*value_gen()?.borrow());
                 if value.get()? {
-                    Ok(E::Fr::one())
+                    Ok(ConstraintF::one())
                 } else {
-                    Ok(E::Fr::zero())
+                    Ok(ConstraintF::zero())
                 }
             },
         )?;
@@ -248,7 +248,7 @@ impl<E: PairingEngine> AllocGadget<bool, E> for AllocatedBit {
         })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<E>>(
+    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -262,9 +262,9 @@ impl<E: PairingEngine> AllocGadget<bool, E> for AllocatedBit {
             || {
                 value = Some(*value_gen()?.borrow());
                 if value.get()? {
-                    Ok(E::Fr::one())
+                    Ok(ConstraintF::one())
                 } else {
-                    Ok(E::Fr::zero())
+                    Ok(ConstraintF::zero())
                 }
             },
         )?;
@@ -285,8 +285,8 @@ impl<E: PairingEngine> AllocGadget<bool, E> for AllocatedBit {
     }
 }
 
-impl<E: PairingEngine> CondSelectGadget<E> for AllocatedBit {
-    fn conditionally_select<CS: ConstraintSystem<E>>(
+impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for AllocatedBit {
+    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -315,7 +315,7 @@ impl<E: PairingEngine> CondSelectGadget<E> for AllocatedBit {
         let one = CS::one();
         cs.enforce(
             || "conditionally_select",
-            |_| cond.lc(one, E::Fr::one()),
+            |_| cond.lc(one, ConstraintF::one()),
             |lc| lc + first.variable - second.variable,
             |lc| lc + result.variable - second.variable,
         );
@@ -349,24 +349,24 @@ impl Boolean {
         }
     }
 
-    pub fn lc<E: PairingEngine>(&self, one: Variable, coeff: E::Fr) -> LinearCombination<E> {
+    pub fn lc<ConstraintF: Field>(&self, one: Variable, coeff: ConstraintF) -> LinearCombination<ConstraintF> {
         match *self {
             Boolean::Constant(c) => {
                 if c {
                     (coeff, one).into()
                 } else {
-                    LinearCombination::<E>::zero()
+                    LinearCombination::<ConstraintF>::zero()
                 }
             },
             Boolean::Is(ref v) => (coeff, v.get_variable()).into(),
             Boolean::Not(ref v) => {
-                LinearCombination::<E>::zero() + (coeff, one) - (coeff, v.get_variable())
+                LinearCombination::<ConstraintF>::zero() + (coeff, one) - (coeff, v.get_variable())
             },
         }
     }
 
     /// Construct a boolean vector from a vector of u8
-    pub fn constant_u8_vec<E: PairingEngine, CS: ConstraintSystem<E>>(
+    pub fn constant_u8_vec<ConstraintF: Field, CS: ConstraintSystem<ConstraintF>>(
         cs: &mut CS,
         values: &[u8],
     ) -> Vec<Self> {
@@ -399,10 +399,10 @@ impl Boolean {
     }
 
     /// Perform XOR over two boolean operands
-    pub fn xor<'a, E, CS>(cs: CS, a: &'a Self, b: &'a Self) -> Result<Self, SynthesisError>
+    pub fn xor<'a, ConstraintF, CS>(cs: CS, a: &'a Self, b: &'a Self) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         match (a, b) {
             (&Boolean::Constant(false), x) | (x, &Boolean::Constant(false)) => Ok(*x),
@@ -421,10 +421,10 @@ impl Boolean {
     }
 
     /// Perform OR over two boolean operands
-    pub fn or<'a, E, CS>(cs: CS, a: &'a Self, b: &'a Self) -> Result<Self, SynthesisError>
+    pub fn or<'a, ConstraintF, CS>(cs: CS, a: &'a Self, b: &'a Self) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         match (a, b) {
             (&Boolean::Constant(false), x) | (x, &Boolean::Constant(false)) => Ok(*x),
@@ -444,10 +444,10 @@ impl Boolean {
     }
 
     /// Perform AND over two boolean operands
-    pub fn and<'a, E, CS>(cs: CS, a: &'a Self, b: &'a Self) -> Result<Self, SynthesisError>
+    pub fn and<'a, ConstraintF, CS>(cs: CS, a: &'a Self, b: &'a Self) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         match (a, b) {
             // false AND x is always false
@@ -472,10 +472,10 @@ impl Boolean {
         }
     }
 
-    pub fn kary_and<E, CS>(mut cs: CS, bits: &[Self]) -> Result<Self, SynthesisError>
+    pub fn kary_and<ConstraintF, CS>(mut cs: CS, bits: &[Self]) -> Result<Self, SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         assert!(!bits.is_empty());
         let mut bits = bits.iter();
@@ -489,10 +489,10 @@ impl Boolean {
     }
 
     /// Asserts that at least one operand is false.
-    pub fn enforce_nand<E, CS>(mut cs: CS, bits: &[Self]) -> Result<(), SynthesisError>
+    pub fn enforce_nand<ConstraintF, CS>(mut cs: CS, bits: &[Self]) -> Result<(), SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         let res = Self::kary_and(&mut cs, bits)?;
 
@@ -524,13 +524,13 @@ impl Boolean {
 
     /// Asserts that this bit_gadget representation is "in
     /// the field" when interpreted in big endian.
-    pub fn enforce_in_field<E, CS, F: PrimeField>(
+    pub fn enforce_in_field<ConstraintF, CS, F: PrimeField>(
         mut cs: CS,
         bits: &[Self],
     ) -> Result<(), SynthesisError>
     where
-        E: PairingEngine,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         let mut bits_iter = bits.iter();
 
@@ -631,8 +631,8 @@ impl From<AllocatedBit> for Boolean {
     }
 }
 
-impl<E: PairingEngine> AllocGadget<bool, E> for Boolean {
-    fn alloc<F, T, CS: ConstraintSystem<E>>(cs: CS, value_gen: F) -> Result<Self, SynthesisError>
+impl<ConstraintF: Field> AllocGadget<bool, ConstraintF> for Boolean {
+    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(cs: CS, value_gen: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<bool>,
@@ -640,7 +640,7 @@ impl<E: PairingEngine> AllocGadget<bool, E> for Boolean {
         AllocatedBit::alloc(cs, value_gen).map(Boolean::from)
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<E>>(
+    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -652,9 +652,9 @@ impl<E: PairingEngine> AllocGadget<bool, E> for Boolean {
     }
 }
 
-impl<E: PairingEngine> EqGadget<E> for Boolean {}
+impl<ConstraintF: Field> EqGadget<ConstraintF> for Boolean {}
 
-impl<E: PairingEngine> ConditionalEqGadget<E> for Boolean {
+impl<ConstraintF: Field> ConditionalEqGadget<ConstraintF> for Boolean {
     fn conditional_enforce_equal<CS>(
         &self,
         mut cs: CS,
@@ -662,11 +662,11 @@ impl<E: PairingEngine> ConditionalEqGadget<E> for Boolean {
         condition: &Boolean,
     ) -> Result<(), SynthesisError>
     where
-        CS: ConstraintSystem<E>,
+        CS: ConstraintSystem<ConstraintF>,
     {
         use self::Boolean::*;
         let one = CS::one();
-        let difference: LinearCombination<E> = match (self, other) {
+        let difference: LinearCombination<ConstraintF> = match (self, other) {
             // 1 - 1 = 0 - 0 = 0
             (Constant(true), Constant(true)) | (Constant(false), Constant(false)) => return Ok(()),
             // false != true
@@ -703,7 +703,7 @@ impl<E: PairingEngine> ConditionalEqGadget<E> for Boolean {
             cs.enforce(
                 || "conditional_equals",
                 |lc| difference + &lc,
-                |lc| condition.lc(one, E::Fr::one()) + &lc,
+                |lc| condition.lc(one, ConstraintF::one()) + &lc,
                 |lc| lc,
             );
             Ok(())
@@ -715,8 +715,8 @@ impl<E: PairingEngine> ConditionalEqGadget<E> for Boolean {
     }
 }
 
-impl<E: PairingEngine> ToBytesGadget<E> for Boolean {
-    fn to_bytes<CS: ConstraintSystem<E>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+impl<ConstraintF: Field> ToBytesGadget<ConstraintF> for Boolean {
+    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
         let mut bits = vec![Boolean::constant(false); 7];
         bits.push(*self);
         bits.reverse();
@@ -726,7 +726,7 @@ impl<E: PairingEngine> ToBytesGadget<E> for Boolean {
     }
 
     /// Additionally checks if the produced list of booleans is 'valid'.
-    fn to_bytes_strict<CS: ConstraintSystem<E>>(
+    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -741,9 +741,7 @@ mod test {
         test_constraint_system::TestConstraintSystem,
         utils::{AllocGadget, ConditionalEqGadget, EqGadget, ToBytesGadget},
     };
-    use algebra::{
-        curves::bls12_381::Bls12_381, fields::bls12_381::Fr, BitIterator, Field, PrimeField,
-    };
+    use algebra::{fields::bls12_381::Fr, BitIterator, Field, PrimeField};
     use rand::{Rand, SeedableRng, XorShiftRng};
     use snark::ConstraintSystem;
     use std::str::FromStr;
@@ -751,7 +749,7 @@ mod test {
     #[test]
     fn test_boolean_to_byte() {
         for val in [true, false].iter() {
-            let mut cs = TestConstraintSystem::<Bls12_381>::new();
+            let mut cs = TestConstraintSystem::<Fr>::new();
             let a: Boolean = AllocatedBit::alloc(&mut cs, || Ok(*val)).unwrap().into();
             let bytes = a.to_bytes(&mut cs.ns(|| "ToBytes")).unwrap();
             assert_eq!(bytes.len(), 1);
@@ -769,7 +767,7 @@ mod test {
 
     #[test]
     fn test_allocated_bit() {
-        let mut cs = TestConstraintSystem::<Bls12_381>::new();
+        let mut cs = TestConstraintSystem::<Fr>::new();
 
         AllocatedBit::alloc(&mut cs, || Ok(true)).unwrap();
         assert!(cs.get("boolean") == Fr::one());
@@ -785,7 +783,7 @@ mod test {
     fn test_xor() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::xor(&mut cs, &a, &b).unwrap();
@@ -800,7 +798,7 @@ mod test {
     fn test_or() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::or(&mut cs, &a, &b).unwrap();
@@ -817,7 +815,7 @@ mod test {
     fn test_and() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::and(&mut cs, &a, &b).unwrap();
@@ -853,7 +851,7 @@ mod test {
     fn test_and_not() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::and_not(&mut cs, &a, &b).unwrap();
@@ -889,7 +887,7 @@ mod test {
     fn test_nor() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::nor(&mut cs, &a, &b).unwrap();
@@ -927,7 +925,7 @@ mod test {
             for b_bool in [false, true].iter().cloned() {
                 for a_neg in [false, true].iter().cloned() {
                     for b_neg in [false, true].iter().cloned() {
-                        let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                        let mut cs = TestConstraintSystem::<Fr>::new();
 
                         let mut a: Boolean = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(a_bool))
                             .unwrap()
@@ -958,7 +956,7 @@ mod test {
             for b_bool in [false, true].iter().cloned() {
                 for a_neg in [false, true].iter().cloned() {
                     for b_neg in [false, true].iter().cloned() {
-                        let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                        let mut cs = TestConstraintSystem::<Fr>::new();
 
                         // First test if constraint system is satisfied
                         // when we do want to enforce the condition.
@@ -983,7 +981,7 @@ mod test {
 
                         // Now test if constraint system is satisfied even
                         // when we don't want to enforce the condition.
-                        let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                        let mut cs = TestConstraintSystem::<Fr>::new();
 
                         let mut a: Boolean = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(a_bool))
                             .unwrap()
@@ -1014,7 +1012,7 @@ mod test {
 
     #[test]
     fn test_boolean_negation() {
-        let mut cs = TestConstraintSystem::<Bls12_381>::new();
+        let mut cs = TestConstraintSystem::<Fr>::new();
 
         let mut b = Boolean::from(AllocatedBit::alloc(&mut cs, || Ok(true)).unwrap());
 
@@ -1082,7 +1080,7 @@ mod test {
 
         for first_operand in variants.iter().cloned() {
             for second_operand in variants.iter().cloned() {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
 
                 let a;
                 let b;
@@ -1291,7 +1289,7 @@ mod test {
 
         for first_operand in variants.iter().cloned() {
             for second_operand in variants.iter().cloned() {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
 
                 let a;
                 let b;
@@ -1503,7 +1501,7 @@ mod test {
 
         for first_operand in variants.iter().cloned() {
             for second_operand in variants.iter().cloned() {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
 
                 let a;
                 let b;
@@ -1727,7 +1725,7 @@ mod test {
     #[test]
     fn test_enforce_in_field() {
         {
-            let mut cs = TestConstraintSystem::<Bls12_381>::new();
+            let mut cs = TestConstraintSystem::<Fr>::new();
 
             let mut bits = vec![];
             for (i, b) in BitIterator::new(Fr::characteristic()).skip(1).enumerate() {
@@ -1745,7 +1743,7 @@ mod test {
 
         for _ in 0..1000 {
             let r = Fr::rand(&mut rng);
-            let mut cs = TestConstraintSystem::<Bls12_381>::new();
+            let mut cs = TestConstraintSystem::<Fr>::new();
 
             let mut bits = vec![];
             for (i, b) in BitIterator::new(r.into_repr()).skip(1).enumerate() {
@@ -1773,7 +1771,7 @@ mod test {
         //         }
         //     };
 
-        //     let mut cs = TestConstraintSystem::<Bls12_381>::new();
+        //     let mut cs = TestConstraintSystem::<Fr>::new();
 
         //     let mut bits = vec![];
         //     for (i, b) in BitIterator::new(r).skip(1).enumerate() {
@@ -1792,7 +1790,7 @@ mod test {
     #[test]
     fn test_enforce_nand() {
         {
-            let mut cs = TestConstraintSystem::<Bls12_381>::new();
+            let mut cs = TestConstraintSystem::<Fr>::new();
 
             assert!(Boolean::enforce_nand(&mut cs, &[Boolean::constant(false)]).is_ok());
             assert!(Boolean::enforce_nand(&mut cs, &[Boolean::constant(true)]).is_err());
@@ -1803,7 +1801,7 @@ mod test {
             for mut b in 0..(1 << i) {
                 // with every possible negation
                 for mut n in 0..(1 << i) {
-                    let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                    let mut cs = TestConstraintSystem::<Fr>::new();
 
                     let mut expected = true;
 
@@ -1855,7 +1853,7 @@ mod test {
         for i in 1..15 {
             // with every possible assignment for them
             for mut b in 0..(1 << i) {
-                let mut cs = TestConstraintSystem::<Bls12_381>::new();
+                let mut cs = TestConstraintSystem::<Fr>::new();
 
                 let mut expected = true;
 

--- a/snark-gadgets/src/fields/bls12_377.rs
+++ b/snark-gadgets/src/fields/bls12_377.rs
@@ -1,11 +1,10 @@
 use algebra::{
-    curves::sw6::SW6,
-    fields::bls12_377::{Fq12Parameters, Fq2Parameters, Fq6Parameters},
+    fields::bls12_377::{Fq, Fq12Parameters, Fq2Parameters, Fq6Parameters},
 };
 
 use super::{fp::FpGadget, fp12::Fp12Gadget, fp2::Fp2Gadget, fp6_3over2::Fp6Gadget};
 
-pub type FqGadget = FpGadget<SW6>;
-pub type Fq2Gadget = Fp2Gadget<Fq2Parameters, SW6>;
-pub type Fq6Gadget = Fp6Gadget<Fq6Parameters, SW6>;
-pub type Fq12Gadget = Fp12Gadget<Fq12Parameters, SW6>;
+pub type FqGadget = FpGadget<Fq>;
+pub type Fq2Gadget = Fp2Gadget<Fq2Parameters, Fq>;
+pub type Fq6Gadget = Fp6Gadget<Fq6Parameters, Fq>;
+pub type Fq12Gadget = Fp12Gadget<Fq12Parameters, Fq>;

--- a/snark-gadgets/src/fields/edwards_bls12.rs
+++ b/snark-gadgets/src/fields/edwards_bls12.rs
@@ -1,6 +1,4 @@
-use algebra::curves::bls12_377::Bls12_377;
-
+use algebra::fields::edwards_bls12::fq::Fq;
 use crate::fields::fp::FpGadget;
 
-// JubJub Fq uses BLS12-377 Fr.
-pub type FqGadget = FpGadget<Bls12_377>;
+pub type FqGadget = FpGadget<Fq>;

--- a/snark-gadgets/src/fields/edwards_sw6.rs
+++ b/snark-gadgets/src/fields/edwards_sw6.rs
@@ -1,6 +1,4 @@
-use algebra::curves::sw6::SW6;
-
+use algebra::fields::edwards_sw6::fq::Fq;
 use crate::fields::fp::FpGadget;
 
-// Edwards_SW6 Fq uses SW6 Fr.
-pub type FqGadget = FpGadget<SW6>;
+pub type FqGadget = FpGadget<Fq>;

--- a/snark-gadgets/src/fields/jubjub.rs
+++ b/snark-gadgets/src/fields/jubjub.rs
@@ -1,6 +1,6 @@
-use algebra::curves::bls12_381::Bls12_381;
+use algebra::fields::jubjub::fq::Fq;
 
 use crate::fields::fp::FpGadget;
 
 // JubJub Fq uses BLS12-381 Fr.
-pub type FqGadget = FpGadget<Bls12_381>;
+pub type FqGadget = FpGadget<Fq>;

--- a/snark-gadgets/src/fields/mod.rs
+++ b/snark-gadgets/src/fields/mod.rs
@@ -1,5 +1,5 @@
 // use std::ops::{Mul, MulAssign};
-use algebra::{Field, PairingEngine};
+use algebra::Field;
 use snark::{ConstraintSystem, SynthesisError};
 use std::fmt::Debug;
 
@@ -21,17 +21,17 @@ pub mod edwards_bls12;
 pub mod edwards_sw6;
 pub mod jubjub;
 
-pub trait FieldGadget<F: Field, E: PairingEngine>:
+pub trait FieldGadget<F: Field, ConstraintF: Field>:
     Sized
     + Clone
-    + EqGadget<E>
-    + NEqGadget<E>
-    + ConditionalEqGadget<E>
-    + ToBitsGadget<E>
-    + AllocGadget<F, E>
-    + ToBytesGadget<E>
-    + CondSelectGadget<E>
-    + TwoBitLookupGadget<E, TableConstant = F>
+    + EqGadget<ConstraintF>
+    + NEqGadget<ConstraintF>
+    + ConditionalEqGadget<ConstraintF>
+    + ToBitsGadget<ConstraintF>
+    + AllocGadget<F, ConstraintF>
+    + ToBytesGadget<ConstraintF>
+    + CondSelectGadget<ConstraintF>
+    + TwoBitLookupGadget<ConstraintF, TableConstant = F>
     + Debug
 {
     type Variable: Clone + Debug;
@@ -40,13 +40,13 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
 
     fn get_variable(&self) -> Self::Variable;
 
-    fn zero<CS: ConstraintSystem<E>>(_: CS) -> Result<Self, SynthesisError>;
+    fn zero<CS: ConstraintSystem<ConstraintF>>(_: CS) -> Result<Self, SynthesisError>;
 
-    fn one<CS: ConstraintSystem<E>>(_: CS) -> Result<Self, SynthesisError>;
+    fn one<CS: ConstraintSystem<ConstraintF>>(_: CS) -> Result<Self, SynthesisError>;
 
-    fn add<CS: ConstraintSystem<E>>(&self, _: CS, _: &Self) -> Result<Self, SynthesisError>;
+    fn add<CS: ConstraintSystem<ConstraintF>>(&self, _: CS, _: &Self) -> Result<Self, SynthesisError>;
 
-    fn add_in_place<CS: ConstraintSystem<E>>(
+    fn add_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &Self,
@@ -55,11 +55,11 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         Ok(self)
     }
 
-    fn double<CS: ConstraintSystem<E>>(&self, cs: CS) -> Result<Self, SynthesisError> {
+    fn double<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
         self.add(cs, &self)
     }
 
-    fn double_in_place<CS: ConstraintSystem<E>>(
+    fn double_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -67,9 +67,9 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         Ok(self)
     }
 
-    fn sub<CS: ConstraintSystem<E>>(&self, _: CS, _: &Self) -> Result<Self, SynthesisError>;
+    fn sub<CS: ConstraintSystem<ConstraintF>>(&self, _: CS, _: &Self) -> Result<Self, SynthesisError>;
 
-    fn sub_in_place<CS: ConstraintSystem<E>>(
+    fn sub_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &Self,
@@ -78,10 +78,10 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         Ok(self)
     }
 
-    fn negate<CS: ConstraintSystem<E>>(&self, _: CS) -> Result<Self, SynthesisError>;
+    fn negate<CS: ConstraintSystem<ConstraintF>>(&self, _: CS) -> Result<Self, SynthesisError>;
 
     #[inline]
-    fn negate_in_place<CS: ConstraintSystem<E>>(
+    fn negate_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -89,9 +89,9 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         Ok(self)
     }
 
-    fn mul<CS: ConstraintSystem<E>>(&self, _: CS, _: &Self) -> Result<Self, SynthesisError>;
+    fn mul<CS: ConstraintSystem<ConstraintF>>(&self, _: CS, _: &Self) -> Result<Self, SynthesisError>;
 
-    fn mul_in_place<CS: ConstraintSystem<E>>(
+    fn mul_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &Self,
@@ -100,11 +100,11 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         Ok(self)
     }
 
-    fn square<CS: ConstraintSystem<E>>(&self, cs: CS) -> Result<Self, SynthesisError> {
+    fn square<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
         self.mul(cs, &self)
     }
 
-    fn square_in_place<CS: ConstraintSystem<E>>(
+    fn square_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -112,7 +112,7 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         Ok(self)
     }
 
-    fn mul_equals<CS: ConstraintSystem<E>>(
+    fn mul_equals<CS: ConstraintSystem<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -122,7 +122,7 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         result.enforce_equal(&mut cs.ns(|| "test_equals"), &actual_result)
     }
 
-    fn square_equals<CS: ConstraintSystem<E>>(
+    fn square_equals<CS: ConstraintSystem<ConstraintF>>(
         &self,
         mut cs: CS,
         result: &Self,
@@ -131,9 +131,9 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         result.enforce_equal(&mut cs.ns(|| "test_equals"), &actual_result)
     }
 
-    fn add_constant<CS: ConstraintSystem<E>>(&self, _: CS, _: &F) -> Result<Self, SynthesisError>;
+    fn add_constant<CS: ConstraintSystem<ConstraintF>>(&self, _: CS, _: &F) -> Result<Self, SynthesisError>;
 
-    fn add_constant_in_place<CS: ConstraintSystem<E>>(
+    fn add_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &F,
@@ -142,7 +142,7 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         Ok(self)
     }
 
-    fn sub_constant<CS: ConstraintSystem<E>>(
+    fn sub_constant<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
         fe: &F,
@@ -150,7 +150,7 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         self.add_constant(cs, &(-(*fe)))
     }
 
-    fn sub_constant_in_place<CS: ConstraintSystem<E>>(
+    fn sub_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &F,
@@ -158,13 +158,13 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         self.add_constant_in_place(cs, &(-(*other)))
     }
 
-    fn mul_by_constant<CS: ConstraintSystem<E>>(
+    fn mul_by_constant<CS: ConstraintSystem<ConstraintF>>(
         &self,
         _: CS,
         _: &F,
     ) -> Result<Self, SynthesisError>;
 
-    fn mul_by_constant_in_place<CS: ConstraintSystem<E>>(
+    fn mul_by_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &F,
@@ -173,15 +173,15 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
         Ok(self)
     }
 
-    fn inverse<CS: ConstraintSystem<E>>(&self, _: CS) -> Result<Self, SynthesisError>;
+    fn inverse<CS: ConstraintSystem<ConstraintF>>(&self, _: CS) -> Result<Self, SynthesisError>;
 
-    fn frobenius_map<CS: ConstraintSystem<E>>(
+    fn frobenius_map<CS: ConstraintSystem<ConstraintF>>(
         &self,
         _: CS,
         power: usize,
     ) -> Result<Self, SynthesisError>;
 
-    fn frobenius_map_in_place<CS: ConstraintSystem<E>>(
+    fn frobenius_map_in_place<CS: ConstraintSystem<ConstraintF>>(
         &mut self,
         cs: CS,
         power: usize,
@@ -193,7 +193,7 @@ pub trait FieldGadget<F: Field, E: PairingEngine>:
     /// Accepts as input a list of bits which, when interpreted in big-endian
     /// form, are a scalar.
     #[inline]
-    fn pow<CS: ConstraintSystem<E>>(
+    fn pow<CS: ConstraintSystem<ConstraintF>>(
         &self,
         mut cs: CS,
         bits: &[Boolean],
@@ -225,10 +225,10 @@ mod test {
     use crate::{
         bits::boolean::Boolean, test_constraint_system::TestConstraintSystem, utils::AllocGadget,
     };
-    use algebra::{curves::PairingEngine, fields::Field, BitIterator};
+    use algebra::{fields::Field, BitIterator};
     use snark::ConstraintSystem;
 
-    fn field_test<FE: Field, E: PairingEngine, F: FieldGadget<FE, E>, CS: ConstraintSystem<E>>(
+    fn field_test<FE: Field, ConstraintF: Field, F: FieldGadget<FE, ConstraintF>, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         a: F,
         b: F,
@@ -414,9 +414,9 @@ mod test {
 
     fn random_frobenius_tests<
         FE: Field,
-        E: PairingEngine,
-        F: FieldGadget<FE, E>,
-        CS: ConstraintSystem<E>,
+        ConstraintF: Field,
+        F: FieldGadget<FE, ConstraintF>,
+        CS: ConstraintSystem<ConstraintF>,
     >(
         mut cs: CS,
         maxpower: usize,
@@ -437,12 +437,9 @@ mod test {
     #[test]
     fn bls12_377_field_gadgets_test() {
         use crate::fields::bls12_377::{Fq12Gadget, Fq2Gadget, Fq6Gadget, FqGadget};
-        use algebra::{
-            curves::sw6::SW6,
-            fields::bls12_377::{Fq, Fq12, Fq2, Fq6},
-        };
+        use algebra::fields::bls12_377::{Fq, Fq12, Fq2, Fq6};
 
-        let mut cs = TestConstraintSystem::<SW6>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
 
         let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0653]);
 
@@ -486,9 +483,9 @@ mod test {
     #[test]
     fn jubjub_field_gadgets_test() {
         use crate::fields::jubjub::FqGadget;
-        use algebra::{curves::bls12_381::Bls12_381, fields::jubjub::fq::Fq};
+        use algebra::fields::jubjub::fq::Fq;
 
-        let mut cs = TestConstraintSystem::<Bls12_381>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
 
         let mut rng = thread_rng();
 
@@ -504,9 +501,9 @@ mod test {
     #[test]
     fn edwards_field_gadgets_test() {
         use crate::fields::edwards_bls12::FqGadget;
-        use algebra::{curves::bls12_377::Bls12_377, fields::edwards_bls12::fq::Fq};
+        use algebra::fields::edwards_bls12::fq::Fq;
 
-        let mut cs = TestConstraintSystem::<Bls12_377>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
 
         let mut rng = thread_rng();
 

--- a/snark-gadgets/src/groups/curves/short_weierstrass/bls12/bls12_377.rs
+++ b/snark-gadgets/src/groups/curves/short_weierstrass/bls12/bls12_377.rs
@@ -2,13 +2,13 @@ use crate::groups::bls12::{
     G1Gadget as Bls12G1Gadget, G1PreparedGadget as Bls12G1PreparedGadget,
     G2Gadget as Bls12G2Gadget, G2PreparedGadget as Bls12G2PreparedGadget,
 };
-use algebra::curves::{bls12_377::Bls12_377Parameters, sw6::SW6};
+use algebra::curves::bls12_377::Bls12_377Parameters;
 
-pub type G1Gadget = Bls12G1Gadget<Bls12_377Parameters, SW6>;
-pub type G2Gadget = Bls12G2Gadget<Bls12_377Parameters, SW6>;
+pub type G1Gadget = Bls12G1Gadget<Bls12_377Parameters>;
+pub type G2Gadget = Bls12G2Gadget<Bls12_377Parameters>;
 
-pub type G1PreparedGadget = Bls12G1PreparedGadget<Bls12_377Parameters, SW6>;
-pub type G2PreparedGadget = Bls12G2PreparedGadget<Bls12_377Parameters, SW6>;
+pub type G1PreparedGadget = Bls12G1PreparedGadget<Bls12_377Parameters>;
+pub type G2PreparedGadget = Bls12G2PreparedGadget<Bls12_377Parameters>;
 
 #[cfg(test)]
 mod test {
@@ -23,11 +23,9 @@ mod test {
         utils::{AllocGadget, CondSelectGadget, EqGadget},
     };
     use algebra::{
-        curves::{
-            bls12_377::{G1Projective as G1, G2Projective as G2},
-            sw6::SW6,
-        },
+        curves::bls12_377::{G1Projective as G1, G2Projective as G2},
         fields::bls12_377::Fr,
+        fields::bls12_377::Fq,
         AffineCurve, BitIterator, PrimeField, ProjectiveCurve,
     };
     use snark::ConstraintSystem;
@@ -36,7 +34,7 @@ mod test {
     fn bls12_g1_constraint_costs() {
         use crate::boolean::AllocatedBit;
 
-        let mut cs = TestConstraintSystem::<SW6>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
 
         let bit = AllocatedBit::alloc(&mut cs.ns(|| "bool"), || Ok(true))
             .unwrap()
@@ -62,7 +60,7 @@ mod test {
         assert!(cs.is_satisfied());
         assert_eq!(
             cond_select_cost,
-            <G1Gadget as CondSelectGadget<SW6>>::cost()
+            <G1Gadget as CondSelectGadget<Fq>>::cost()
         );
         assert_eq!(add_cost, G1Gadget::cost_of_add());
     }
@@ -71,7 +69,7 @@ mod test {
     fn bls12_g2_constraint_costs() {
         use crate::boolean::AllocatedBit;
 
-        let mut cs = TestConstraintSystem::<SW6>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
 
         let bit = AllocatedBit::alloc(&mut cs.ns(|| "bool"), || Ok(true))
             .unwrap()
@@ -97,7 +95,7 @@ mod test {
         assert!(cs.is_satisfied());
         assert_eq!(
             cond_select_cost,
-            <G2Gadget as CondSelectGadget<SW6>>::cost()
+            <G2Gadget as CondSelectGadget<Fq>>::cost()
         );
         assert_eq!(add_cost, G2Gadget::cost_of_add());
     }
@@ -107,7 +105,7 @@ mod test {
         use rand::{Rand, SeedableRng, XorShiftRng};
         let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
-        let mut cs = TestConstraintSystem::<SW6>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
 
         let a = G1::rand(&mut rng);
         let b = G1::rand(&mut rng);
@@ -175,7 +173,7 @@ mod test {
 
     #[test]
     fn bls12_g2_gadget_test() {
-        let mut cs = TestConstraintSystem::<SW6>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
 
         let a: G2 = rand::random();
         let b: G2 = rand::random();

--- a/snark-gadgets/src/groups/curves/twisted_edwards/edwards_bls12.rs
+++ b/snark-gadgets/src/groups/curves/twisted_edwards/edwards_bls12.rs
@@ -1,9 +1,10 @@
 use crate::groups::curves::twisted_edwards::AffineGadget;
-use algebra::curves::{bls12_377::Bls12_377, edwards_bls12::EdwardsParameters};
+use algebra::curves::edwards_bls12::EdwardsParameters;
+use algebra::fields::edwards_bls12::fq::Fq;
 
 use crate::fields::edwards_bls12::FqGadget;
 
-pub type EdwardsBlsGadget = AffineGadget<EdwardsParameters, Bls12_377, FqGadget>;
+pub type EdwardsBlsGadget = AffineGadget<EdwardsParameters, Fq, FqGadget>;
 
 #[cfg(test)]
 mod test {
@@ -12,18 +13,19 @@ mod test {
         groups::curves::twisted_edwards::test::{edwards_constraint_costs, edwards_test},
         test_constraint_system::TestConstraintSystem,
     };
-    use algebra::curves::{bls12_377::Bls12_377, edwards_bls12::EdwardsParameters};
+    use algebra::fields::edwards_bls12::fq::Fq;
+    use algebra::curves::edwards_bls12::EdwardsParameters;
 
     #[test]
     fn edwards_constraint_costs_test() {
-        let mut cs = TestConstraintSystem::<Bls12_377>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
         edwards_constraint_costs::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }
 
     #[test]
     fn edwards_bls12_gadget_test() {
-        let mut cs = TestConstraintSystem::<Bls12_377>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
         edwards_test::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }

--- a/snark-gadgets/src/groups/curves/twisted_edwards/edwards_sw6.rs
+++ b/snark-gadgets/src/groups/curves/twisted_edwards/edwards_sw6.rs
@@ -1,9 +1,10 @@
 use crate::groups::curves::twisted_edwards::AffineGadget;
-use algebra::curves::{edwards_sw6::EdwardsParameters, sw6::SW6};
+use algebra::curves::edwards_sw6::EdwardsParameters;
+use algebra::fields::edwards_sw6::fq::Fq;
 
 use crate::fields::edwards_sw6::FqGadget;
 
-pub type EdwardsSWGadget = AffineGadget<EdwardsParameters, SW6, FqGadget>;
+pub type EdwardsSWGadget = AffineGadget<EdwardsParameters, Fq, FqGadget>;
 
 #[cfg(test)]
 mod test {
@@ -12,18 +13,19 @@ mod test {
         groups::curves::twisted_edwards::test::{edwards_constraint_costs, edwards_test},
         test_constraint_system::TestConstraintSystem,
     };
-    use algebra::curves::{edwards_sw6::EdwardsParameters, sw6::SW6};
+    use algebra::curves::edwards_sw6::EdwardsParameters;
+    use algebra::fields::edwards_sw6::fq::Fq;
 
     #[test]
     fn edwards_constraint_costs_test() {
-        let mut cs = TestConstraintSystem::<SW6>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
         edwards_constraint_costs::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }
 
     #[test]
     fn edwards_sw6_gadget_test() {
-        let mut cs = TestConstraintSystem::<SW6>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
         edwards_test::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }

--- a/snark-gadgets/src/groups/curves/twisted_edwards/jubjub.rs
+++ b/snark-gadgets/src/groups/curves/twisted_edwards/jubjub.rs
@@ -1,9 +1,10 @@
 use crate::groups::curves::twisted_edwards::AffineGadget;
-use algebra::curves::{bls12_381::Bls12_381, jubjub::JubJubParameters};
+use algebra::curves::jubjub::JubJubParameters;
+use algebra::fields::jubjub::fq::Fq;
 
 use crate::fields::jubjub::FqGadget;
 
-pub type JubJubGadget = AffineGadget<JubJubParameters, Bls12_381, FqGadget>;
+pub type JubJubGadget = AffineGadget<JubJubParameters, Fq, FqGadget>;
 
 #[cfg(test)]
 mod test {
@@ -12,18 +13,19 @@ mod test {
         groups::curves::twisted_edwards::test::{edwards_constraint_costs, edwards_test},
         test_constraint_system::TestConstraintSystem,
     };
-    use algebra::curves::{bls12_381::Bls12_381, jubjub::JubJubParameters as EdwardsParameters};
+    use algebra::fields::jubjub::fq::Fq;
+    use algebra::curves::jubjub::JubJubParameters as EdwardsParameters;
 
     #[test]
     fn edwards_constraint_costs_test() {
-        let mut cs = TestConstraintSystem::<Bls12_381>::new();
+        let mut cs = TestConstraintSystem::<Fq>::new();
         edwards_constraint_costs::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }
 
     #[test]
-    fn edwards_sw6_gadget_test() {
-        let mut cs = TestConstraintSystem::<Bls12_381>::new();
+    fn jubjub_gadget_test() {
+        let mut cs = TestConstraintSystem::<Fq>::new();
         edwards_test::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }

--- a/snark-gadgets/src/groups/curves/twisted_edwards/test.rs
+++ b/snark-gadgets/src/groups/curves/twisted_edwards/test.rs
@@ -8,17 +8,17 @@ use crate::{
 
 use algebra::{
     curves::{models::TEModelParameters, twisted_edwards_extended::GroupAffine as TEAffine},
-    BitIterator, Group, PairingEngine, PrimeField,
+    BitIterator, Group, PrimeField, Field,
 };
 
 use snark::ConstraintSystem;
 
-pub(crate) fn edwards_test<E, P, GG, CS>(cs: &mut CS)
+pub(crate) fn edwards_test<ConstraintF, P, GG, CS>(cs: &mut CS)
 where
-    E: PairingEngine,
+    ConstraintF: Field,
     P: TEModelParameters,
-    GG: GroupGadget<TEAffine<P>, E, Value = TEAffine<P>>,
-    CS: ConstraintSystem<E>,
+    GG: GroupGadget<TEAffine<P>, ConstraintF, Value = TEAffine<P>>,
+    CS: ConstraintSystem<ConstraintF>,
 {
     let a: TEAffine<P> = rand::random();
     let b: TEAffine<P> = rand::random();
@@ -26,7 +26,7 @@ where
     let gadget_b = GG::alloc(&mut cs.ns(|| "b"), || Ok(b)).unwrap();
     assert_eq!(gadget_a.get_value().unwrap(), a);
     assert_eq!(gadget_b.get_value().unwrap(), b);
-    group_test::<E, TEAffine<P>, GG, _>(
+    group_test::<ConstraintF, TEAffine<P>, GG, _>(
         &mut cs.ns(|| "GroupTest(a, b)"),
         gadget_a.clone(),
         gadget_b,
@@ -48,12 +48,12 @@ where
     assert_eq!(native_result, gadget_value);
 }
 
-pub(crate) fn edwards_constraint_costs<E, P, GG, CS>(cs: &mut CS)
+pub(crate) fn edwards_constraint_costs<ConstraintF, P, GG, CS>(cs: &mut CS)
 where
-    E: PairingEngine,
+    ConstraintF: Field,
     P: TEModelParameters,
-    GG: GroupGadget<TEAffine<P>, E, Value = TEAffine<P>>,
-    CS: ConstraintSystem<E>,
+    GG: GroupGadget<TEAffine<P>, ConstraintF, Value = TEAffine<P>>,
+    CS: ConstraintSystem<ConstraintF>,
 {
     use crate::boolean::AllocatedBit;
 

--- a/snark-gadgets/src/utils.rs
+++ b/snark-gadgets/src/utils.rs
@@ -1,12 +1,12 @@
 use crate::bits::{boolean::Boolean, uint8::UInt8};
-use algebra::PairingEngine;
+use algebra::Field;
 use snark::{ConstraintSystem, SynthesisError};
 use std::borrow::Borrow;
 
 /// If `condition == 1`, then enforces that `self` and `other` are equal;
 /// otherwise, it doesn't enforce anything.
-pub trait ConditionalEqGadget<E: PairingEngine>: Eq {
-    fn conditional_enforce_equal<CS: ConstraintSystem<E>>(
+pub trait ConditionalEqGadget<ConstraintF: Field>: Eq {
+    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
         other: &Self,
@@ -15,8 +15,8 @@ pub trait ConditionalEqGadget<E: PairingEngine>: Eq {
 
     fn cost() -> usize;
 }
-impl<T: ConditionalEqGadget<E>, E: PairingEngine> ConditionalEqGadget<E> for [T] {
-    fn conditional_enforce_equal<CS: ConstraintSystem<E>>(
+impl<T: ConditionalEqGadget<ConstraintF>, ConstraintF: Field> ConditionalEqGadget<ConstraintF> for [T] {
+    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -34,11 +34,11 @@ impl<T: ConditionalEqGadget<E>, E: PairingEngine> ConditionalEqGadget<E> for [T]
     }
 }
 
-pub trait EqGadget<E: PairingEngine>: Eq
+pub trait EqGadget<ConstraintF: Field>: Eq
 where
-    Self: ConditionalEqGadget<E>,
+    Self: ConditionalEqGadget<ConstraintF>,
 {
-    fn enforce_equal<CS: ConstraintSystem<E>>(
+    fn enforce_equal<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
         other: &Self,
@@ -47,14 +47,14 @@ where
     }
 
     fn cost() -> usize {
-        <Self as ConditionalEqGadget<E>>::cost()
+        <Self as ConditionalEqGadget<ConstraintF>>::cost()
     }
 }
 
-impl<T: EqGadget<E>, E: PairingEngine> EqGadget<E> for [T] {}
+impl<T: EqGadget<ConstraintF>, ConstraintF: Field> EqGadget<ConstraintF> for [T] {}
 
-pub trait NEqGadget<E: PairingEngine>: Eq {
-    fn enforce_not_equal<CS: ConstraintSystem<E>>(
+pub trait NEqGadget<ConstraintF: Field>: Eq {
+    fn enforce_not_equal<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
         other: &Self,
@@ -63,22 +63,22 @@ pub trait NEqGadget<E: PairingEngine>: Eq {
     fn cost() -> usize;
 }
 
-pub trait ToBitsGadget<E: PairingEngine> {
-    fn to_bits<CS: ConstraintSystem<E>>(&self, cs: CS) -> Result<Vec<Boolean>, SynthesisError>;
+pub trait ToBitsGadget<ConstraintF: Field> {
+    fn to_bits<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Vec<Boolean>, SynthesisError>;
 
     /// Additionally checks if the produced list of booleans is 'valid'.
-    fn to_bits_strict<CS: ConstraintSystem<E>>(
+    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError>;
 }
 
-impl<E: PairingEngine> ToBitsGadget<E> for Boolean {
-    fn to_bits<CS: ConstraintSystem<E>>(&self, _: CS) -> Result<Vec<Boolean>, SynthesisError> {
+impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for Boolean {
+    fn to_bits<CS: ConstraintSystem<ConstraintF>>(&self, _: CS) -> Result<Vec<Boolean>, SynthesisError> {
         Ok(vec![self.clone()])
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<E>>(
+    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
         &self,
         _: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -86,24 +86,24 @@ impl<E: PairingEngine> ToBitsGadget<E> for Boolean {
     }
 }
 
-impl<E: PairingEngine> ToBitsGadget<E> for [Boolean] {
-    fn to_bits<CS: ConstraintSystem<E>>(&self, _cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
+impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for [Boolean] {
+    fn to_bits<CS: ConstraintSystem<ConstraintF>>(&self, _cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         Ok(self.to_vec())
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<E>>(
+    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
         Ok(self.to_vec())
     }
 }
-impl<E: PairingEngine> ToBitsGadget<E> for Vec<Boolean> {
-    fn to_bits<CS: ConstraintSystem<E>>(&self, _cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
+impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for Vec<Boolean> {
+    fn to_bits<CS: ConstraintSystem<ConstraintF>>(&self, _cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         Ok(self.clone())
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<E>>(
+    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -111,8 +111,8 @@ impl<E: PairingEngine> ToBitsGadget<E> for Vec<Boolean> {
     }
 }
 
-impl<E: PairingEngine> ToBitsGadget<E> for [UInt8] {
-    fn to_bits<CS: ConstraintSystem<E>>(&self, _cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
+impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for [UInt8] {
+    fn to_bits<CS: ConstraintSystem<ConstraintF>>(&self, _cs: CS) -> Result<Vec<Boolean>, SynthesisError> {
         let mut result = Vec::with_capacity(&self.len() * 8);
         for byte in self {
             result.extend_from_slice(&byte.into_bits_le());
@@ -120,7 +120,7 @@ impl<E: PairingEngine> ToBitsGadget<E> for [UInt8] {
         Ok(result)
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<E>>(
+    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -128,22 +128,22 @@ impl<E: PairingEngine> ToBitsGadget<E> for [UInt8] {
     }
 }
 
-pub trait ToBytesGadget<E: PairingEngine> {
-    fn to_bytes<CS: ConstraintSystem<E>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError>;
+pub trait ToBytesGadget<ConstraintF: Field> {
+    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Vec<UInt8>, SynthesisError>;
 
     /// Additionally checks if the produced list of booleans is 'valid'.
-    fn to_bytes_strict<CS: ConstraintSystem<E>>(
+    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError>;
 }
 
 /// If condition is `true`, return `first`; else, select `second`.
-pub trait CondSelectGadget<E: PairingEngine>
+pub trait CondSelectGadget<ConstraintF: Field>
 where
     Self: Sized,
 {
-    fn conditionally_select<CS: ConstraintSystem<E>>(
+    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -154,12 +154,12 @@ where
 }
 
 /// Uses two bits to perform a lookup into a table
-pub trait TwoBitLookupGadget<E: PairingEngine>
+pub trait TwoBitLookupGadget<ConstraintF: Field>
 where
     Self: Sized,
 {
     type TableConstant;
-    fn two_bit_lookup<CS: ConstraintSystem<E>>(
+    fn two_bit_lookup<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         bits: &[Boolean],
         constants: &[Self::TableConstant],
@@ -168,11 +168,11 @@ where
     fn cost() -> usize;
 }
 
-pub trait OrEqualsGadget<E: PairingEngine>
+pub trait OrEqualsGadget<ConstraintF: Field>
 where
     Self: Sized,
 {
-    fn enforce_equal_or<CS: ConstraintSystem<E>>(
+    fn enforce_equal_or<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         var: &Self,
@@ -183,8 +183,8 @@ where
     fn cost() -> usize;
 }
 
-impl<E: PairingEngine, T: Sized + ConditionalOrEqualsGadget<E>> OrEqualsGadget<E> for T {
-    fn enforce_equal_or<CS: ConstraintSystem<E>>(
+impl<ConstraintF: Field, T: Sized + ConditionalOrEqualsGadget<ConstraintF>> OrEqualsGadget<ConstraintF> for T {
+    fn enforce_equal_or<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         var: &Self,
@@ -195,15 +195,15 @@ impl<E: PairingEngine, T: Sized + ConditionalOrEqualsGadget<E>> OrEqualsGadget<E
     }
 
     fn cost() -> usize {
-        <Self as ConditionalOrEqualsGadget<E>>::cost()
+        <Self as ConditionalOrEqualsGadget<ConstraintF>>::cost()
     }
 }
 
-pub trait ConditionalOrEqualsGadget<E: PairingEngine>
+pub trait ConditionalOrEqualsGadget<ConstraintF: Field>
 where
     Self: Sized,
 {
-    fn conditional_enforce_equal_or<CS: ConstraintSystem<E>>(
+    fn conditional_enforce_equal_or<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         var: &Self,
@@ -215,10 +215,10 @@ where
     fn cost() -> usize;
 }
 
-impl<E: PairingEngine, T: Sized + ConditionalEqGadget<E> + CondSelectGadget<E>>
-    ConditionalOrEqualsGadget<E> for T
+impl<ConstraintF: Field, T: Sized + ConditionalEqGadget<ConstraintF> + CondSelectGadget<ConstraintF>>
+    ConditionalOrEqualsGadget<ConstraintF> for T
 {
-    fn conditional_enforce_equal_or<CS: ConstraintSystem<E>>(
+    fn conditional_enforce_equal_or<CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
         var: &Self,
@@ -236,21 +236,21 @@ impl<E: PairingEngine, T: Sized + ConditionalEqGadget<E> + CondSelectGadget<E>>
     }
 
     fn cost() -> usize {
-        <Self as ConditionalEqGadget<E>>::cost() + <Self as CondSelectGadget<E>>::cost()
+        <Self as ConditionalEqGadget<ConstraintF>>::cost() + <Self as CondSelectGadget<ConstraintF>>::cost()
     }
 }
 
-pub trait AllocGadget<V, E: PairingEngine>
+pub trait AllocGadget<V, ConstraintF: Field>
 where
     Self: Sized,
     V: ?Sized,
 {
-    fn alloc<F, T, CS: ConstraintSystem<E>>(cs: CS, f: F) -> Result<Self, SynthesisError>
+    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<V>;
 
-    fn alloc_checked<F, T, CS: ConstraintSystem<E>>(cs: CS, f: F) -> Result<Self, SynthesisError>
+    fn alloc_checked<F, T, CS: ConstraintSystem<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<V>,
@@ -258,12 +258,12 @@ where
         Self::alloc(cs, f)
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<E>>(cs: CS, f: F) -> Result<Self, SynthesisError>
+    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<V>;
 
-    fn alloc_input_checked<F, T, CS: ConstraintSystem<E>>(
+    fn alloc_input_checked<F, T, CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -275,8 +275,8 @@ where
     }
 }
 
-impl<I, E: PairingEngine, A: AllocGadget<I, E>> AllocGadget<[I], E> for Vec<A> {
-    fn alloc<F, T, CS: ConstraintSystem<E>>(mut cs: CS, f: F) -> Result<Self, SynthesisError>
+impl<I, ConstraintF: Field, A: AllocGadget<I, ConstraintF>> AllocGadget<[I], ConstraintF> for Vec<A> {
+    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(mut cs: CS, f: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<[I]>,
@@ -290,7 +290,7 @@ impl<I, E: PairingEngine, A: AllocGadget<I, E>> AllocGadget<[I], E> for Vec<A> {
         Ok(vec)
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<E>>(mut cs: CS, f: F) -> Result<Self, SynthesisError>
+    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(mut cs: CS, f: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<[I]>,
@@ -305,7 +305,7 @@ impl<I, E: PairingEngine, A: AllocGadget<I, E>> AllocGadget<[I], E> for Vec<A> {
         Ok(vec)
     }
 
-    fn alloc_checked<F, T, CS: ConstraintSystem<E>>(
+    fn alloc_checked<F, T, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -323,7 +323,7 @@ impl<I, E: PairingEngine, A: AllocGadget<I, E>> AllocGadget<[I], E> for Vec<A> {
         Ok(vec)
     }
 
-    fn alloc_input_checked<F, T, CS: ConstraintSystem<E>>(
+    fn alloc_input_checked<F, T, CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>

--- a/snark/examples/snark-scalability/constraints.rs
+++ b/snark/examples/snark-scalability/constraints.rs
@@ -1,13 +1,13 @@
-use algebra::{Field, PairingEngine};
+use algebra::Field;
 use snark::{Circuit, ConstraintSystem, LinearCombination, SynthesisError};
 use std::marker::PhantomData;
 
-pub struct Benchmark<E: PairingEngine> {
+pub struct Benchmark<F: Field> {
     num_constraints: usize,
-    _engine:         PhantomData<E>,
+    _engine:         PhantomData<F>,
 }
 
-impl<E: PairingEngine> Benchmark<E> {
+impl<F: Field> Benchmark<F> {
     pub fn new(num_constraints: usize) -> Self {
         Self {
             num_constraints,
@@ -16,15 +16,15 @@ impl<E: PairingEngine> Benchmark<E> {
     }
 }
 
-impl<E: PairingEngine> Circuit<E> for Benchmark<E> {
-    fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+impl<F: Field> Circuit<F> for Benchmark<F> {
+    fn synthesize<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let mut assignments = Vec::new();
 
-        let mut a_val = E::Fr::one();
+        let mut a_val = F::one();
         let mut a_var = cs.alloc_input(|| "a", || Ok(a_val))?;
         assignments.push((a_val, a_var));
 
-        let mut b_val = E::Fr::one();
+        let mut b_val = F::one();
         let mut b_var = cs.alloc_input(|| "b", || Ok(b_val))?;
         assignments.push((a_val, a_var));
 
@@ -66,7 +66,7 @@ impl<E: PairingEngine> Circuit<E> for Benchmark<E> {
 
         let mut a_lc = LinearCombination::zero();
         let mut b_lc = LinearCombination::zero();
-        let mut c_val = E::Fr::zero();
+        let mut c_val = F::zero();
 
         for (val, var) in assignments {
             a_lc = a_lc + var;

--- a/snark/examples/snark-scalability/gm17.rs
+++ b/snark/examples/snark-scalability/gm17.rs
@@ -38,7 +38,8 @@ use std::{
 
 // Bring in some tools for using pairing-friendly curves
 // We're going to use the BLS12-377 pairing-friendly elliptic curve.
-use algebra::{curves::bls12_377::Bls12_377, fields::bls12_377::fr::Fr, Field};
+use algebra::curves::bls12_377::Bls12_377;
+use algebra::fields::{bls12_377::fr::Fr, Field};
 
 // We're going to use the Groth-Maller 17 proving system.
 use snark::gm17::{
@@ -106,8 +107,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Create parameters for our circuit
         let start = Instant::now();
         let params = {
-            let c = Benchmark::<Bls12_377>::new(num_constraints);
-            generate_random_parameters(c, rng)?
+            let c = Benchmark::<Fr>::new(num_constraints);
+            generate_random_parameters::<Bls12_377, _, _>(c, rng)?
         };
 
         // Prepare the verification key (for proof verification)

--- a/snark/src/gm17/test.rs
+++ b/snark/src/gm17/test.rs
@@ -1,46 +1,46 @@
+use algebra::Field;
+use crate::{Circuit, ConstraintSystem, SynthesisError};
+struct MySillyCircuit<F: Field> {
+    a: Option<F>,
+    b: Option<F>,
+}
+
+impl<ConstraintF: Field> Circuit<ConstraintF> for MySillyCircuit<ConstraintF> {
+    fn synthesize<CS: ConstraintSystem<ConstraintF>>(
+        self,
+        cs: &mut CS,
+    ) -> Result<(), SynthesisError> {
+        let a = cs.alloc(|| "a", || self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        let b = cs.alloc(|| "b", || self.b.ok_or(SynthesisError::AssignmentMissing))?;
+        let c = cs.alloc_input(
+            || "c",
+            || {
+                let mut a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
+                let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
+
+                a.mul_assign(&b);
+                Ok(a)
+            },
+            )?;
+
+        cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
+
+        Ok(())
+    }
+}
+
 mod bls12_377 {
-    use crate::{
-        gm17::{
-            create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
-        },
-        Circuit, ConstraintSystem, SynthesisError,
+    use super::*;
+    use crate::gm17::{
+        create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     };
 
-    use algebra::{curves::bls12_377::Bls12_377, fields::bls12_377::Fr, PairingEngine};
+    use algebra::{curves::bls12_377::Bls12_377, fields::bls12_377::Fr};
     use rand::{thread_rng, Rand};
     use std::ops::MulAssign;
 
     #[test]
     fn prove_and_verify() {
-        struct MySillyCircuit<E: PairingEngine> {
-            a: Option<E::Fr>,
-            b: Option<E::Fr>,
-        }
-
-        impl<E: PairingEngine> Circuit<E> for MySillyCircuit<E> {
-            fn synthesize<CS: ConstraintSystem<E>>(
-                self,
-                cs: &mut CS,
-            ) -> Result<(), SynthesisError> {
-                let a = cs.alloc(|| "a", || self.a.ok_or(SynthesisError::AssignmentMissing))?;
-                let b = cs.alloc(|| "b", || self.b.ok_or(SynthesisError::AssignmentMissing))?;
-                let c = cs.alloc_input(
-                    || "c",
-                    || {
-                        let mut a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
-                        let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
-
-                        a.mul_assign(&b);
-                        Ok(a)
-                    },
-                )?;
-
-                cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
-
-                Ok(())
-            }
-        }
-
         let rng = &mut thread_rng();
 
         let params =
@@ -72,49 +72,17 @@ mod bls12_377 {
 }
 
 mod sw6 {
-    use crate::{
-        gm17::{
-            create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
-        },
-        Circuit, ConstraintSystem, SynthesisError,
+    use super::*;
+    use crate::gm17::{
+        create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     };
 
     use rand::{thread_rng, Rand};
 
-    use algebra::{curves::sw6::SW6, fields::sw6::Fr as SW6Fr, Field, PairingEngine};
-    use std::ops::MulAssign;
+    use algebra::{curves::sw6::SW6, fields::sw6::Fr as SW6Fr, Field};
 
     #[test]
     fn prove_and_verify() {
-        struct MySillyCircuit<E: PairingEngine> {
-            a: Option<E::Fr>,
-            b: Option<E::Fr>,
-        }
-
-        impl<E: PairingEngine> Circuit<E> for MySillyCircuit<E> {
-            fn synthesize<CS: ConstraintSystem<E>>(
-                self,
-                cs: &mut CS,
-            ) -> Result<(), SynthesisError> {
-                let a = cs.alloc(|| "a", || self.a.ok_or(SynthesisError::AssignmentMissing))?;
-                let b = cs.alloc(|| "b", || self.b.ok_or(SynthesisError::AssignmentMissing))?;
-                let c = cs.alloc_input(
-                    || "c",
-                    || {
-                        let mut a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
-                        let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
-
-                        a.mul_assign(&b);
-                        Ok(a)
-                    },
-                )?;
-
-                cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
-
-                Ok(())
-            }
-        }
-
         let rng = &mut thread_rng();
 
         let params =


### PR DESCRIPTION
Currently the `ConstraintSystem` trait and its ecosystem (such as all the gadgets) are generic over a parameter `E: PairingEngine`. This parameter *only* specifies the field over which the `ConstraintSystem` is defined; it has no other purpose.

This is an issue because requiring `E` to be a `PairingEngine` unnecessarily limits the kinds of proofs systems that our gadgets can be used with. For example, one might wish to use these gadgets with a Bulletproofs implementation build atop the `algebra` crate; currently, this is only possible if the underlying group is a pairing-friendly group.

This pull request remedies this by changing `ConstraintSystem` to instead be generic over a parameter `F: Field`, which is the minimum bound needed to define the system.

Note that this is a *breaking change*.

TL;DR: 
* `ConstraintSystem<E: PairingEngine>` -> `ConstraintSystem<F: Field>`
* `Circuit<E: PairingEngine>` -> `ConstraintSynthesizer<F: Field>`
These changes propagate through all the infrastructure built atop them.