### PR TITLE
Add `has_witness` method to `ConstraintSynthesizer`

### DIFF
--- a/algebra/src/bytes.rs
+++ b/algebra/src/bytes.rs
@@ -123,7 +123,7 @@ array_bytes!(31);
 array_bytes!(32);
 
 /// Takes as input a sequence of structs, and converts them to a series of
-/// bytes. All traits that implement `Bytes` can be automatically converted to
+/// bytes. All traits that implement `ToBytes` can be automatically converted to
 /// bytes in this manner.
 #[macro_export]
 macro_rules! to_bytes {

--- a/dpc/src/crypto_primitives/nizk/mod.rs
+++ b/dpc/src/crypto_primitives/nizk/mod.rs
@@ -68,6 +68,10 @@ mod test {
         }
 
         impl ConstraintSynthesizer<Fr> for R1CSCircuit {
+            fn has_witness(&self) -> bool {
+                self.x.is_some() && self.sum.is_some() && self.w.is_some()
+            }
+
             fn generate_constraints<CS: ConstraintSystem<Fr>>(
                 self,
                 cs: &mut CS,

--- a/dpc/src/dpc/delegable_dpc/core_checks_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/core_checks_circuit.rs
@@ -250,6 +250,31 @@ impl<C: DelegableDPCComponents> CoreChecksCircuit<C> {
 }
 
 impl<C: DelegableDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for CoreChecksCircuit<C> {
+    fn has_witness(&self) -> bool {
+        self.comm_crh_sig_parameters.is_some()
+        && self.ledger_parameters.is_some()
+
+        && self.ledger_digest.is_some()
+
+        && self.old_records.is_some()
+        && self.old_witnesses.is_some()
+        && self.old_address_secret_keys.is_some()
+        && self.old_serial_numbers.is_some()
+
+        && self.new_records.is_some()
+        && self.new_sn_nonce_randomness.is_some()
+        && self.new_commitments.is_some()
+
+        && self.predicate_comm.is_some()
+        && self.predicate_rand.is_some()
+
+        && self.local_data_comm.is_some()
+        && self.local_data_rand.is_some()
+
+        && self.memo.is_some()
+        && self.auxiliary.is_some()
+    }
+
     fn generate_constraints<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         execute_core_checks_gadget::<C, CS>(
             cs,

--- a/dpc/src/dpc/delegable_dpc/predicate_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/predicate_circuit.rs
@@ -162,6 +162,10 @@ impl<C: DelegableDPCComponents> EmptyPredicateCircuit<C> {
 }
 
 impl<C: DelegableDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for EmptyPredicateCircuit<C> {
+    fn has_witness(&self) -> bool {
+        self.comm_and_crh_parameters.is_some() && self.local_data_comm.is_some()
+    }
+
     fn generate_constraints<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let _position = UInt8::alloc_input_vec(cs.ns(|| "Alloc position"), &[self.position])?;
 

--- a/dpc/src/dpc/delegable_dpc/proof_check_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/proof_check_circuit.rs
@@ -145,6 +145,15 @@ where
     <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
     <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
 {
+    fn has_witness(&self) -> bool {
+        self.comm_crh_sig_parameters.is_some()
+        && self.old_private_pred_inputs.is_some()
+        && self.new_private_pred_inputs.is_some()
+        && self.predicate_comm.is_some()
+        && self.predicate_rand.is_some()
+        && self.local_data_comm.is_some()
+    }
+
     fn generate_constraints<CS: ConstraintSystem<C::ProofCheckF>>(
         self,
         cs: &mut CS,

--- a/dpc/src/dpc/plain_dpc/core_checks_circuit.rs
+++ b/dpc/src/dpc/plain_dpc/core_checks_circuit.rs
@@ -245,6 +245,31 @@ impl<C: PlainDPCComponents> CoreChecksCircuit<C> {
 }
 
 impl<C: PlainDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for CoreChecksCircuit<C> {
+    fn has_witness(&self) -> bool {
+        self.comm_and_crh_parameters.is_some()
+            && self.ledger_parameters.is_some()
+
+            && self.ledger_digest.is_some()
+
+            && self.old_records.is_some()
+            && self.old_witnesses.is_some()
+            && self.old_address_secret_keys.is_some()
+            && self.old_serial_numbers.is_some()
+
+            && self.new_records.is_some()
+            && self.new_sn_nonce_randomness.is_some()
+            && self.new_commitments.is_some()
+
+            && self.predicate_comm.is_some()
+            && self.predicate_rand.is_some()
+
+            && self.local_data_comm.is_some()
+            && self.local_data_rand.is_some()
+
+            && self.memo.is_some()
+            && self.auxiliary.is_some()
+    }
+
     fn generate_constraints<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         execute_core_checks_gadget::<C, CS>(
             cs,

--- a/dpc/src/dpc/plain_dpc/predicate_circuit.rs
+++ b/dpc/src/dpc/plain_dpc/predicate_circuit.rs
@@ -158,6 +158,10 @@ impl<C: PlainDPCComponents> EmptyPredicateCircuit<C> {
 }
 
 impl<C: PlainDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for EmptyPredicateCircuit<C> {
+    fn has_witness(&self) -> bool {
+        self.comm_and_crh_parameters.is_some() && self.local_data_comm.is_some()
+    }
+
     fn generate_constraints<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let _position = UInt8::alloc_input_vec(cs.ns(|| "Alloc position"), &[self.position])?;
 

--- a/dpc/src/dpc/plain_dpc/proof_check_circuit.rs
+++ b/dpc/src/dpc/plain_dpc/proof_check_circuit.rs
@@ -148,6 +148,18 @@ where
     <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
     <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
 {
+    fn has_witness(&self) -> bool {
+        self.comm_and_crh_parameters.is_some()
+
+        && self.old_private_pred_inputs.is_some()
+
+        && self.new_private_pred_inputs.is_some()
+
+        && self.predicate_comm.is_some()
+        && self.predicate_rand.is_some()
+        && self.local_data_comm.is_some()
+    }
+
     fn generate_constraints<CS: ConstraintSystem<C::ProofCheckF>>(
         self,
         cs: &mut CS,

--- a/dpc/src/gadgets/verifier/gm17.rs
+++ b/dpc/src/gadgets/verifier/gm17.rs
@@ -429,6 +429,10 @@ mod test {
     }
 
     impl<F: Field> ConstraintSynthesizer<F> for Bench<F> {
+        fn has_witness(&self) -> bool {
+            self.inputs.iter().all(|inp| inp.is_some())
+        }
+
         fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
             assert!(self.inputs.len() >= 2);
             assert!(self.num_constraints >= self.inputs.len());

--- a/gm17/examples/snark-scalability/constraints.rs
+++ b/gm17/examples/snark-scalability/constraints.rs
@@ -17,6 +17,11 @@ impl<F: Field> Benchmark<F> {
 }
 
 impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
+    fn has_witness(&self) -> bool {
+        // we always generate a witness, so this is always true.
+        true
+    }
+
     fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let mut assignments = Vec::new();
 

--- a/gm17/src/test.rs
+++ b/gm17/src/test.rs
@@ -6,6 +6,10 @@ struct MySillyCircuit<F: Field> {
 }
 
 impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<ConstraintF> {
+    fn has_witness(&self) -> bool {
+        self.a.is_some() && self.b.is_some()
+    }
+
     fn generate_constraints<CS: ConstraintSystem<ConstraintF>>(
         self,
         cs: &mut CS,

--- a/gm17/tests/mimc.rs
+++ b/gm17/tests/mimc.rs
@@ -87,6 +87,10 @@ struct MiMCDemo<'a, F: Field> {
 /// is used during paramgen and proving in order to
 /// synthesize the constraint system.
 impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
+    fn has_witness(&self) -> bool {
+        self.xl.is_some() && self.xr.is_some()
+    }
+
     fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         assert_eq!(self.constants.len(), MIMC_ROUNDS);
 

--- a/r1cs-core/src/constraint_system.rs
+++ b/r1cs-core/src/constraint_system.rs
@@ -83,6 +83,10 @@ pub struct Namespace<'a, F: Field, CS: ConstraintSystem<F>>(&'a mut CS, PhantomD
 /// The `generate_constraints` method is called to generate constraints for
 /// both CRS generation and for proving.
 pub trait ConstraintSynthesizer<F: Field> {
+    /// Does `self` have a witness for the constraint system? This should 
+    /// return false when in CRS generation mode, and true in proving mode.
+    fn has_witness(&self) -> bool;
+
     /// Drives generation of new constraints inside `CS`.
     fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError>;
 }


### PR DESCRIPTION
This is a breaking change which adds a `has_witness` method to the `ConstraintSynthesizer` trait. This method is useful when implementing SNARKs; it enables the setup and prover methods of these SNARKs to assert that, when setup is being performed, the constraint system doesn't have the inputs to the synthesized constraint system, and when proving is being performed, *does* have said inputs.