### PR TITLE
Make CI check that tests compile and that tests pass for some crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,5 @@ matrix:
 cache: cargo
 
 script:
-  - cd algebra
-  - cargo test
-  - cargo check --profile bench
-  - cd ../r1cs-core
-  - cargo check
-  - cd ../r1cs-std
-  - cargo test
-  - cd ../gm17
-  - cargo test
-  - cargo check --examples
-  - cd ../dpc
-  - cargo check --profile test
+  - cargo test --all --release
+  - cargo check --examples --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,15 @@ matrix:
 cache: cargo
 
 script:
+  - cd algebra
+  - cargo test
+  - cargo check --profile bench
+  - cd ../r1cs-core
   - cargo check
+  - cd ../r1cs-std
+  - cargo test
+  - cd ../gm17
+  - cargo test
+  - cargo check --examples
+  - cd ../dpc
+  - cargo check --profile test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ matrix:
 cache: cargo
 
 script:
-  - cargo test --all --release
+  - cargo test --all --release -- --skip "plain_dpc" --skip "integration_test"
   - cargo check --examples --all


### PR DESCRIPTION
#21 highlighted that some PRs might forget to update tests; this changes CI to compile tests (and for crates where these tests are reasonably fast, run them as well).