### PR TITLE
Groth16: Makes SRS match the description in the paper

### DIFF
--- a/groth16/src/generator.rs
+++ b/groth16/src/generator.rs
@@ -268,7 +268,7 @@ where
         scalar_bits,
         g1_window,
         &g1_table,
-        &(0..m_raw + 1)
+        &(0..m_raw - 1)
             .into_par_iter()
             .map(|i| zt * &delta_inverse * &t.pow([i as u64]))
             .collect::<Vec<_>>(),
@@ -278,8 +278,9 @@ where
 
     // Compute the L-query
     let l_time = start_timer!(|| "Calculate L");
-    let mut l_query =
+    let l_query =
         FixedBaseMSM::multi_scalar_mul::<E::G1Projective>(scalar_bits, g1_window, &g1_table, &l);
+    let mut l_query = l_query[assembly.num_inputs..].to_vec();
     end_timer!(l_time);
 
     end_timer!(proving_key_time);

--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -273,13 +273,6 @@ impl<E: PairingEngine> Parameters<E> {
         Ok((&self.h_query[0..num_inputs], &self.h_query[num_inputs..]))
     }
 
-    pub fn get_l_query(
-        &self,
-        num_inputs: usize,
-    ) -> Result<(&[E::G1Affine], &[E::G1Affine]), SynthesisError> {
-        Ok((&self.l_query[1..num_inputs], &self.l_query[num_inputs..]))
-    }
-
     pub fn get_a_query_full(&self) -> Result<&[E::G1Affine], SynthesisError> {
         Ok(&self.a_query)
     }

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -321,7 +321,7 @@ where
     let h_inputs_acc = VariableBaseMSM::multi_scalar_mul(h_inputs_source, &h_input_assignment);
     let h_aux_acc = VariableBaseMSM::multi_scalar_mul(h_aux_source, &h_aux_assignment);
 
-    let (_, l_aux_source) = params.get_l_query(prover.num_inputs)?;
+    let l_aux_source = params.get_l_query_full()?;
     let l_aux_acc = VariableBaseMSM::multi_scalar_mul(l_aux_source, &aux_assignment);
 
     let s_g_a = g_a.clone().mul(&s);


### PR DESCRIPTION
* The L query has only the auxiliary portion after the setup.
* The H query has only elements up to degree n-2.
