### PR TITLE
[Work In Progress][failing test build] minor edits to gm17/tests/mimc.rs

### DIFF
--- a/gm17/tests/mimc.rs
+++ b/gm17/tests/mimc.rs
@@ -32,12 +32,12 @@ use rand::{thread_rng, Rng};
 use std::time::{Duration, Instant};
 
 // Bring in some tools for using pairing-friendly curves
-use algebra::{curves::bls12_381::Bls12_381, Field, PairingEngine};
+use algebra::{curves::bls12_381::Bls12_381, Field};
 
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.
 
 // We'll use these interfaces to construct our circuit.
-use snark::{Circuit, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
 
 use std::ops::{AddAssign, MulAssign};
 
@@ -56,7 +56,7 @@ const MIMC_ROUNDS: usize = 322;
 ///     return xL
 /// }
 /// ```
-fn mimc<E: PairingEngine>(mut xl: E::Fr, mut xr: E::Fr, constants: &[E::Fr]) -> E::Fr {
+fn mimc<F: Field>(mut xl: F, mut xr: F, constants: &[F]) -> F {
     assert_eq!(constants.len(), MIMC_ROUNDS);
 
     for i in 0..MIMC_ROUNDS {
@@ -75,17 +75,17 @@ fn mimc<E: PairingEngine>(mut xl: E::Fr, mut xr: E::Fr, constants: &[E::Fr]) -> 
 
 /// This is our demo circuit for proving knowledge of the
 /// preimage of a MiMC hash invocation.
-struct MiMCDemo<'a, E: PairingEngine> {
-    xl:        Option<E::Fr>,
-    xr:        Option<E::Fr>,
-    constants: &'a [E::Fr],
+struct MiMCDemo<'a, F: Field> {
+    xl:        Option<F>,
+    xr:        Option<F>,
+    constants: &'a [F],
 }
 
 /// Our demo circuit implements this `Circuit` trait which
 /// is used during paramgen and proving in order to
 /// synthesize the constraint system.
-impl<'a, E: PairingEngine> Circuit<E> for MiMCDemo<'a, E> {
-    fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
+    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         assert_eq!(self.constants.len(), MIMC_ROUNDS);
 
         // Allocate the first component of the preimage.
@@ -171,7 +171,7 @@ impl<'a, E: PairingEngine> Circuit<E> for MiMCDemo<'a, E> {
 #[test]
 fn test_mimc_groth_maller_17() {
     // We're going to use the GM17 proving system.
-    use snark::gm17::{
+    use gm17::{
         create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     };
 

--- a/gm17/tests/mimc.rs
+++ b/gm17/tests/mimc.rs
@@ -215,7 +215,7 @@ fn test_mimc_groth_maller_17() {
         // Generate a random preimage and compute the image
         let xl = rng.gen();
         let xr = rng.gen();
-        let image = mimc::<Fr>(xl, xr, &constants);
+        let image = mimc(xl, xr, &constants);
 
         // proof_vec.truncate(0);
 

--- a/gm17/tests/mimc.rs
+++ b/gm17/tests/mimc.rs
@@ -32,14 +32,16 @@ use rand::{thread_rng, Rng};
 use std::time::{Duration, Instant};
 
 // Bring in some tools for using pairing-friendly curves
-use algebra::{curves::bls12_381::Bls12_381, Field};
+use algebra::{
+    curves::bls12_381::Bls12_381,
+    fields::bls12_381::fr::Fr, 
+    Field
+};
 
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.
 
 // We'll use these interfaces to construct our circuit.
 use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
-
-use std::ops::{AddAssign, MulAssign};
 
 const MIMC_ROUNDS: usize = 322;
 
@@ -186,13 +188,13 @@ fn test_mimc_groth_maller_17() {
 
     // Create parameters for our circuit
     let params = {
-        let c = MiMCDemo::<Bls12_381> {
+        let c = MiMCDemo::<Fr> {
             xl:        None,
             xr:        None,
             constants: &constants,
         };
 
-        generate_random_parameters(c, rng).unwrap()
+        generate_random_parameters::<Bls12_381, _, _>(c, rng).unwrap()
     };
 
     // Prepare the verification key (for proof verification)
@@ -213,7 +215,7 @@ fn test_mimc_groth_maller_17() {
         // Generate a random preimage and compute the image
         let xl = rng.gen();
         let xr = rng.gen();
-        let image = mimc::<Bls12_381>(xl, xr, &constants);
+        let image = mimc::<Fr>(xl, xr, &constants);
 
         // proof_vec.truncate(0);
 

--- a/r1cs-core/src/lib.rs
+++ b/r1cs-core/src/lib.rs
@@ -18,7 +18,6 @@ pub use constraint_system::{ConstraintSystem, ConstraintSynthesizer, Namespace};
 pub use error::SynthesisError;
 pub use algebra::ToConstraintField;
 
-
 use algebra::Field;
 use smallvec::SmallVec as StackVec;
 use std::cmp::Ordering;


### PR DESCRIPTION
`cargo test test_execute_constraint_systems --release` was leading to this build failure on the CLI: https://gist.github.com/savil/7e42f106b207b31082a202e27c279108

The current edits seem to fix some issues, but the replacement of
`PairingEngine` with `Field` is hitting an error.

The compiler error is:
```
error[E0277]: the trait bound `algebra::curves::models::bls12::Bls12<algebra::curves::bls12_381::Bls12_381Parameters>: algebra::fields::Field` is not satisfied
   --> gm17/tests/mimc.rs:189:17
    |
189 |         let c = MiMCDemo::<Bls12_381> {
    |                 ^^^^^^^^^^^^^^^^^^^^^ the trait `algebra::fields::Field` is not implemented for `algebra::curves::models::bls12::Bls12<algebra::curves::bls12_381::Bls12_381Parameters>`
    |
```

I'm not sure how to proceed here. Halp?