### PR TITLE
renames ConstraintSystem to R1CS

### DIFF
--- a/crypto-primitives/src/commitment/blake2s/constraints.rs
+++ b/crypto-primitives/src/commitment/blake2s/constraints.rs
@@ -1,4 +1,4 @@
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use crate::{
     commitment::blake2s::Blake2sCommitment,
@@ -25,7 +25,7 @@ impl<ConstraintF: PrimeField> CommitmentGadget<Blake2sCommitment, ConstraintF>
     type ParametersGadget = Blake2sParametersGadget;
     type RandomnessGadget = Blake2sRandomnessGadget;
 
-    fn check_commitment_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_commitment_gadget<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         _: &Self::ParametersGadget,
         input: &[UInt8],
@@ -48,7 +48,7 @@ impl<ConstraintF: PrimeField> CommitmentGadget<Blake2sCommitment, ConstraintF>
 }
 
 impl<ConstraintF: Field> AllocGadget<(), ConstraintF> for Blake2sParametersGadget {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(_: CS, _: F) -> Result<Self, SynthesisError>
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(_: CS, _: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<()>,
@@ -56,7 +56,7 @@ impl<ConstraintF: Field> AllocGadget<(), ConstraintF> for Blake2sParametersGadge
         Ok(Blake2sParametersGadget)
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         _: CS,
         _: F,
     ) -> Result<Self, SynthesisError>
@@ -70,7 +70,7 @@ impl<ConstraintF: Field> AllocGadget<(), ConstraintF> for Blake2sParametersGadge
 
 impl<ConstraintF: PrimeField> AllocGadget<[u8; 32], ConstraintF> for Blake2sRandomnessGadget {
     #[inline]
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -89,7 +89,7 @@ impl<ConstraintF: PrimeField> AllocGadget<[u8; 32], ConstraintF> for Blake2sRand
     }
 
     #[inline]
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -120,12 +120,12 @@ mod test {
         },
         *,
     };
-    use r1cs_core::ConstraintSystem;
-    use r1cs_std::{prelude::*, test_constraint_system::TestConstraintSystem};
+    use r1cs_core::R1CS;
+    use r1cs_std::{prelude::*, test_constraint_system::TestR1CS};
 
     #[test]
     fn commitment_gadget_test() {
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
 
         let input = [1u8; 32];
 

--- a/crypto-primitives/src/commitment/constraints.rs
+++ b/crypto-primitives/src/commitment/constraints.rs
@@ -1,6 +1,6 @@
 use crate::CommitmentScheme;
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 use std::fmt::Debug;
 
@@ -14,7 +14,7 @@ pub trait CommitmentGadget<C: CommitmentScheme, ConstraintF: Field> {
     type ParametersGadget: AllocGadget<C::Parameters, ConstraintF> + Clone;
     type RandomnessGadget: AllocGadget<C::Randomness, ConstraintF> + Clone;
 
-    fn check_commitment_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_commitment_gadget<CS: R1CS<ConstraintF>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],

--- a/crypto-primitives/src/commitment/injective_map/constraints.rs
+++ b/crypto-primitives/src/commitment/injective_map/constraints.rs
@@ -13,7 +13,7 @@ use crate::commitment::{
 
 pub use crate::crh::injective_map::constraints::InjectiveMapGadget;
 use algebra::groups::Group;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::{groups::GroupGadget, uint8::UInt8};
 
 use std::marker::PhantomData;
@@ -45,7 +45,7 @@ where
     type ParametersGadget = PedersenCommitmentGadgetParameters<G, W, ConstraintF>;
     type RandomnessGadget = PedersenRandomnessGadget;
 
-    fn check_commitment_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_commitment_gadget<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],

--- a/crypto-primitives/src/commitment/pedersen/constraints.rs
+++ b/crypto-primitives/src/commitment/pedersen/constraints.rs
@@ -3,7 +3,7 @@ use crate::{
     crh::pedersen::PedersenWindow,
 };
 use algebra::{to_bytes, Group, ToBytes};
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use crate::commitment::CommitmentGadget;
 use algebra::fields::{Field, PrimeField};
@@ -43,7 +43,7 @@ where
     type ParametersGadget = PedersenCommitmentGadgetParameters<G, W, ConstraintF>;
     type RandomnessGadget = PedersenRandomnessGadget;
 
-    fn check_commitment_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_commitment_gadget<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],
@@ -95,7 +95,7 @@ where
     W: PedersenWindow,
     ConstraintF: PrimeField,
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         _cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -114,7 +114,7 @@ where
         })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         _cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -139,7 +139,7 @@ where
     G: Group,
     ConstraintF: PrimeField,
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -152,7 +152,7 @@ where
         Ok(PedersenRandomnessGadget(UInt8::alloc_vec(cs, &randomness)?))
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -187,14 +187,14 @@ mod test {
         crh::pedersen::PedersenWindow,
     };
     use algebra::curves::{jubjub::JubJubProjective as JubJub, ProjectiveCurve};
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
     use r1cs_std::{
-        groups::jubjub::JubJubGadget, prelude::*, test_constraint_system::TestConstraintSystem,
+        groups::jubjub::JubJubGadget, prelude::*, test_constraint_system::TestR1CS,
     };
 
     #[test]
     fn commitment_gadget_test() {
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         #[derive(Clone, PartialEq, Eq, Hash)]
         pub(super) struct Window;

--- a/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
@@ -7,7 +7,7 @@ use crate::crh::{
     FixedLengthCRHGadget,
 };
 use algebra::groups::Group;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::{alloc::AllocGadget, groups::GroupGadget, uint8::UInt8};
 
 use r1cs_std::bits::boolean::Boolean;
@@ -50,7 +50,7 @@ where
     type OutputGadget = GG;
     type ParametersGadget = BoweHopwoodPedersenCRHGadgetParameters<G, W, ConstraintF, GG>;
 
-    fn check_evaluation_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_evaluation_gadget<CS: R1CS<ConstraintF>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],
@@ -88,7 +88,7 @@ impl<G: Group, W: PedersenWindow, ConstraintF: Field, GG: GroupGadget<G, Constra
     AllocGadget<BoweHopwoodPedersenParameters<G>, ConstraintF>
     for BoweHopwoodPedersenCRHGadgetParameters<G, W, ConstraintF, GG>
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         _cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -105,7 +105,7 @@ impl<G: Group, W: PedersenWindow, ConstraintF: Field, GG: GroupGadget<G, Constra
         })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         _cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -134,10 +134,10 @@ mod test {
         FixedLengthCRH, FixedLengthCRHGadget,
     };
     use algebra::{curves::edwards_sw6::EdwardsProjective as Edwards, ProjectiveCurve};
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
     use r1cs_std::{
         alloc::AllocGadget, groups::curves::twisted_edwards::edwards_sw6::EdwardsSWGadget,
-        test_constraint_system::TestConstraintSystem, uint8::UInt8,
+        test_constraint_system::TestR1CS, uint8::UInt8,
     };
 
     type TestCRH = BoweHopwoodPedersenCRH<Edwards, Window>;
@@ -151,7 +151,7 @@ mod test {
         const NUM_WINDOWS: usize = 8;
     }
 
-    fn generate_input<CS: ConstraintSystem<Fr>, R: Rng>(
+    fn generate_input<CS: R1CS<Fr>, R: Rng>(
         mut cs: CS,
         rng: &mut R,
     ) -> ([u8; 270], Vec<UInt8>) {
@@ -169,7 +169,7 @@ mod test {
     #[test]
     fn crh_primitive_gadget_test() {
         let rng = &mut thread_rng();
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
 
         let (input, input_bytes) = generate_input(&mut cs, rng);
         println!("number of constraints for input: {}", cs.num_constraints());

--- a/crypto-primitives/src/crh/constraints.rs
+++ b/crypto-primitives/src/crh/constraints.rs
@@ -2,7 +2,7 @@ use algebra::Field;
 use std::fmt::Debug;
 
 use crate::crh::FixedLengthCRH;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use r1cs_std::prelude::*;
 
@@ -17,7 +17,7 @@ pub trait FixedLengthCRHGadget<H: FixedLengthCRH, ConstraintF: Field>: Sized {
         + Sized;
     type ParametersGadget: AllocGadget<H::Parameters, ConstraintF> + Clone;
 
-    fn check_evaluation_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_evaluation_gadget<CS: R1CS<ConstraintF>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],

--- a/crypto-primitives/src/crh/injective_map/constraints.rs
+++ b/crypto-primitives/src/crh/injective_map/constraints.rs
@@ -17,7 +17,7 @@ use algebra::{
     fields::{Field, PrimeField, SquareRootField},
     groups::Group,
 };
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::{
     fields::fp::FpGadget,
     groups::{curves::twisted_edwards::AffineGadget as TwistedEdwardsGadget, GroupGadget},
@@ -39,7 +39,7 @@ pub trait InjectiveMapGadget<
         + Clone
         + Sized;
 
-    fn evaluate_map<CS: ConstraintSystem<ConstraintF>>(
+    fn evaluate_map<CS: R1CS<ConstraintF>>(
         cs: CS,
         ge: &GG,
     ) -> Result<Self::OutputGadget, SynthesisError>;
@@ -60,7 +60,7 @@ where
 {
     type OutputGadget = FpGadget<ConstraintF>;
 
-    fn evaluate_map<CS: ConstraintSystem<ConstraintF>>(
+    fn evaluate_map<CS: R1CS<ConstraintF>>(
         _cs: CS,
         ge: &TwistedEdwardsGadget<P, ConstraintF, FpGadget<ConstraintF>>,
     ) -> Result<Self::OutputGadget, SynthesisError> {
@@ -81,7 +81,7 @@ where
 {
     type OutputGadget = FpGadget<ConstraintF>;
 
-    fn evaluate_map<CS: ConstraintSystem<ConstraintF>>(
+    fn evaluate_map<CS: R1CS<ConstraintF>>(
         _cs: CS,
         ge: &TwistedEdwardsGadget<P, ConstraintF, FpGadget<ConstraintF>>,
     ) -> Result<Self::OutputGadget, SynthesisError> {
@@ -115,7 +115,7 @@ where
     type OutputGadget = IG::OutputGadget;
     type ParametersGadget = PedersenCRHGadgetParameters<G, W, ConstraintF, GG>;
 
-    fn check_evaluation_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_evaluation_gadget<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],

--- a/crypto-primitives/src/crh/pedersen/constraints.rs
+++ b/crypto-primitives/src/crh/pedersen/constraints.rs
@@ -3,7 +3,7 @@ use crate::crh::{
     FixedLengthCRHGadget,
 };
 use algebra::{Field, Group};
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 
 use std::{borrow::Borrow, marker::PhantomData};
@@ -44,7 +44,7 @@ where
     type OutputGadget = GG;
     type ParametersGadget = PedersenCRHGadgetParameters<G, W, ConstraintF, GG>;
 
-    fn check_evaluation_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_evaluation_gadget<CS: R1CS<ConstraintF>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         input: &[UInt8],
@@ -77,7 +77,7 @@ impl<G: Group, W: PedersenWindow, ConstraintF: Field, GG: GroupGadget<G, Constra
     AllocGadget<PedersenParameters<G>, ConstraintF>
     for PedersenCRHGadgetParameters<G, W, ConstraintF, GG>
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         _cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -94,7 +94,7 @@ impl<G: Group, W: PedersenWindow, ConstraintF: Field, GG: GroupGadget<G, Constra
         })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         _cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -122,10 +122,10 @@ mod test {
         FixedLengthCRH, FixedLengthCRHGadget,
     };
     use algebra::curves::{jubjub::JubJubProjective as JubJub, ProjectiveCurve};
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
     use r1cs_std::{
         groups::curves::twisted_edwards::jubjub::JubJubGadget, prelude::*,
-        test_constraint_system::TestConstraintSystem,
+        test_constraint_system::TestR1CS,
     };
 
     type TestCRH = PedersenCRH<JubJub, Window>;
@@ -139,7 +139,7 @@ mod test {
         const NUM_WINDOWS: usize = 8;
     }
 
-    fn generate_input<CS: ConstraintSystem<Fr>, R: Rng>(
+    fn generate_input<CS: R1CS<Fr>, R: Rng>(
         mut cs: CS,
         rng: &mut R,
     ) -> ([u8; 128], Vec<UInt8>) {
@@ -157,7 +157,7 @@ mod test {
     #[test]
     fn crh_primitive_gadget_test() {
         let rng = &mut thread_rng();
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
 
         let (input, input_bytes) = generate_input(&mut cs, rng);
         println!("number of constraints for input: {}", cs.num_constraints());

--- a/crypto-primitives/src/merkle_tree/constraints.rs
+++ b/crypto-primitives/src/merkle_tree/constraints.rs
@@ -1,5 +1,5 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::{boolean::AllocatedBit, prelude::*};
 
 use crate::{
@@ -24,7 +24,7 @@ where
     ConstraintF: Field,
     CRHGadget: FixedLengthCRHGadget<P::H, ConstraintF>,
 {
-    pub fn check_membership<CS: ConstraintSystem<ConstraintF>>(
+    pub fn check_membership<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         parameters: &CRHGadget::ParametersGadget,
@@ -34,7 +34,7 @@ where
         self.conditionally_check_membership(cs, parameters, root, leaf, &Boolean::Constant(true))
     }
 
-    pub fn conditionally_check_membership<CS: ConstraintSystem<ConstraintF>>(
+    pub fn conditionally_check_membership<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         parameters: &CRHGadget::ParametersGadget,
@@ -109,7 +109,7 @@ pub(crate) fn hash_inner_node_gadget<H, HG, ConstraintF, CS>(
 ) -> Result<HG::OutputGadget, SynthesisError>
 where
     ConstraintF: Field,
-    CS: ConstraintSystem<ConstraintF>,
+    CS: R1CS<ConstraintF>,
     H: FixedLengthCRH,
     HG: FixedLengthCRHGadget<H, ConstraintF>,
 {
@@ -128,7 +128,7 @@ where
     HGadget: FixedLengthCRHGadget<P::H, ConstraintF>,
     ConstraintF: Field,
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -151,7 +151,7 @@ where
         Ok(MerkleTreePathGadget { path })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -188,14 +188,14 @@ mod test {
         merkle_tree::*,
     };
     use algebra::{curves::jubjub::JubJubAffine as JubJub, fields::jubjub::fq::Fq};
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
     use super::*;
     use r1cs_std::{
         groups::curves::twisted_edwards::jubjub::JubJubGadget,
-        test_constraint_system::TestConstraintSystem,
+        test_constraint_system::TestR1CS,
     };
 
     #[derive(Clone)]
@@ -225,7 +225,7 @@ mod test {
         let root = tree.root();
         let mut satisfied = true;
         for (i, leaf) in leaves.iter().enumerate() {
-            let mut cs = TestConstraintSystem::<Fq>::new();
+            let mut cs = TestR1CS::<Fq>::new();
             let proof = tree.generate_proof(i, &leaf).unwrap();
             assert!(proof.verify(&crh_parameters, &root, &leaf).unwrap());
 

--- a/crypto-primitives/src/nizk/constraints.rs
+++ b/crypto-primitives/src/nizk/constraints.rs
@@ -1,5 +1,5 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 
 use crate::nizk::NIZK;
@@ -17,7 +17,7 @@ pub trait NIZKVerifierGadget<N: NIZK, ConstraintF: Field> {
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
         I: Iterator<Item = &'a T>,
         T: 'a + ToBitsGadget<ConstraintF> + ?Sized;
 }

--- a/crypto-primitives/src/nizk/gm17/constraints.rs
+++ b/crypto-primitives/src/nizk/gm17/constraints.rs
@@ -1,6 +1,6 @@
 use crate::nizk::{gm17::Gm17, NIZKVerifierGadget};
 use algebra::{AffineCurve, Field, PairingEngine, ToConstraintField};
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 
 use gm17::{Proof, VerifyingKey};
@@ -39,7 +39,7 @@ pub struct VerifyingKeyGadget<
 impl<PairingE: PairingEngine, ConstraintF: Field, P: PairingGadget<PairingE, ConstraintF>>
     VerifyingKeyGadget<PairingE, ConstraintF, P>
 {
-    pub fn prepare<CS: ConstraintSystem<ConstraintF>>(
+    pub fn prepare<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>, SynthesisError> {
@@ -112,7 +112,7 @@ where
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
         I: Iterator<Item = &'a T>,
         T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
     {
@@ -200,7 +200,7 @@ where
     P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -250,7 +250,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -310,7 +310,7 @@ where
     P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -328,7 +328,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -356,7 +356,7 @@ where
     P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -389,7 +389,7 @@ where
         Ok(bytes)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -400,7 +400,7 @@ where
 #[cfg(test)]
 mod test {
     use gm17::*;
-    use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+    use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
     use super::*;
     use algebra::{
@@ -410,7 +410,7 @@ mod test {
     };
     use r1cs_std::{
         boolean::Boolean, pairing::bls12_377::PairingGadget as Bls12_377PairingGadget,
-        test_constraint_system::TestConstraintSystem,
+        test_constraint_system::TestR1CS,
     };
     use rand::{thread_rng, Rng};
 
@@ -425,7 +425,7 @@ mod test {
     }
 
     impl<F: Field> ConstraintSynthesizer<F> for Bench<F> {
-        fn generate_constraints<CS: ConstraintSystem<F>>(
+        fn generate_constraints<CS: R1CS<F>>(
             self,
             cs: &mut CS,
         ) -> Result<(), SynthesisError> {
@@ -496,7 +496,7 @@ mod test {
             };
 
             // assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
-            let mut cs = TestConstraintSystem::<Fq>::new();
+            let mut cs = TestR1CS::<Fq>::new();
 
             let inputs: Vec<_> = inputs.into_iter().map(|input| input.unwrap()).collect();
             let mut input_gadgets = Vec::new();

--- a/crypto-primitives/src/nizk/groth16/constraints.rs
+++ b/crypto-primitives/src/nizk/groth16/constraints.rs
@@ -1,6 +1,6 @@
 use crate::nizk::{groth16::Groth16, NIZKVerifierGadget};
 use algebra::{AffineCurve, Field, PairingEngine, ToConstraintField};
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 
 use groth16::{Proof, VerifyingKey};
@@ -38,7 +38,7 @@ pub struct VerifyingKeyGadget<
 impl<PairingE: PairingEngine, ConstraintF: Field, P: PairingGadget<PairingE, ConstraintF>>
     VerifyingKeyGadget<PairingE, ConstraintF, P>
 {
-    pub fn prepare<CS: ConstraintSystem<ConstraintF>>(
+    pub fn prepare<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>, SynthesisError> {
@@ -113,7 +113,7 @@ where
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
         I: Iterator<Item = &'a T>,
         T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
     {
@@ -171,7 +171,7 @@ where
     P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -218,7 +218,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -274,7 +274,7 @@ where
     P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -292,7 +292,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -320,7 +320,7 @@ where
     P: PairingGadget<PairingE, ConstraintF>,
 {
     #[inline]
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -336,7 +336,7 @@ where
         Ok(bytes)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -347,7 +347,7 @@ where
 #[cfg(test)]
 mod test {
     use groth16::*;
-    use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+    use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
     use super::*;
     use algebra::{
@@ -357,7 +357,7 @@ mod test {
     };
     use r1cs_std::{
         boolean::Boolean, pairing::bls12_377::PairingGadget as Bls12_377PairingGadget,
-        test_constraint_system::TestConstraintSystem,
+        test_constraint_system::TestR1CS,
     };
     use rand::{thread_rng, Rng};
 
@@ -372,7 +372,7 @@ mod test {
     }
 
     impl<F: Field> ConstraintSynthesizer<F> for Bench<F> {
-        fn generate_constraints<CS: ConstraintSystem<F>>(
+        fn generate_constraints<CS: R1CS<F>>(
             self,
             cs: &mut CS,
         ) -> Result<(), SynthesisError> {
@@ -443,7 +443,7 @@ mod test {
             };
 
             // assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
-            let mut cs = TestConstraintSystem::<Fq>::new();
+            let mut cs = TestR1CS::<Fq>::new();
 
             let inputs: Vec<_> = inputs.into_iter().map(|input| input.unwrap()).collect();
             let mut input_gadgets = Vec::new();

--- a/crypto-primitives/src/nizk/mod.rs
+++ b/crypto-primitives/src/nizk/mod.rs
@@ -60,7 +60,7 @@ mod test {
     fn test_gm17() {
         use crate::nizk::{gm17::Gm17, NIZK};
         use algebra::{curves::bls12_381::Bls12_381, fields::bls12_381::Fr, Field};
-        use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+        use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
         #[derive(Copy, Clone)]
         struct R1CSCircuit {
@@ -80,7 +80,7 @@ mod test {
         }
 
         impl ConstraintSynthesizer<Fr> for R1CSCircuit {
-            fn generate_constraints<CS: ConstraintSystem<Fr>>(
+            fn generate_constraints<CS: R1CS<Fr>>(
                 self,
                 cs: &mut CS,
             ) -> Result<(), SynthesisError> {

--- a/crypto-primitives/src/prf/blake2s/constraints.rs
+++ b/crypto-primitives/src/prf/blake2s/constraints.rs
@@ -1,5 +1,5 @@
 use algebra::PrimeField;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use crate::prf::PRFGadget;
 use r1cs_std::prelude::*;
@@ -76,7 +76,7 @@ const SIGMA: [[usize; 16]; 10] = [
 // END FUNCTION.
 //
 
-fn mixing_g<ConstraintF: PrimeField, CS: ConstraintSystem<ConstraintF>>(
+fn mixing_g<ConstraintF: PrimeField, CS: R1CS<ConstraintF>>(
     mut cs: CS,
     v: &mut [UInt32],
     a: usize,
@@ -151,7 +151,7 @@ fn mixing_g<ConstraintF: PrimeField, CS: ConstraintSystem<ConstraintF>>(
 // END FUNCTION.
 //
 
-fn blake2s_compression<ConstraintF: PrimeField, CS: ConstraintSystem<ConstraintF>>(
+fn blake2s_compression<ConstraintF: PrimeField, CS: R1CS<ConstraintF>>(
     mut cs: CS,
     h: &mut [UInt32],
     m: &[UInt32],
@@ -312,7 +312,7 @@ fn blake2s_compression<ConstraintF: PrimeField, CS: ConstraintSystem<ConstraintF
 // END FUNCTION.
 //
 
-pub fn blake2s_gadget<ConstraintF: PrimeField, CS: ConstraintSystem<ConstraintF>>(
+pub fn blake2s_gadget<ConstraintF: PrimeField, CS: R1CS<ConstraintF>>(
     mut cs: CS,
     input: &[Boolean],
 ) -> Result<Vec<UInt32>, SynthesisError> {
@@ -388,7 +388,7 @@ impl<ConstraintF: PrimeField> EqGadget<ConstraintF> for Blake2sOutputGadget {}
 
 impl<ConstraintF: PrimeField> ConditionalEqGadget<ConstraintF> for Blake2sOutputGadget {
     #[inline]
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -411,7 +411,7 @@ impl<ConstraintF: PrimeField> ConditionalEqGadget<ConstraintF> for Blake2sOutput
 
 impl<ConstraintF: PrimeField> ToBytesGadget<ConstraintF> for Blake2sOutputGadget {
     #[inline]
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -419,7 +419,7 @@ impl<ConstraintF: PrimeField> ToBytesGadget<ConstraintF> for Blake2sOutputGadget
     }
 
     #[inline]
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -429,7 +429,7 @@ impl<ConstraintF: PrimeField> ToBytesGadget<ConstraintF> for Blake2sOutputGadget
 
 impl<ConstraintF: PrimeField> AllocGadget<[u8; 32], ConstraintF> for Blake2sOutputGadget {
     #[inline]
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -448,7 +448,7 @@ impl<ConstraintF: PrimeField> AllocGadget<[u8; 32], ConstraintF> for Blake2sOutp
     }
 
     #[inline]
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -470,11 +470,11 @@ impl<ConstraintF: PrimeField> AllocGadget<[u8; 32], ConstraintF> for Blake2sOutp
 impl<ConstraintF: PrimeField> PRFGadget<Blake2s, ConstraintF> for Blake2sGadget {
     type OutputGadget = Blake2sOutputGadget;
 
-    fn new_seed<CS: ConstraintSystem<ConstraintF>>(mut cs: CS, seed: &[u8; 32]) -> Vec<UInt8> {
+    fn new_seed<CS: R1CS<ConstraintF>>(mut cs: CS, seed: &[u8; 32]) -> Vec<UInt8> {
         UInt8::alloc_vec(&mut cs.ns(|| "alloc_seed"), seed).unwrap()
     }
 
-    fn check_evaluation_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_evaluation_gadget<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         seed: &[UInt8],
         input: &[UInt8],
@@ -506,16 +506,16 @@ mod test {
 
     use crate::prf::blake2s::{constraints::blake2s_gadget, Blake2s as B2SPRF};
     use blake2::Blake2s;
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
 
     use super::Blake2sGadget;
     use r1cs_std::{
-        boolean::AllocatedBit, prelude::*, test_constraint_system::TestConstraintSystem,
+        boolean::AllocatedBit, prelude::*, test_constraint_system::TestR1CS,
     };
 
     #[test]
     fn test_blake2s_constraints() {
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
         let input_bits: Vec<_> = (0..512)
             .map(|i| {
                 AllocatedBit::alloc(cs.ns(|| format!("input bit_gadget {}", i)), || Ok(true))
@@ -534,7 +534,7 @@ mod test {
         use rand::Rng;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
 
         let mut seed = [0u8; 32];
         rng.fill(&mut seed);
@@ -575,7 +575,7 @@ mod test {
         // Test that 512 fixed leading bits (constants)
         // doesn't result in more constraints.
 
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
         let input_bits: Vec<_> = (0..512)
             .map(|_| Boolean::constant(rng.gen()))
@@ -592,7 +592,7 @@ mod test {
 
     #[test]
     fn test_blake2s_constant_constraints() {
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
         let input_bits: Vec<_> = (0..512).map(|_| Boolean::constant(rng.gen())).collect();
         blake2s_gadget(&mut cs, &input_bits).unwrap();
@@ -612,7 +612,7 @@ mod test {
 
             let hash_result = h.fixed_result();
 
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
 
             let mut input_bits = vec![];
 

--- a/crypto-primitives/src/prf/constraints.rs
+++ b/crypto-primitives/src/prf/constraints.rs
@@ -2,7 +2,7 @@ use algebra::Field;
 use std::fmt::Debug;
 
 use crate::prf::PRF;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use r1cs_std::prelude::*;
 
@@ -13,9 +13,9 @@ pub trait PRFGadget<P: PRF, ConstraintF: Field> {
         + Clone
         + Debug;
 
-    fn new_seed<CS: ConstraintSystem<ConstraintF>>(cs: CS, output: &P::Seed) -> Vec<UInt8>;
+    fn new_seed<CS: R1CS<ConstraintF>>(cs: CS, output: &P::Seed) -> Vec<UInt8>;
 
-    fn check_evaluation_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_evaluation_gadget<CS: R1CS<ConstraintF>>(
         cs: CS,
         seed: &[UInt8],
         input: &[UInt8],

--- a/crypto-primitives/src/signature/constraints.rs
+++ b/crypto-primitives/src/signature/constraints.rs
@@ -1,5 +1,5 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 
 use crate::signature::SignatureScheme;
@@ -12,7 +12,7 @@ pub trait SigRandomizePkGadget<S: SignatureScheme, ConstraintF: Field> {
         + AllocGadget<S::PublicKey, ConstraintF>
         + Clone;
 
-    fn check_randomization_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_randomization_gadget<CS: R1CS<ConstraintF>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
         public_key: &Self::PublicKeyGadget,

--- a/crypto-primitives/src/signature/schnorr/constraints.rs
+++ b/crypto-primitives/src/signature/schnorr/constraints.rs
@@ -1,5 +1,5 @@
 use algebra::{groups::Group, Field};
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 
 use crate::signature::SigRandomizePkGadget;
@@ -63,7 +63,7 @@ where
     type ParametersGadget = SchnorrSigGadgetParameters<G, ConstraintF, GG>;
     type PublicKeyGadget = SchnorrSigGadgetPk<G, ConstraintF, GG>;
 
-    fn check_randomization_gadget<CS: ConstraintSystem<ConstraintF>>(
+    fn check_randomization_gadget<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         parameters: &Self::ParametersGadget,
         public_key: &Self::PublicKeyGadget,
@@ -95,7 +95,7 @@ where
     GG: GroupGadget<G, ConstraintF>,
     D: Digest,
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<SchnorrSigParameters<G, D>>,
@@ -108,7 +108,7 @@ where
         })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -132,7 +132,7 @@ where
     ConstraintF: Field,
     GG: GroupGadget<G, ConstraintF>,
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<SchnorrPublicKey<G>>,
@@ -145,7 +145,7 @@ where
         })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -169,7 +169,7 @@ where
     GG: GroupGadget<G, ConstraintF>,
 {
     #[inline]
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -202,14 +202,14 @@ where
     ConstraintF: Field,
     GG: GroupGadget<G, ConstraintF>,
 {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
         self.pub_key.to_bytes(&mut cs.ns(|| "PubKey To Bytes"))
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {

--- a/dpc/src/constraints/delegable_dpc.rs
+++ b/dpc/src/constraints/delegable_dpc.rs
@@ -12,13 +12,13 @@ use crate::{
     },
 };
 use algebra::{to_bytes, ToConstraintField, FpParameters, PrimeField};
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 use r1cs_std::boolean::Boolean;
 
 use algebra::bytes::ToBytes;
 
-pub fn execute_core_checks_gadget<C: DelegableDPCComponents, CS: ConstraintSystem<C::CoreCheckF>>(
+pub fn execute_core_checks_gadget<C: DelegableDPCComponents, CS: R1CS<C::CoreCheckF>>(
     cs: &mut CS,
     // Parameters
     comm_crh_sig_parameters: &CommCRHSigPublicParameters<C>,
@@ -85,7 +85,7 @@ pub fn execute_core_checks_gadget<C: DelegableDPCComponents, CS: ConstraintSyste
 
 fn delegable_dpc_execute_gadget_helper<
     C,
-    CS: ConstraintSystem<C::CoreCheckF>,
+    CS: R1CS<C::CoreCheckF>,
     AddrC,
     RecC,
     SnNonceH,
@@ -695,7 +695,7 @@ where
     Ok(())
 }
 
-pub fn execute_proof_check_gadget<C: DelegableDPCComponents, CS: ConstraintSystem<C::ProofCheckF>>(
+pub fn execute_proof_check_gadget<C: DelegableDPCComponents, CS: R1CS<C::ProofCheckF>>(
     cs: &mut CS,
     // Parameters
     comm_crh_sig_parameters: &CommCRHSigPublicParameters<C>,

--- a/dpc/src/constraints/plain_dpc.rs
+++ b/dpc/src/constraints/plain_dpc.rs
@@ -12,13 +12,13 @@ use crate::{
     },
 };
 use algebra::{to_bytes, ToConstraintField};
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use r1cs_std::prelude::*;
 
 use algebra::bytes::ToBytes;
 use r1cs_std::boolean::Boolean;
 
-pub fn execute_core_checks_gadget<C: PlainDPCComponents, CS: ConstraintSystem<C::CoreCheckF>>(
+pub fn execute_core_checks_gadget<C: PlainDPCComponents, CS: R1CS<C::CoreCheckF>>(
     cs: &mut CS,
     // Parameters
     comm_crh_parameters: &CommAndCRHPublicParameters<C>,
@@ -85,7 +85,7 @@ pub fn execute_core_checks_gadget<C: PlainDPCComponents, CS: ConstraintSystem<C:
 
 fn execute_core_checks_gadget_helper<
     C,
-    CS: ConstraintSystem<C::CoreCheckF>,
+    CS: R1CS<C::CoreCheckF>,
     AddrC,
     RecC,
     SnNonceH,
@@ -672,7 +672,7 @@ where
     Ok(())
 }
 
-pub fn execute_proof_check_gadget<C: PlainDPCComponents, CS: ConstraintSystem<C::ProofCheckF>>(
+pub fn execute_proof_check_gadget<C: PlainDPCComponents, CS: R1CS<C::ProofCheckF>>(
     cs: &mut CS,
     // Parameters
     comm_crh_parameters: &CommAndCRHPublicParameters<C>,

--- a/dpc/src/dpc/delegable_dpc/core_checks_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/core_checks_circuit.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
 use crypto_primitives::{CommitmentScheme, FixedLengthCRH, SignatureScheme, merkle_tree::*};
 
@@ -247,7 +247,7 @@ impl<C: DelegableDPCComponents> CoreChecksCircuit<C> {
 }
 
 impl<C: DelegableDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for CoreChecksCircuit<C> {
-    fn generate_constraints<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: R1CS<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         execute_core_checks_gadget::<C, CS>(
             cs,
             // Params

--- a/dpc/src/dpc/delegable_dpc/predicate_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/predicate_circuit.rs
@@ -10,7 +10,7 @@ use std::io::{Result as IoResult, Write};
 use algebra::{bytes::ToBytes, ToConstraintField};
 
 // We'll use these interfaces to construct our circuit.
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
 use crate::Error;
 
@@ -162,7 +162,7 @@ impl<C: DelegableDPCComponents> EmptyPredicateCircuit<C> {
 }
 
 impl<C: DelegableDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for EmptyPredicateCircuit<C> {
-    fn generate_constraints<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: R1CS<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let _position = UInt8::alloc_input_vec(cs.ns(|| "Alloc position"), &[self.position])?;
 
         let _local_data_comm_pp =

--- a/dpc/src/dpc/delegable_dpc/proof_check_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/proof_check_circuit.rs
@@ -1,6 +1,6 @@
 use algebra::ToConstraintField;
 use algebra::{bytes::ToBytes, to_bytes};
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
 use crate::Error;
 use crypto_primitives::{CommitmentScheme, FixedLengthCRH};
@@ -143,7 +143,7 @@ where
     <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
     <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
 {
-    fn generate_constraints<CS: ConstraintSystem<C::ProofCheckF>>(
+    fn generate_constraints<CS: R1CS<C::ProofCheckF>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {

--- a/dpc/src/dpc/delegable_dpc/test.rs
+++ b/dpc/src/dpc/delegable_dpc/test.rs
@@ -23,11 +23,11 @@ use crate::crypto_primitives::{
 use blake2::Blake2s as Blake2sHash;
 use crate::crypto_primitives::{CommitmentScheme, FixedLengthCRH};
 
-use r1cs_core::ConstraintSystem;
+use r1cs_core::R1CS;
 
 use crate::constraints::delegable_dpc::execute_core_checks_gadget;
 use crate::constraints::delegable_dpc::execute_proof_check_gadget;
-use r1cs_std::test_constraint_system::TestConstraintSystem;
+use r1cs_std::test_constraint_system::TestR1CS;
 use crate::constraints::commitment::{
     injective_map::PedersenCommitmentCompressorGadget,
     blake2s::Blake2sCommitmentGadget,
@@ -303,7 +303,7 @@ fn core_checks_gadget() {
         local_data_rand,
     } = context;
 
-    let mut core_cs = TestConstraintSystem::<Bls12_377>::new();
+    let mut core_cs = TestR1CS::<Bls12_377>::new();
 
     execute_core_checks_gadget::<_, _>(
         &mut core_cs.ns(|| "Core checks"),
@@ -449,7 +449,7 @@ fn proof_check_gadget() {
     } = context;
 
 
-    let mut pf_check_cs = TestConstraintSystem::<SW6>::new();
+    let mut pf_check_cs = TestR1CS::<SW6>::new();
 
     execute_proof_check_gadget::<_, _>(
         &mut pf_check_cs.ns(|| "Check predicate proofs"),

--- a/dpc/src/dpc/plain_dpc/core_checks_circuit.rs
+++ b/dpc/src/dpc/plain_dpc/core_checks_circuit.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
 use crypto_primitives::{CommitmentScheme, FixedLengthCRH, PRF, merkle_tree::*};
 
@@ -242,7 +242,7 @@ impl<C: PlainDPCComponents> CoreChecksCircuit<C> {
 }
 
 impl<C: PlainDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for CoreChecksCircuit<C> {
-    fn generate_constraints<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: R1CS<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         execute_core_checks_gadget::<C, CS>(
             cs,
             // Params

--- a/dpc/src/dpc/plain_dpc/predicate_circuit.rs
+++ b/dpc/src/dpc/plain_dpc/predicate_circuit.rs
@@ -9,7 +9,7 @@ use std::io::{Result as IoResult, Write};
 
 use algebra::{bytes::ToBytes, ToConstraintField};
 
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
 use crate::Error;
 
@@ -158,7 +158,7 @@ impl<C: PlainDPCComponents> EmptyPredicateCircuit<C> {
 }
 
 impl<C: PlainDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for EmptyPredicateCircuit<C> {
-    fn generate_constraints<CS: ConstraintSystem<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: R1CS<C::CoreCheckF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let _position = UInt8::alloc_input_vec(cs.ns(|| "Alloc position"), &[self.position])?;
 
         let _local_data_comm_pp =

--- a/dpc/src/dpc/plain_dpc/proof_check_circuit.rs
+++ b/dpc/src/dpc/plain_dpc/proof_check_circuit.rs
@@ -1,6 +1,6 @@
 use algebra::{bytes::ToBytes, to_bytes, ToConstraintField};
 use crate::Error;
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
 
 use crypto_primitives::{CommitmentScheme, FixedLengthCRH};
@@ -147,7 +147,7 @@ where
     <C::LocalDataComm as CommitmentScheme>::Output: ToConstraintField<C::CoreCheckF>,
     <C::LocalDataComm as CommitmentScheme>::Parameters: ToConstraintField<C::CoreCheckF>,
 {
-    fn generate_constraints<CS: ConstraintSystem<C::ProofCheckF>>(
+    fn generate_constraints<CS: R1CS<C::ProofCheckF>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {

--- a/dpc/src/dpc/plain_dpc/test.rs
+++ b/dpc/src/dpc/plain_dpc/test.rs
@@ -11,10 +11,10 @@ use gm17::PreparedVerifyingKey;
 
 use crypto_primitives::FixedLengthCRH;
 
-use r1cs_core::ConstraintSystem;
+use r1cs_core::R1CS;
 
 use crate::constraints::plain_dpc::{execute_core_checks_gadget, execute_proof_check_gadget};
-use r1cs_std::test_constraint_system::TestConstraintSystem;
+use r1cs_std::test_constraint_system::TestR1CS;
 
 use crate::dpc::{
     plain_dpc::{predicate::PrivatePredInput, predicate_circuit::*, ExecuteContext, DPC},
@@ -134,7 +134,7 @@ fn test_execute_constraint_systems() {
 
     //////////////////////////////////////////////////////////////////////////
     // Check that the core check constraint system was satisfied.
-    let mut core_cs = TestConstraintSystem::<Fr>::new();
+    let mut core_cs = TestR1CS::<Fr>::new();
 
     execute_core_checks_gadget::<_, _>(
         &mut core_cs.ns(|| "Core checks"),
@@ -175,7 +175,7 @@ fn test_execute_constraint_systems() {
     assert!(core_cs.is_satisfied());
 
     // Check that the proof check constraint system was satisfied.
-    let mut pf_check_cs = TestConstraintSystem::<Fq>::new();
+    let mut pf_check_cs = TestR1CS::<Fq>::new();
 
     let mut old_proof_and_vk = vec![];
     for i in 0..NUM_INPUT_RECORDS {

--- a/dpc/src/predicates/plain_dpc/predicate_circuit.rs
+++ b/dpc/src/predicates/plain_dpc/predicate_circuit.rs
@@ -13,7 +13,7 @@ use algebra::PairingEngine;
 
 use r1cs_core::{
     ConstraintSynthesizer,
-    ConstraintSystem,
+    R1CS,
     SynthesisError
 };
 
@@ -59,7 +59,7 @@ impl<C: PlainDPCComponents> EmptyPredicateCircuit<C> {
 }
 
 impl<C: PlainDPCComponents> ConstraintSynthesizer<C::E> for EmptyPredicateCircuit<C> {
-    fn generate_constraints<CS: ConstraintSystem<C::E>>(
+    fn generate_constraints<CS: R1CS<C::E>>(
         self,
         cs: &mut CS
     ) -> Result<(), SynthesisError> {

--- a/gm17/examples/snark-scalability/constraints.rs
+++ b/gm17/examples/snark-scalability/constraints.rs
@@ -1,5 +1,5 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, LinearCombination, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, LinearCombination, SynthesisError};
 use std::marker::PhantomData;
 
 pub struct Benchmark<F: Field> {
@@ -17,7 +17,7 @@ impl<F: Field> Benchmark<F> {
 }
 
 impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: R1CS<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let mut assignments = Vec::new();
 
         let mut a_val = F::one();

--- a/gm17/src/generator.rs
+++ b/gm17/src/generator.rs
@@ -6,7 +6,7 @@ use algebra::{
 
 use rand::Rng;
 use rayon::prelude::*;
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use r1cs_core::{ConstraintSynthesizer, R1CS, Index, LinearCombination, SynthesisError, Variable};
 
 use crate::{Parameters, VerifyingKey, r1cs_to_sap::R1CStoSAP};
 
@@ -42,7 +42,7 @@ pub struct KeypairAssembly<E: PairingEngine> {
     pub(crate) ct:              Vec<Vec<(E::Fr, Index)>>,
 }
 
-impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
+impl<E: PairingEngine> R1CS<E::Fr> for KeypairAssembly<E> {
     type Root = Self;
 
     #[inline]

--- a/gm17/src/prover.rs
+++ b/gm17/src/prover.rs
@@ -8,7 +8,7 @@ use algebra::{
 use crate::{Parameters, Proof};
 use crate::r1cs_to_sap::R1CStoSAP;
 
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use r1cs_core::{ConstraintSynthesizer, R1CS, Index, LinearCombination, SynthesisError, Variable};
 
 use smallvec::SmallVec;
 
@@ -87,7 +87,7 @@ impl<E: PairingEngine> ProvingAssignment<E> {
     }
 }
 
-impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
+impl<E: PairingEngine> R1CS<E::Fr> for ProvingAssignment<E> {
     type Root = Self;
 
     #[inline]

--- a/gm17/src/test.rs
+++ b/gm17/src/test.rs
@@ -1,12 +1,12 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 struct MySillyCircuit<F: Field> {
     a: Option<F>,
     b: Option<F>,
 }
 
 impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<ConstraintF> {
-    fn generate_constraints<CS: ConstraintSystem<ConstraintF>>(
+    fn generate_constraints<CS: R1CS<ConstraintF>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {

--- a/gm17/tests/mimc.rs
+++ b/gm17/tests/mimc.rs
@@ -41,7 +41,7 @@ use algebra::{
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.
 
 // We'll use these interfaces to construct our circuit.
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
 const MIMC_ROUNDS: usize = 322;
 
@@ -87,7 +87,7 @@ struct MiMCDemo<'a, F: Field> {
 /// is used during paramgen and proving in order to
 /// synthesize the constraint system.
 impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: R1CS<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         assert_eq!(self.constants.len(), MIMC_ROUNDS);
 
         // Allocate the first component of the preimage.

--- a/groth16/examples/snark-scalability/constraints.rs
+++ b/groth16/examples/snark-scalability/constraints.rs
@@ -1,5 +1,5 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, LinearCombination, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, LinearCombination, SynthesisError};
 use std::marker::PhantomData;
 
 pub struct Benchmark<F: Field> {
@@ -17,7 +17,7 @@ impl<F: Field> Benchmark<F> {
 }
 
 impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(
+    fn generate_constraints<CS: R1CS<F>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {

--- a/groth16/src/generator.rs
+++ b/groth16/src/generator.rs
@@ -5,7 +5,7 @@ use algebra::{
 use ff_fft::EvaluationDomain;
 
 use r1cs_core::{
-    ConstraintSynthesizer, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable,
+    ConstraintSynthesizer, R1CS, Index, LinearCombination, SynthesisError, Variable,
 };
 use rand::Rng;
 use rayon::prelude::*;
@@ -42,7 +42,7 @@ pub struct KeypairAssembly<E: PairingEngine> {
     pub(crate) ct:              Vec<Vec<(E::Fr, Index)>>,
 }
 
-impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
+impl<E: PairingEngine> R1CS<E::Fr> for KeypairAssembly<E> {
     type Root = Self;
 
     #[inline]

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -9,7 +9,7 @@ use algebra::{
 use crate::{r1cs_to_qap::R1CStoQAP, Parameters, Proof};
 
 use r1cs_core::{
-    ConstraintSynthesizer, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable,
+    ConstraintSynthesizer, R1CS, Index, LinearCombination, SynthesisError, Variable,
 };
 
 use smallvec::SmallVec;
@@ -89,7 +89,7 @@ impl<E: PairingEngine> ProvingAssignment<E> {
     }
 }
 
-impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
+impl<E: PairingEngine> R1CS<E::Fr> for ProvingAssignment<E> {
     type Root = Self;
 
     #[inline]

--- a/groth16/src/test.rs
+++ b/groth16/src/test.rs
@@ -1,12 +1,12 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 struct MySillyCircuit<F: Field> {
     a: Option<F>,
     b: Option<F>,
 }
 
 impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<ConstraintF> {
-    fn generate_constraints<CS: ConstraintSystem<ConstraintF>>(
+    fn generate_constraints<CS: R1CS<ConstraintF>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {

--- a/groth16/tests/mimc.rs
+++ b/groth16/tests/mimc.rs
@@ -37,7 +37,7 @@ use algebra::{curves::bls12_381::Bls12_381, fields::bls12_381::fr::Fr, Field};
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.
 
 // We'll use these interfaces to construct our circuit.
-use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use r1cs_core::{ConstraintSynthesizer, R1CS, SynthesisError};
 
 const MIMC_ROUNDS: usize = 322;
 
@@ -83,7 +83,7 @@ struct MiMCDemo<'a, F: Field> {
 /// is used during paramgen and proving in order to
 /// synthesize the constraint system.
 impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(
+    fn generate_constraints<CS: R1CS<F>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {

--- a/r1cs-core/src/lib.rs
+++ b/r1cs-core/src/lib.rs
@@ -14,7 +14,7 @@ mod error;
 mod impl_lc;
 mod impl_constraint_var;
 
-pub use constraint_system::{ConstraintSystem, ConstraintSynthesizer, Namespace};
+pub use constraint_system::{R1CS, ConstraintSynthesizer, Namespace};
 pub use error::SynthesisError;
 pub use algebra::ToConstraintField;
 

--- a/r1cs-std/src/alloc.rs
+++ b/r1cs-std/src/alloc.rs
@@ -1,5 +1,5 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use std::borrow::Borrow;
 
 pub trait AllocGadget<V, ConstraintF: Field>
@@ -7,12 +7,12 @@ where
     Self: Sized,
     V: ?Sized,
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(cs: CS, f: F) -> Result<Self, SynthesisError>
     where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<V>;
 
-    fn alloc_checked<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_checked<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -23,7 +23,7 @@ where
         Self::alloc(cs, f)
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -31,7 +31,7 @@ where
         F: FnOnce() -> Result<T, SynthesisError>,
         T: Borrow<V>;
 
-    fn alloc_input_checked<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input_checked<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -46,7 +46,7 @@ where
 impl<I, ConstraintF: Field, A: AllocGadget<I, ConstraintF>> AllocGadget<[I], ConstraintF>
     for Vec<A>
 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -63,7 +63,7 @@ impl<I, ConstraintF: Field, A: AllocGadget<I, ConstraintF>> AllocGadget<[I], Con
         Ok(vec)
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -81,7 +81,7 @@ impl<I, ConstraintF: Field, A: AllocGadget<I, ConstraintF>> AllocGadget<[I], Con
         Ok(vec)
     }
 
-    fn alloc_checked<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_checked<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>
@@ -99,7 +99,7 @@ impl<I, ConstraintF: Field, A: AllocGadget<I, ConstraintF>> AllocGadget<[I], Con
         Ok(vec)
     }
 
-    fn alloc_input_checked<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input_checked<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         f: F,
     ) -> Result<Self, SynthesisError>

--- a/r1cs-std/src/bits/boolean.rs
+++ b/r1cs-std/src/bits/boolean.rs
@@ -1,7 +1,7 @@
 use algebra::{BitIterator, Field, FpParameters, PrimeField};
 
 use crate::{prelude::*, Assignment};
-use r1cs_core::{ConstraintSystem, LinearCombination, SynthesisError, Variable, ConstraintVar};
+use r1cs_core::{R1CS, LinearCombination, SynthesisError, Variable, ConstraintVar};
 use std::borrow::Borrow;
 
 /// Represents a variable in the constraint system which is guaranteed
@@ -26,7 +26,7 @@ impl AllocatedBit {
     pub fn xor<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -78,7 +78,7 @@ impl AllocatedBit {
     pub fn and<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -117,7 +117,7 @@ impl AllocatedBit {
     pub fn or<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -153,7 +153,7 @@ impl AllocatedBit {
     pub fn and_not<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -191,7 +191,7 @@ impl AllocatedBit {
     pub fn nor<ConstraintF, CS>(mut cs: CS, a: &Self, b: &Self) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let mut result_value = None;
 
@@ -235,7 +235,7 @@ impl PartialEq for AllocatedBit {
 impl Eq for AllocatedBit {}
 
 impl<ConstraintF: Field> AllocGadget<bool, ConstraintF> for AllocatedBit {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -271,7 +271,7 @@ impl<ConstraintF: Field> AllocGadget<bool, ConstraintF> for AllocatedBit {
         })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -309,7 +309,7 @@ impl<ConstraintF: Field> AllocGadget<bool, ConstraintF> for AllocatedBit {
 }
 
 impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for AllocatedBit {
-    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_select<CS: R1CS<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -328,7 +328,7 @@ impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for AllocatedBit {
     }
 }
 
-fn cond_select_helper<F: Field, CS: ConstraintSystem<F>>(
+fn cond_select_helper<F: Field, CS: R1CS<F>>(
     mut cs: CS,
     cond: &Boolean,
     first: (Option<bool>, impl Into<ConstraintVar<F>>),
@@ -404,7 +404,7 @@ impl Boolean {
     }
 
     /// Construct a boolean vector from a vector of u8
-    pub fn constant_u8_vec<ConstraintF: Field, CS: ConstraintSystem<ConstraintF>>(
+    pub fn constant_u8_vec<ConstraintF: Field, CS: R1CS<ConstraintF>>(
         cs: &mut CS,
         values: &[u8],
     ) -> Vec<Self> {
@@ -444,7 +444,7 @@ impl Boolean {
     ) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         match (a, b) {
             (&Boolean::Constant(false), x) | (x, &Boolean::Constant(false)) => Ok(*x),
@@ -466,7 +466,7 @@ impl Boolean {
     pub fn or<'a, ConstraintF, CS>(cs: CS, a: &'a Self, b: &'a Self) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         match (a, b) {
             (&Boolean::Constant(false), x) | (x, &Boolean::Constant(false)) => Ok(*x),
@@ -493,7 +493,7 @@ impl Boolean {
     ) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         match (a, b) {
             // false AND x is always false
@@ -521,7 +521,7 @@ impl Boolean {
     pub fn kary_and<ConstraintF, CS>(mut cs: CS, bits: &[Self]) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         assert!(!bits.is_empty());
         let mut bits = bits.iter();
@@ -538,7 +538,7 @@ impl Boolean {
     pub fn enforce_nand<ConstraintF, CS>(mut cs: CS, bits: &[Self]) -> Result<(), SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let res = Self::kary_and(&mut cs, bits)?;
 
@@ -576,7 +576,7 @@ impl Boolean {
     ) -> Result<(), SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let mut bits_iter = bits.iter();
 
@@ -678,7 +678,7 @@ impl From<AllocatedBit> for Boolean {
 }
 
 impl<ConstraintF: Field> AllocGadget<bool, ConstraintF> for Boolean {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -689,7 +689,7 @@ impl<ConstraintF: Field> AllocGadget<bool, ConstraintF> for Boolean {
         AllocatedBit::alloc(cs, value_gen).map(Boolean::from)
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -711,7 +711,7 @@ impl<ConstraintF: Field> ConditionalEqGadget<ConstraintF> for Boolean {
         condition: &Boolean,
     ) -> Result<(), SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         use self::Boolean::*;
         let one = CS::one();
@@ -765,7 +765,7 @@ impl<ConstraintF: Field> ConditionalEqGadget<ConstraintF> for Boolean {
 }
 
 impl<ConstraintF: Field> ToBytesGadget<ConstraintF> for Boolean {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -778,7 +778,7 @@ impl<ConstraintF: Field> ToBytesGadget<ConstraintF> for Boolean {
     }
 
     /// Additionally checks if the produced list of booleans is 'valid'.
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -793,7 +793,7 @@ impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for Boolean {
         second: &Self,
     ) -> Result<Self, SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         match cond {
             Boolean::Constant(true) => Ok(first.clone()),
@@ -837,9 +837,9 @@ impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for Boolean {
 #[cfg(test)]
 mod test {
     use super::{AllocatedBit, Boolean};
-    use crate::{prelude::*, test_constraint_system::TestConstraintSystem};
+    use crate::{prelude::*, test_constraint_system::TestR1CS};
     use algebra::{fields::bls12_381::Fr, BitIterator, Field, PrimeField, UniformRand};
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use std::str::FromStr;
@@ -847,7 +847,7 @@ mod test {
     #[test]
     fn test_boolean_to_byte() {
         for val in [true, false].iter() {
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
             let a: Boolean = AllocatedBit::alloc(&mut cs, || Ok(*val)).unwrap().into();
             let bytes = a.to_bytes(&mut cs.ns(|| "ToBytes")).unwrap();
             assert_eq!(bytes.len(), 1);
@@ -865,7 +865,7 @@ mod test {
 
     #[test]
     fn test_allocated_bit() {
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
 
         AllocatedBit::alloc(&mut cs, || Ok(true)).unwrap();
         assert!(cs.get("boolean") == Fr::one());
@@ -881,7 +881,7 @@ mod test {
     fn test_xor() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::xor(&mut cs, &a, &b).unwrap();
@@ -896,7 +896,7 @@ mod test {
     fn test_or() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::or(&mut cs, &a, &b).unwrap();
@@ -913,7 +913,7 @@ mod test {
     fn test_and() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::and(&mut cs, &a, &b).unwrap();
@@ -949,7 +949,7 @@ mod test {
     fn test_and_not() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::and_not(&mut cs, &a, &b).unwrap();
@@ -985,7 +985,7 @@ mod test {
     fn test_nor() {
         for a_val in [false, true].iter() {
             for b_val in [false, true].iter() {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
                 let a = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(*a_val)).unwrap();
                 let b = AllocatedBit::alloc(cs.ns(|| "b"), || Ok(*b_val)).unwrap();
                 let c = AllocatedBit::nor(&mut cs, &a, &b).unwrap();
@@ -1023,7 +1023,7 @@ mod test {
             for b_bool in [false, true].iter().cloned() {
                 for a_neg in [false, true].iter().cloned() {
                     for b_neg in [false, true].iter().cloned() {
-                        let mut cs = TestConstraintSystem::<Fr>::new();
+                        let mut cs = TestR1CS::<Fr>::new();
 
                         let mut a: Boolean = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(a_bool))
                             .unwrap()
@@ -1054,7 +1054,7 @@ mod test {
             for b_bool in [false, true].iter().cloned() {
                 for a_neg in [false, true].iter().cloned() {
                     for b_neg in [false, true].iter().cloned() {
-                        let mut cs = TestConstraintSystem::<Fr>::new();
+                        let mut cs = TestR1CS::<Fr>::new();
 
                         // First test if constraint system is satisfied
                         // when we do want to enforce the condition.
@@ -1079,7 +1079,7 @@ mod test {
 
                         // Now test if constraint system is satisfied even
                         // when we don't want to enforce the condition.
-                        let mut cs = TestConstraintSystem::<Fr>::new();
+                        let mut cs = TestR1CS::<Fr>::new();
 
                         let mut a: Boolean = AllocatedBit::alloc(cs.ns(|| "a"), || Ok(a_bool))
                             .unwrap()
@@ -1110,7 +1110,7 @@ mod test {
 
     #[test]
     fn test_boolean_negation() {
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
 
         let mut b = Boolean::from(AllocatedBit::alloc(&mut cs, || Ok(true)).unwrap());
 
@@ -1178,7 +1178,7 @@ mod test {
 
         for first_operand in variants.iter().cloned() {
             for second_operand in variants.iter().cloned() {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
 
                 let a;
                 let b;
@@ -1388,7 +1388,7 @@ mod test {
         for condition in variants.iter().cloned() {
             for first_operand in variants.iter().cloned() {
                 for second_operand in variants.iter().cloned() {
-                    let mut cs = TestConstraintSystem::<Fr>::new();
+                    let mut cs = TestR1CS::<Fr>::new();
 
                     let cond;
                     let a;
@@ -1452,7 +1452,7 @@ mod test {
 
         for first_operand in variants.iter().cloned() {
             for second_operand in variants.iter().cloned() {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
 
                 let a;
                 let b;
@@ -1664,7 +1664,7 @@ mod test {
 
         for first_operand in variants.iter().cloned() {
             for second_operand in variants.iter().cloned() {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
 
                 let a;
                 let b;
@@ -1888,7 +1888,7 @@ mod test {
     #[test]
     fn test_enforce_in_field() {
         {
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
 
             let mut bits = vec![];
             for (i, b) in BitIterator::new(Fr::characteristic()).skip(1).enumerate() {
@@ -1906,7 +1906,7 @@ mod test {
 
         for _ in 0..1000 {
             let r = Fr::rand(&mut rng);
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
 
             let mut bits = vec![];
             for (i, b) in BitIterator::new(r.into_repr()).skip(1).enumerate() {
@@ -1934,7 +1934,7 @@ mod test {
         //         }
         //     };
 
-        //     let mut cs = TestConstraintSystem::<Fr>::new();
+        //     let mut cs = TestR1CS::<Fr>::new();
 
         //     let mut bits = vec![];
         //     for (i, b) in BitIterator::new(r).skip(1).enumerate() {
@@ -1953,7 +1953,7 @@ mod test {
     #[test]
     fn test_enforce_nand() {
         {
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
 
             assert!(Boolean::enforce_nand(&mut cs, &[Boolean::constant(false)]).is_ok());
             assert!(Boolean::enforce_nand(&mut cs, &[Boolean::constant(true)]).is_err());
@@ -1964,7 +1964,7 @@ mod test {
             for mut b in 0..(1 << i) {
                 // with every possible negation
                 for mut n in 0..(1 << i) {
-                    let mut cs = TestConstraintSystem::<Fr>::new();
+                    let mut cs = TestR1CS::<Fr>::new();
 
                     let mut expected = true;
 
@@ -2016,7 +2016,7 @@ mod test {
         for i in 1..15 {
             // with every possible assignment for them
             for mut b in 0..(1 << i) {
-                let mut cs = TestConstraintSystem::<Fr>::new();
+                let mut cs = TestR1CS::<Fr>::new();
 
                 let mut expected = true;
 

--- a/r1cs-std/src/bits/mod.rs
+++ b/r1cs-std/src/bits/mod.rs
@@ -1,33 +1,33 @@
 use crate::bits::{boolean::Boolean, uint8::UInt8};
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 pub mod boolean;
 pub mod uint32;
 pub mod uint8;
 
 pub trait ToBitsGadget<ConstraintF: Field> {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError>;
 
     /// Additionally checks if the produced list of booleans is 'valid'.
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError>;
 }
 
 impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for Boolean {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
         Ok(vec![self.clone()])
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -36,14 +36,14 @@ impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for Boolean {
 }
 
 impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for [Boolean] {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
         Ok(self.to_vec())
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -51,14 +51,14 @@ impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for [Boolean] {
     }
 }
 impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for Vec<Boolean> {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
         Ok(self.clone())
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -67,7 +67,7 @@ impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for Vec<Boolean> {
 }
 
 impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for [UInt8] {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -78,7 +78,7 @@ impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for [UInt8] {
         Ok(result)
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -87,27 +87,27 @@ impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for [UInt8] {
 }
 
 pub trait ToBytesGadget<ConstraintF: Field> {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError>;
 
     /// Additionally checks if the produced list of booleans is 'valid'.
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError>;
 }
 
 impl<ConstraintF: Field> ToBytesGadget<ConstraintF> for [UInt8] {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
         Ok(self.to_vec())
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -118,14 +118,14 @@ impl<ConstraintF: Field> ToBytesGadget<ConstraintF> for [UInt8] {
 impl<'a, ConstraintF: Field, T: 'a + ToBytesGadget<ConstraintF>> ToBytesGadget<ConstraintF>
     for &'a T
 {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
         (*self).to_bytes(cs)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -134,14 +134,14 @@ impl<'a, ConstraintF: Field, T: 'a + ToBytesGadget<ConstraintF>> ToBytesGadget<C
 }
 
 impl<'a, ConstraintF: Field> ToBytesGadget<ConstraintF> for &'a [UInt8] {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
         Ok(self.to_vec())
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {

--- a/r1cs-std/src/bits/uint32.rs
+++ b/r1cs-std/src/bits/uint32.rs
@@ -1,6 +1,6 @@
 use algebra::{Field, FpParameters, PrimeField};
 
-use r1cs_core::{ConstraintSystem, LinearCombination, SynthesisError};
+use r1cs_core::{R1CS, LinearCombination, SynthesisError};
 
 use crate::{
     boolean::{AllocatedBit, Boolean},
@@ -43,7 +43,7 @@ impl UInt32 {
     pub fn alloc<ConstraintF, CS>(mut cs: CS, value: Option<u32>) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let values = match value {
             Some(mut val) => {
@@ -137,7 +137,7 @@ impl UInt32 {
     pub fn xor<ConstraintF, CS>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let new_value = match (self.value, other.value) {
             (Some(a), Some(b)) => Some(a ^ b),
@@ -162,7 +162,7 @@ impl UInt32 {
     pub fn addmany<ConstraintF, CS>(mut cs: CS, operands: &[Self]) -> Result<Self, SynthesisError>
     where
         ConstraintF: PrimeField,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         // Make some arbitrary bounds for ourselves to avoid overflows
         // in the scalar field
@@ -272,7 +272,7 @@ impl UInt32 {
 
 impl<ConstraintF: Field> ToBytesGadget<ConstraintF> for UInt32 {
     #[inline]
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         _cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -302,7 +302,7 @@ impl<ConstraintF: Field> ToBytesGadget<ConstraintF> for UInt32 {
         Ok(bytes)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -319,7 +319,7 @@ impl PartialEq for UInt32 {
 impl Eq for UInt32 {}
 
 impl<ConstraintF: Field> ConditionalEqGadget<ConstraintF> for UInt32 {
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -343,9 +343,9 @@ impl<ConstraintF: Field> ConditionalEqGadget<ConstraintF> for UInt32 {
 #[cfg(test)]
 mod test {
     use super::UInt32;
-    use crate::{bits::boolean::Boolean, test_constraint_system::TestConstraintSystem};
+    use crate::{bits::boolean::Boolean, test_constraint_system::TestR1CS};
     use algebra::fields::{bls12_381::Fr, Field};
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
@@ -386,7 +386,7 @@ mod test {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
         for _ in 0..1000 {
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
 
             let a: u32 = rng.gen();
             let b: u32 = rng.gen();
@@ -428,7 +428,7 @@ mod test {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
         for _ in 0..1000 {
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
 
             let a: u32 = rng.gen();
             let b: u32 = rng.gen();
@@ -463,7 +463,7 @@ mod test {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
         for _ in 0..1000 {
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
 
             let a: u32 = rng.gen();
             let b: u32 = rng.gen();

--- a/r1cs-std/src/bits/uint8.rs
+++ b/r1cs-std/src/bits/uint8.rs
@@ -1,6 +1,6 @@
 use algebra::{Field, FpParameters, PrimeField, ToConstraintField};
 
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use crate::{boolean::AllocatedBit, fields::fp::FpGadget, prelude::*, Assignment};
 use std::borrow::Borrow;
@@ -56,7 +56,7 @@ impl UInt8 {
     ) -> Result<Vec<Self>, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
         T: Into<Option<u8>> + Copy,
     {
         let mut output_vec = Vec::with_capacity(values.len());
@@ -78,7 +78,7 @@ impl UInt8 {
     ) -> Result<Vec<Self>, SynthesisError>
     where
         ConstraintF: PrimeField,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let values_len = values.len();
         let field_elements: Vec<ConstraintF> =
@@ -159,7 +159,7 @@ impl UInt8 {
     pub fn xor<ConstraintF, CS>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError>
     where
         ConstraintF: Field,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     {
         let new_value = match (self.value, other.value) {
             (Some(a), Some(b)) => Some(a ^ b),
@@ -190,7 +190,7 @@ impl PartialEq for UInt8 {
 impl Eq for UInt8 {}
 
 impl<ConstraintF: Field> ConditionalEqGadget<ConstraintF> for UInt8 {
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -214,7 +214,7 @@ impl<ConstraintF: Field> ConditionalEqGadget<ConstraintF> for UInt8 {
 impl<ConstraintF: Field> EqGadget<ConstraintF> for UInt8 {}
 
 impl<ConstraintF: Field> AllocGadget<u8, ConstraintF> for UInt8 {
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -254,7 +254,7 @@ impl<ConstraintF: Field> AllocGadget<u8, ConstraintF> for UInt8 {
         })
     }
 
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -297,15 +297,15 @@ impl<ConstraintF: Field> AllocGadget<u8, ConstraintF> for UInt8 {
 #[cfg(test)]
 mod test {
     use super::UInt8;
-    use crate::{prelude::*, test_constraint_system::TestConstraintSystem};
+    use crate::{prelude::*, test_constraint_system::TestR1CS};
     use algebra::fields::bls12_381::Fr;
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
     #[test]
     fn test_uint8_from_bits_to_bits() {
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
         let byte_val = 0b01110001;
         let byte = UInt8::alloc(cs.ns(|| "alloc value"), || Ok(byte_val)).unwrap();
         let bits = byte.into_bits_le();
@@ -316,7 +316,7 @@ mod test {
 
     #[test]
     fn test_uint8_alloc_input_vec() {
-        let mut cs = TestConstraintSystem::<Fr>::new();
+        let mut cs = TestR1CS::<Fr>::new();
         let byte_vals = (64u8..128u8).collect::<Vec<_>>();
         let bytes = UInt8::alloc_input_vec(cs.ns(|| "alloc value"), &byte_vals).unwrap();
         for (native_byte, gadget_byte) in byte_vals.into_iter().zip(bytes) {
@@ -364,7 +364,7 @@ mod test {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
         for _ in 0..1000 {
-            let mut cs = TestConstraintSystem::<Fr>::new();
+            let mut cs = TestR1CS::<Fr>::new();
 
             let a: u8 = rng.gen();
             let b: u8 = rng.gen();

--- a/r1cs-std/src/eq.rs
+++ b/r1cs-std/src/eq.rs
@@ -1,11 +1,11 @@
 use crate::prelude::*;
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 /// If `condition == 1`, then enforces that `self` and `other` are equal;
 /// otherwise, it doesn't enforce anything.
 pub trait ConditionalEqGadget<ConstraintF: Field>: Eq {
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         other: &Self,
@@ -17,7 +17,7 @@ pub trait ConditionalEqGadget<ConstraintF: Field>: Eq {
 impl<T: ConditionalEqGadget<ConstraintF>, ConstraintF: Field> ConditionalEqGadget<ConstraintF>
     for [T]
 {
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -39,7 +39,7 @@ pub trait EqGadget<ConstraintF: Field>: Eq
 where
     Self: ConditionalEqGadget<ConstraintF>,
 {
-    fn enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         other: &Self,
@@ -55,7 +55,7 @@ where
 impl<T: EqGadget<ConstraintF>, ConstraintF: Field> EqGadget<ConstraintF> for [T] {}
 
 pub trait NEqGadget<ConstraintF: Field>: Eq {
-    fn enforce_not_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_not_equal<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         other: &Self,
@@ -68,7 +68,7 @@ pub trait OrEqualsGadget<ConstraintF: Field>
 where
     Self: Sized,
 {
-    fn enforce_equal_or<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_equal_or<CS: R1CS<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         var: &Self,
@@ -82,7 +82,7 @@ where
 impl<ConstraintF: Field, T: Sized + ConditionalOrEqualsGadget<ConstraintF>>
     OrEqualsGadget<ConstraintF> for T
 {
-    fn enforce_equal_or<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_equal_or<CS: R1CS<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         var: &Self,
@@ -101,7 +101,7 @@ pub trait ConditionalOrEqualsGadget<ConstraintF: Field>
 where
     Self: Sized,
 {
-    fn conditional_enforce_equal_or<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal_or<CS: R1CS<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         var: &Self,
@@ -118,7 +118,7 @@ impl<
         T: Sized + ConditionalEqGadget<ConstraintF> + CondSelectGadget<ConstraintF>,
     > ConditionalOrEqualsGadget<ConstraintF> for T
 {
-    fn conditional_enforce_equal_or<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal_or<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
         var: &Self,

--- a/r1cs-std/src/fields/fp12.rs
+++ b/r1cs-std/src/fields/fp12.rs
@@ -1,4 +1,4 @@
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use algebra::{
     fields::{
@@ -53,7 +53,7 @@ where
 
     /// Multiply by quadratic nonresidue v.
     #[inline]
-    pub(crate) fn mul_fp6_by_nonresidue<CS: ConstraintSystem<ConstraintF>>(
+    pub(crate) fn mul_fp6_by_nonresidue<CS: R1CS<ConstraintF>>(
         cs: CS,
         fe: &Fp6Gadget<P, ConstraintF>,
     ) -> Result<Fp6Gadget<P, ConstraintF>, SynthesisError> {
@@ -64,7 +64,7 @@ where
     }
 
     #[inline]
-    pub fn conjugate_in_place<CS: ConstraintSystem<ConstraintF>>(
+    pub fn conjugate_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -74,7 +74,7 @@ where
 
     /// Multiplies by an element of the form (c0 = (c0, c1, 0), c1 = (0, d1, 0))
     #[inline]
-    pub fn mul_by_014<CS: ConstraintSystem<ConstraintF>>(
+    pub fn mul_by_014<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         c0: &Fp2Gadget<P, ConstraintF>,
@@ -99,7 +99,7 @@ where
 
     /// Multiplies by an element of the form (c0 = (c0, 0, 0), c1 = (d0, d1, 0))
     #[inline]
-    pub fn mul_by_034<CS: ConstraintSystem<ConstraintF>>(
+    pub fn mul_by_034<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         c0: &Fp2Gadget<P, ConstraintF>,
@@ -125,7 +125,7 @@ where
         Ok(Self::new(c0, c1))
     }
 
-    pub fn cyclotomic_square<CS: ConstraintSystem<ConstraintF>>(
+    pub fn cyclotomic_square<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -249,7 +249,7 @@ where
     }
 
     #[inline]
-    pub fn cyclotomic_exp<CS: ConstraintSystem<ConstraintF>, S: AsRef<[u64]>>(
+    pub fn cyclotomic_exp<CS: R1CS<ConstraintF>, S: AsRef<[u64]>>(
         &self,
         mut cs: CS,
         exp: S,
@@ -291,21 +291,21 @@ where
     }
 
     #[inline]
-    fn zero<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+    fn zero<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
         let c0 = Fp6Gadget::<P, ConstraintF>::zero(cs.ns(|| "c0"))?;
         let c1 = Fp6Gadget::<P, ConstraintF>::zero(cs.ns(|| "c1"))?;
         Ok(Self::new(c0, c1))
     }
 
     #[inline]
-    fn one<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+    fn one<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
         let c0 = Fp6Gadget::<P, ConstraintF>::one(cs.ns(|| "c0"))?;
         let c1 = Fp6Gadget::<P, ConstraintF>::zero(cs.ns(|| "c1"))?;
         Ok(Self::new(c0, c1))
     }
 
     #[inline]
-    fn conditionally_add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_add_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         bit: &Boolean,
@@ -321,7 +321,7 @@ where
     }
 
     #[inline]
-    fn add<CS: ConstraintSystem<ConstraintF>>(
+    fn add<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -332,7 +332,7 @@ where
     }
 
     #[inline]
-    fn add_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn add_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
         other: &Self,
@@ -343,7 +343,7 @@ where
     }
 
     #[inline]
-    fn sub<CS: ConstraintSystem<ConstraintF>>(
+    fn sub<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -354,7 +354,7 @@ where
     }
 
     #[inline]
-    fn sub_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn sub_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
         other: &Self,
@@ -365,7 +365,7 @@ where
     }
 
     #[inline]
-    fn negate<CS: ConstraintSystem<ConstraintF>>(
+    fn negate<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -375,7 +375,7 @@ where
     }
 
     #[inline]
-    fn negate_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn negate_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -385,7 +385,7 @@ where
     }
 
     #[inline]
-    fn mul<CS: ConstraintSystem<ConstraintF>>(
+    fn mul<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -421,7 +421,7 @@ where
         Ok(Self::new(c0, c1))
     }
 
-    fn square<CS: ConstraintSystem<ConstraintF>>(
+    fn square<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -466,7 +466,7 @@ where
     }
 
     #[inline]
-    fn add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Fp12<P>,
@@ -478,7 +478,7 @@ where
     }
 
     #[inline]
-    fn add_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
         other: &Fp12<P>,
@@ -488,7 +488,7 @@ where
         Ok(self)
     }
 
-    fn mul_by_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_by_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Fp12<P>,
@@ -514,7 +514,7 @@ where
         Ok(Self::new(c0, c1))
     }
 
-    fn frobenius_map<CS: ConstraintSystem<ConstraintF>>(
+    fn frobenius_map<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         power: usize,
@@ -524,7 +524,7 @@ where
         Ok(res)
     }
 
-    fn frobenius_map_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn frobenius_map_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
         power: usize,
@@ -546,7 +546,7 @@ where
         Ok(self)
     }
 
-    fn inverse<CS: ConstraintSystem<ConstraintF>>(
+    fn inverse<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -587,7 +587,7 @@ where
         Ok(inverse)
     }
 
-    fn mul_equals<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_equals<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -677,7 +677,7 @@ where
     <P::Fp6Params as Fp6Parameters>::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     #[inline]
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -701,7 +701,7 @@ where
     <P::Fp6Params as Fp6Parameters>::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     #[inline]
-    fn enforce_not_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_not_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -721,7 +721,7 @@ where
     P: Fp12Parameters,
     <P::Fp6Params as Fp6Parameters>::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -731,7 +731,7 @@ where
         Ok(c0)
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -747,7 +747,7 @@ where
     P: Fp12Parameters,
     <P::Fp6Params as Fp6Parameters>::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -757,7 +757,7 @@ where
         Ok(c0)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -784,7 +784,7 @@ where
     <P::Fp6Params as Fp6Parameters>::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     #[inline]
-    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_select<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -817,7 +817,7 @@ where
     <P::Fp6Params as Fp6Parameters>::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     type TableConstant = Fp12<P>;
-    fn two_bit_lookup<CS: ConstraintSystem<ConstraintF>>(
+    fn two_bit_lookup<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         b: &[Boolean],
         c: &[Self::TableConstant],
@@ -842,7 +842,7 @@ where
 {
     type TableConstant = Fp12<P>;
 
-    fn three_bit_cond_neg_lookup<CS: ConstraintSystem<ConstraintF>>(
+    fn three_bit_cond_neg_lookup<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         b: &[Boolean],
         b0b1: &Boolean,
@@ -876,7 +876,7 @@ where
     <P::Fp6Params as Fp6Parameters>::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     #[inline]
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -901,7 +901,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>

--- a/r1cs-std/src/fields/fp2.rs
+++ b/r1cs-std/src/fields/fp2.rs
@@ -2,7 +2,7 @@ use algebra::{
     fields::{Fp2, Fp2Parameters},
     Field, PrimeField,
 };
-use r1cs_core::{ConstraintSystem, ConstraintVar, SynthesisError};
+use r1cs_core::{R1CS, ConstraintVar, SynthesisError};
 use std::{borrow::Borrow, marker::PhantomData};
 
 use crate::{fields::fp::FpGadget, prelude::*, Assignment};
@@ -28,7 +28,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> Fp2Gadget<P, C
 
     /// Multiply a FpGadget by quadratic nonresidue P::NONRESIDUE.
     #[inline]
-    pub fn mul_fp_gadget_by_nonresidue<CS: ConstraintSystem<ConstraintF>>(
+    pub fn mul_fp_gadget_by_nonresidue<CS: R1CS<ConstraintF>>(
         cs: CS,
         fe: &FpGadget<ConstraintF>,
     ) -> Result<FpGadget<ConstraintF>, SynthesisError> {
@@ -37,7 +37,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> Fp2Gadget<P, C
 
     /// Multiply a Fp2Gadget by an element of fp.
     #[inline]
-    pub fn mul_by_fp_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
+    pub fn mul_by_fp_constant_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
         fe: &P::Fp,
@@ -49,7 +49,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> Fp2Gadget<P, C
 
     /// Multiply a Fp2Gadget by an element of fp.
     #[inline]
-    pub fn mul_by_fp_constant<CS: ConstraintSystem<ConstraintF>>(
+    pub fn mul_by_fp_constant<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         fe: &P::Fp,
@@ -82,21 +82,21 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn zero<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+    fn zero<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
         let c0 = FpGadget::zero(cs.ns(|| "c0"))?;
         let c1 = FpGadget::zero(cs.ns(|| "c1"))?;
         Ok(Self::new(c0, c1))
     }
 
     #[inline]
-    fn one<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+    fn one<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
         let c0 = FpGadget::one(cs.ns(|| "c0"))?;
         let c1 = FpGadget::zero(cs.ns(|| "c1"))?;
         Ok(Self::new(c0, c1))
     }
 
     #[inline]
-    fn conditionally_add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_add_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         bit: &Boolean,
@@ -112,7 +112,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn add<CS: ConstraintSystem<ConstraintF>>(
+    fn add<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -123,7 +123,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn sub<CS: ConstraintSystem<ConstraintF>>(
+    fn sub<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -134,14 +134,14 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn double<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
+    fn double<CS: R1CS<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
         let mut result = self.clone();
         result.double_in_place(cs)?;
         Ok(result)
     }
 
     #[inline]
-    fn double_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn double_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -151,14 +151,14 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn negate<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
+    fn negate<CS: R1CS<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
         let mut result = self.clone();
         result.negate_in_place(cs)?;
         Ok(result)
     }
 
     #[inline]
-    fn negate_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn negate_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -168,7 +168,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn mul<CS: ConstraintSystem<ConstraintF>>(
+    fn mul<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -207,7 +207,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn square<CS: ConstraintSystem<ConstraintF>>(
+    fn square<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -251,7 +251,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn square_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn square_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -293,7 +293,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn inverse<CS: ConstraintSystem<ConstraintF>>(
+    fn inverse<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -333,7 +333,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
         Ok(inverse)
     }
 
-    fn mul_equals<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_equals<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -385,7 +385,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
         Ok(())
     }
 
-    fn frobenius_map<CS: ConstraintSystem<ConstraintF>>(
+    fn frobenius_map<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         power: usize,
@@ -395,7 +395,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
         Ok(result)
     }
 
-    fn frobenius_map_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn frobenius_map_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
         power: usize,
@@ -406,7 +406,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         other: &Fp2<P>,
@@ -417,7 +417,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
     }
 
     #[inline]
-    fn add_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
         other: &Fp2<P>,
@@ -427,7 +427,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> FieldGadget<Fp
         Ok(self)
     }
 
-    fn mul_by_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_by_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         fe: &Fp2<P>,
@@ -480,7 +480,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> ConditionalEqG
     for Fp2Gadget<P, ConstraintF>
 {
     #[inline]
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -502,7 +502,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> NEqGadget<Cons
     for Fp2Gadget<P, ConstraintF>
 {
     #[inline]
-    fn enforce_not_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_not_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -520,7 +520,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> NEqGadget<Cons
 impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> ToBitsGadget<ConstraintF>
     for Fp2Gadget<P, ConstraintF>
 {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -530,7 +530,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> ToBitsGadget<C
         Ok(c0)
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -544,7 +544,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> ToBitsGadget<C
 impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> ToBytesGadget<ConstraintF>
     for Fp2Gadget<P, ConstraintF>
 {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -554,7 +554,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> ToBytesGadget<
         Ok(c0)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -581,7 +581,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> CondSelectGadg
     for Fp2Gadget<P, ConstraintF>
 {
     #[inline]
-    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_select<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -612,7 +612,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> TwoBitLookupGa
     for Fp2Gadget<P, ConstraintF>
 {
     type TableConstant = Fp2<P>;
-    fn two_bit_lookup<CS: ConstraintSystem<ConstraintF>>(
+    fn two_bit_lookup<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         b: &[Boolean],
         c: &[Self::TableConstant],
@@ -634,7 +634,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField>
 {
     type TableConstant = Fp2<P>;
 
-    fn three_bit_cond_neg_lookup<CS: ConstraintSystem<ConstraintF>>(
+    fn three_bit_cond_neg_lookup<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         b: &[Boolean],
         b0b1: &Boolean,
@@ -656,7 +656,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> AllocGadget<Fp
     for Fp2Gadget<P, ConstraintF>
 {
     #[inline]
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -681,7 +681,7 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> AllocGadget<Fp
     }
 
     #[inline]
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>

--- a/r1cs-std/src/fields/fp6_3over2.rs
+++ b/r1cs-std/src/fields/fp6_3over2.rs
@@ -5,7 +5,7 @@ use algebra::{
     },
     PrimeField,
 };
-use r1cs_core::{ConstraintSystem, ConstraintVar, SynthesisError};
+use r1cs_core::{R1CS, ConstraintVar, SynthesisError};
 use std::{borrow::Borrow, marker::PhantomData};
 
 use crate::{prelude::*, Assignment};
@@ -48,7 +48,7 @@ where
     }
     /// Multiply a Fp2Gadget by cubic nonresidue P::NONRESIDUE.
     #[inline]
-    pub fn mul_fp2_gadget_by_nonresidue<CS: ConstraintSystem<ConstraintF>>(
+    pub fn mul_fp2_gadget_by_nonresidue<CS: R1CS<ConstraintF>>(
         cs: CS,
         fe: &Fp2Gadget<P, ConstraintF>,
     ) -> Result<Fp2Gadget<P, ConstraintF>, SynthesisError> {
@@ -56,7 +56,7 @@ where
     }
 
     #[inline]
-    pub fn mul_by_0_c1_0<CS: ConstraintSystem<ConstraintF>>(
+    pub fn mul_by_0_c1_0<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         c1: &Fp2Gadget<P, ConstraintF>,
@@ -93,7 +93,7 @@ where
     }
 
     // #[inline]
-    pub fn mul_by_c0_c1_0<CS: ConstraintSystem<ConstraintF>>(
+    pub fn mul_by_c0_c1_0<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         c0: &Fp2Gadget<P, ConstraintF>,
@@ -172,7 +172,7 @@ where
     }
 
     #[inline]
-    fn zero<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+    fn zero<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
         let c0 = Fp2Gadget::<P, ConstraintF>::zero(cs.ns(|| "c0"))?;
         let c1 = Fp2Gadget::<P, ConstraintF>::zero(cs.ns(|| "c1"))?;
         let c2 = Fp2Gadget::<P, ConstraintF>::zero(cs.ns(|| "c2"))?;
@@ -180,7 +180,7 @@ where
     }
 
     #[inline]
-    fn one<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+    fn one<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
         let c0 = Fp2Gadget::<P, ConstraintF>::one(cs.ns(|| "c0"))?;
         let c1 = Fp2Gadget::<P, ConstraintF>::zero(cs.ns(|| "c1"))?;
         let c2 = Fp2Gadget::<P, ConstraintF>::zero(cs.ns(|| "c2"))?;
@@ -188,7 +188,7 @@ where
     }
 
     #[inline]
-    fn conditionally_add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_add_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         bit: &Boolean,
@@ -207,7 +207,7 @@ where
     }
 
     #[inline]
-    fn add<CS: ConstraintSystem<ConstraintF>>(
+    fn add<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -219,7 +219,7 @@ where
     }
 
     #[inline]
-    fn sub<CS: ConstraintSystem<ConstraintF>>(
+    fn sub<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -231,7 +231,7 @@ where
     }
 
     #[inline]
-    fn negate<CS: ConstraintSystem<ConstraintF>>(
+    fn negate<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -242,7 +242,7 @@ where
     }
 
     #[inline]
-    fn negate_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn negate_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -254,7 +254,7 @@ where
 
     /// Use the Toom-Cook-3x method to compute multiplication.
     #[inline]
-    fn mul<CS: ConstraintSystem<ConstraintF>>(
+    fn mul<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -400,7 +400,7 @@ where
 
     /// Use the Toom-Cook-3x method to compute multiplication.
     #[inline]
-    fn square<CS: ConstraintSystem<ConstraintF>>(
+    fn square<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -502,7 +502,7 @@ where
 
     // 18 constaints, we can probably do better but not sure it's worth it.
     #[inline]
-    fn inverse<CS: ConstraintSystem<ConstraintF>>(
+    fn inverse<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -515,7 +515,7 @@ where
     }
 
     #[inline]
-    fn add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Fp6<P>,
@@ -528,7 +528,7 @@ where
     }
 
     #[inline]
-    fn add_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
         other: &Fp6<P>,
@@ -541,7 +541,7 @@ where
 
     /// Use the Toom-Cook-3x method to compute multiplication.
     #[inline]
-    fn mul_by_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_by_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Fp6<P>,
@@ -669,7 +669,7 @@ where
         Ok(Self::new(c0, c1, c2))
     }
 
-    fn frobenius_map<CS: ConstraintSystem<ConstraintF>>(
+    fn frobenius_map<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         power: usize,
@@ -679,7 +679,7 @@ where
         Ok(result)
     }
 
-    fn frobenius_map_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn frobenius_map_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
         power: usize,
@@ -739,7 +739,7 @@ where
     P::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     #[inline]
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -765,7 +765,7 @@ where
     P::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     #[inline]
-    fn enforce_not_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_not_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -786,7 +786,7 @@ where
     P: Fp6Parameters,
     P::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -800,7 +800,7 @@ where
         Ok(c0)
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -820,7 +820,7 @@ where
     P: Fp6Parameters,
     P::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -834,7 +834,7 @@ where
         Ok(c0)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -858,7 +858,7 @@ where
     P::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     #[inline]
-    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_select<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -897,7 +897,7 @@ where
     P::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     type TableConstant = Fp6<P>;
-    fn two_bit_lookup<CS: ConstraintSystem<ConstraintF>>(
+    fn two_bit_lookup<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         b: &[Boolean],
         c: &[Self::TableConstant],
@@ -924,7 +924,7 @@ where
 {
     type TableConstant = Fp6<P>;
 
-    fn three_bit_cond_neg_lookup<CS: ConstraintSystem<ConstraintF>>(
+    fn three_bit_cond_neg_lookup<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         b: &[Boolean],
         b0b1: &Boolean,
@@ -965,7 +965,7 @@ where
     P::Fp2Params: Fp2Parameters<Fp = ConstraintF>,
 {
     #[inline]
-    fn alloc<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -992,7 +992,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<F, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<F, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>

--- a/r1cs-std/src/fields/mod.rs
+++ b/r1cs-std/src/fields/mod.rs
@@ -1,6 +1,6 @@
 // use std::ops::{Mul, MulAssign};
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use std::fmt::Debug;
 
 use crate::prelude::*;
@@ -35,24 +35,24 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
 
     fn get_variable(&self) -> Self::Variable;
 
-    fn zero<CS: ConstraintSystem<ConstraintF>>(_: CS) -> Result<Self, SynthesisError>;
+    fn zero<CS: R1CS<ConstraintF>>(_: CS) -> Result<Self, SynthesisError>;
 
-    fn one<CS: ConstraintSystem<ConstraintF>>(_: CS) -> Result<Self, SynthesisError>;
+    fn one<CS: R1CS<ConstraintF>>(_: CS) -> Result<Self, SynthesisError>;
 
-    fn conditionally_add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_add_constant<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
         _: &Boolean,
         _: F,
     ) -> Result<Self, SynthesisError>;
 
-    fn add<CS: ConstraintSystem<ConstraintF>>(
+    fn add<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
         _: &Self,
     ) -> Result<Self, SynthesisError>;
 
-    fn add_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn add_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &Self,
@@ -61,11 +61,11 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         Ok(self)
     }
 
-    fn double<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
+    fn double<CS: R1CS<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
         self.add(cs, &self)
     }
 
-    fn double_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn double_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -73,13 +73,13 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         Ok(self)
     }
 
-    fn sub<CS: ConstraintSystem<ConstraintF>>(
+    fn sub<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
         _: &Self,
     ) -> Result<Self, SynthesisError>;
 
-    fn sub_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn sub_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &Self,
@@ -88,10 +88,10 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         Ok(self)
     }
 
-    fn negate<CS: ConstraintSystem<ConstraintF>>(&self, _: CS) -> Result<Self, SynthesisError>;
+    fn negate<CS: R1CS<ConstraintF>>(&self, _: CS) -> Result<Self, SynthesisError>;
 
     #[inline]
-    fn negate_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn negate_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -99,13 +99,13 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         Ok(self)
     }
 
-    fn mul<CS: ConstraintSystem<ConstraintF>>(
+    fn mul<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
         _: &Self,
     ) -> Result<Self, SynthesisError>;
 
-    fn mul_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &Self,
@@ -114,11 +114,11 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         Ok(self)
     }
 
-    fn square<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
+    fn square<CS: R1CS<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError> {
         self.mul(cs, &self)
     }
 
-    fn square_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn square_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
     ) -> Result<&mut Self, SynthesisError> {
@@ -126,7 +126,7 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         Ok(self)
     }
 
-    fn mul_equals<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_equals<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -136,7 +136,7 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         result.enforce_equal(&mut cs.ns(|| "test_equals"), &actual_result)
     }
 
-    fn square_equals<CS: ConstraintSystem<ConstraintF>>(
+    fn square_equals<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         result: &Self,
@@ -145,13 +145,13 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         result.enforce_equal(&mut cs.ns(|| "test_equals"), &actual_result)
     }
 
-    fn add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
         _: &F,
     ) -> Result<Self, SynthesisError>;
 
-    fn add_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &F,
@@ -160,7 +160,7 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         Ok(self)
     }
 
-    fn sub_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn sub_constant<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         fe: &F,
@@ -168,7 +168,7 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         self.add_constant(cs, &(-(*fe)))
     }
 
-    fn sub_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn sub_constant_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &F,
@@ -176,13 +176,13 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         self.add_constant_in_place(cs, &(-(*other)))
     }
 
-    fn mul_by_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_by_constant<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
         _: &F,
     ) -> Result<Self, SynthesisError>;
 
-    fn mul_by_constant_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn mul_by_constant_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
         other: &F,
@@ -191,15 +191,15 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
         Ok(self)
     }
 
-    fn inverse<CS: ConstraintSystem<ConstraintF>>(&self, _: CS) -> Result<Self, SynthesisError>;
+    fn inverse<CS: R1CS<ConstraintF>>(&self, _: CS) -> Result<Self, SynthesisError>;
 
-    fn frobenius_map<CS: ConstraintSystem<ConstraintF>>(
+    fn frobenius_map<CS: R1CS<ConstraintF>>(
         &self,
         _: CS,
         power: usize,
     ) -> Result<Self, SynthesisError>;
 
-    fn frobenius_map_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn frobenius_map_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
         power: usize,
@@ -211,7 +211,7 @@ pub trait FieldGadget<F: Field, ConstraintF: Field>:
     /// Accepts as input a list of bits which, when interpreted in big-endian
     /// form, are a scalar.
     #[inline]
-    fn pow<CS: ConstraintSystem<ConstraintF>>(
+    fn pow<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         bits: &[Boolean],
@@ -240,15 +240,15 @@ mod test {
     use rand::{self, thread_rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
-    use crate::{prelude::*, test_constraint_system::TestConstraintSystem};
+    use crate::{prelude::*, test_constraint_system::TestR1CS};
     use algebra::{BitIterator, Field, UniformRand};
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
 
     fn field_test<
         FE: Field,
         ConstraintF: Field,
         F: FieldGadget<FE, ConstraintF>,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     >(
         mut cs: CS,
         a: F,
@@ -454,7 +454,7 @@ mod test {
         FE: Field,
         ConstraintF: Field,
         F: FieldGadget<FE, ConstraintF>,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     >(
         mut cs: CS,
         maxpower: usize,
@@ -477,7 +477,7 @@ mod test {
         use crate::fields::bls12_377::{Fq12Gadget, Fq2Gadget, Fq6Gadget, FqGadget};
         use algebra::fields::bls12_377::{Fq, Fq12, Fq2, Fq6};
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
@@ -523,7 +523,7 @@ mod test {
         use crate::fields::jubjub::FqGadget;
         use algebra::fields::jubjub::fq::Fq;
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         let mut rng = thread_rng();
 
@@ -541,7 +541,7 @@ mod test {
         use crate::fields::edwards_bls12::FqGadget;
         use algebra::fields::edwards_bls12::fq::Fq;
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         let mut rng = thread_rng();
 

--- a/r1cs-std/src/groups/curves/short_weierstrass/bls12/bls12_377.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/bls12/bls12_377.rs
@@ -15,19 +15,19 @@ mod test {
     use rand;
 
     use super::{G1Gadget, G2Gadget};
-    use crate::{prelude::*, test_constraint_system::TestConstraintSystem};
+    use crate::{prelude::*, test_constraint_system::TestR1CS};
     use algebra::{
         curves::bls12_377::{G1Projective as G1, G2Projective as G2},
         fields::bls12_377::{Fq, Fr},
         AffineCurve, BitIterator, PrimeField, ProjectiveCurve,
     };
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
 
     #[test]
     fn bls12_g1_constraint_costs() {
         use crate::boolean::AllocatedBit;
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         let bit = AllocatedBit::alloc(&mut cs.ns(|| "bool"), || Ok(true))
             .unwrap()
@@ -59,7 +59,7 @@ mod test {
     fn bls12_g2_constraint_costs() {
         use crate::boolean::AllocatedBit;
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         let bit = AllocatedBit::alloc(&mut cs.ns(|| "bool"), || Ok(true))
             .unwrap()
@@ -94,7 +94,7 @@ mod test {
         use rand_xorshift::XorShiftRng;
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         let a = G1::rand(&mut rng);
         let b = G1::rand(&mut rng);
@@ -162,7 +162,7 @@ mod test {
 
     #[test]
     fn bls12_g2_gadget_test() {
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         let a: G2 = rand::random();
         let b: G2 = rand::random();

--- a/r1cs-std/src/groups/curves/short_weierstrass/bls12/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/bls12/mod.rs
@@ -3,7 +3,7 @@ use algebra::{
     fields::Field,
     BitIterator, ProjectiveCurve,
 };
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use crate::{
     fields::{fp::FpGadget, fp2::Fp2Gadget, FieldGadget},
@@ -37,7 +37,7 @@ impl<P: Bls12Parameters> G1PreparedGadget<P> {
         ))
     }
 
-    pub fn from_affine<CS: ConstraintSystem<P::Fp>>(
+    pub fn from_affine<CS: R1CS<P::Fp>>(
         _cs: CS,
         q: &G1Gadget<P>,
     ) -> Result<Self, SynthesisError> {
@@ -47,14 +47,14 @@ impl<P: Bls12Parameters> G1PreparedGadget<P> {
 
 impl<P: Bls12Parameters> ToBytesGadget<P::Fp> for G1PreparedGadget<P> {
     #[inline]
-    fn to_bytes<CS: ConstraintSystem<P::Fp>>(
+    fn to_bytes<CS: R1CS<P::Fp>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
         self.0.to_bytes(&mut cs.ns(|| "g_alpha to bytes"))
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<P::Fp>>(
+    fn to_bytes_strict<CS: R1CS<P::Fp>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -75,7 +75,7 @@ pub struct G2PreparedGadget<P: Bls12Parameters> {
 
 impl<P: Bls12Parameters> ToBytesGadget<P::Fp> for G2PreparedGadget<P> {
     #[inline]
-    fn to_bytes<CS: ConstraintSystem<P::Fp>>(
+    fn to_bytes<CS: R1CS<P::Fp>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -88,7 +88,7 @@ impl<P: Bls12Parameters> ToBytesGadget<P::Fp> for G2PreparedGadget<P> {
         Ok(bytes)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<P::Fp>>(
+    fn to_bytes_strict<CS: R1CS<P::Fp>>(
         &self,
         cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -97,7 +97,7 @@ impl<P: Bls12Parameters> ToBytesGadget<P::Fp> for G2PreparedGadget<P> {
 }
 
 impl<P: Bls12Parameters> G2PreparedGadget<P> {
-    pub fn from_affine<CS: ConstraintSystem<P::Fp>>(
+    pub fn from_affine<CS: R1CS<P::Fp>>(
         mut cs: CS,
         q: &G2Gadget<P>,
     ) -> Result<Self, SynthesisError> {
@@ -119,7 +119,7 @@ impl<P: Bls12Parameters> G2PreparedGadget<P> {
         Ok(Self { ell_coeffs })
     }
 
-    fn double<CS: ConstraintSystem<P::Fp>>(
+    fn double<CS: R1CS<P::Fp>>(
         mut cs: CS,
         r: &mut G2Gadget<P>,
         two_inv: &P::Fp,
@@ -148,7 +148,7 @@ impl<P: Bls12Parameters> G2PreparedGadget<P> {
         }
     }
 
-    fn add<CS: ConstraintSystem<P::Fp>>(
+    fn add<CS: R1CS<P::Fp>>(
         mut cs: CS,
         r: &mut G2Gadget<P>,
         q: &G2Gadget<P>,

--- a/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
@@ -5,7 +5,7 @@ use algebra::{
     },
     AffineCurve, BitIterator, Field, PrimeField, ProjectiveCurve,
 };
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use std::{borrow::Borrow, marker::PhantomData, ops::Neg};
 
 use crate::{prelude::*, Assignment};
@@ -40,7 +40,7 @@ impl<P: SWModelParameters, ConstraintF: Field, F: FieldGadget<P::BaseField, Cons
         }
     }
 
-    pub fn alloc_without_check<FN, CS: ConstraintSystem<ConstraintF>>(
+    pub fn alloc_without_check<FN, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -113,7 +113,7 @@ where
     }
 
     #[inline]
-    fn zero<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+    fn zero<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
         Ok(Self::new(
             F::zero(cs.ns(|| "zero"))?,
             F::one(cs.ns(|| "one"))?,
@@ -124,7 +124,7 @@ where
     #[inline]
     /// Incomplete addition: neither `self` nor `other` can be the neutral
     /// element.
-    fn add<CS: ConstraintSystem<ConstraintF>>(
+    fn add<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -190,7 +190,7 @@ where
 
     /// Incomplete addition: neither `self` nor `other` can be the neutral
     /// element.
-    fn add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &SWProjective<P>,
@@ -266,7 +266,7 @@ where
     }
 
     #[inline]
-    fn double_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn double_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         mut cs: CS,
     ) -> Result<(), SynthesisError> {
@@ -305,7 +305,7 @@ where
         Ok(())
     }
 
-    fn negate<CS: ConstraintSystem<ConstraintF>>(
+    fn negate<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Self, SynthesisError> {
@@ -332,7 +332,7 @@ where
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
     #[inline]
-    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_select<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -366,7 +366,7 @@ where
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
     #[inline]
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -402,7 +402,7 @@ where
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
     #[inline]
-    fn enforce_not_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_not_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -427,7 +427,7 @@ where
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
     #[inline]
-    fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -469,7 +469,7 @@ where
     }
 
     #[inline]
-    fn alloc_checked<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_checked<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -549,7 +549,7 @@ where
     }
 
     #[inline]
-    fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
+    fn alloc_input<FN, T, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: FN,
     ) -> Result<Self, SynthesisError>
@@ -585,7 +585,7 @@ where
     ConstraintF: Field,
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -596,7 +596,7 @@ where
         Ok(x_bits)
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -619,7 +619,7 @@ where
     ConstraintF: Field,
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -631,7 +631,7 @@ where
         Ok(x_bytes)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {

--- a/r1cs-std/src/groups/curves/twisted_edwards/edwards_bls12.rs
+++ b/r1cs-std/src/groups/curves/twisted_edwards/edwards_bls12.rs
@@ -10,20 +10,20 @@ mod test {
     use super::EdwardsBlsGadget as EdwardsG;
     use crate::{
         groups::curves::twisted_edwards::test::{edwards_constraint_costs, edwards_test},
-        test_constraint_system::TestConstraintSystem,
+        test_constraint_system::TestR1CS,
     };
     use algebra::{curves::edwards_bls12::EdwardsParameters, fields::edwards_bls12::fq::Fq};
 
     #[test]
     fn edwards_constraint_costs_test() {
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
         edwards_constraint_costs::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }
 
     #[test]
     fn edwards_bls12_gadget_test() {
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
         edwards_test::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }

--- a/r1cs-std/src/groups/curves/twisted_edwards/edwards_sw6.rs
+++ b/r1cs-std/src/groups/curves/twisted_edwards/edwards_sw6.rs
@@ -10,20 +10,20 @@ mod test {
     use super::EdwardsSWGadget as EdwardsG;
     use crate::{
         groups::curves::twisted_edwards::test::{edwards_constraint_costs, edwards_test},
-        test_constraint_system::TestConstraintSystem,
+        test_constraint_system::TestR1CS,
     };
     use algebra::{curves::edwards_sw6::EdwardsParameters, fields::edwards_sw6::fq::Fq};
 
     #[test]
     fn edwards_constraint_costs_test() {
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
         edwards_constraint_costs::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }
 
     #[test]
     fn edwards_sw6_gadget_test() {
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
         edwards_test::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }

--- a/r1cs-std/src/groups/curves/twisted_edwards/jubjub.rs
+++ b/r1cs-std/src/groups/curves/twisted_edwards/jubjub.rs
@@ -10,20 +10,20 @@ mod test {
     use super::JubJubGadget as EdwardsG;
     use crate::{
         groups::curves::twisted_edwards::test::{edwards_constraint_costs, edwards_test},
-        test_constraint_system::TestConstraintSystem,
+        test_constraint_system::TestR1CS,
     };
     use algebra::{curves::jubjub::JubJubParameters as EdwardsParameters, fields::jubjub::fq::Fq};
 
     #[test]
     fn edwards_constraint_costs_test() {
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
         edwards_constraint_costs::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }
 
     #[test]
     fn jubjub_gadget_test() {
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
         edwards_test::<_, EdwardsParameters, EdwardsG, _>(&mut cs);
         assert!(cs.is_satisfied());
     }

--- a/r1cs-std/src/groups/curves/twisted_edwards/mod.rs
+++ b/r1cs-std/src/groups/curves/twisted_edwards/mod.rs
@@ -6,7 +6,7 @@ use algebra::{
     BitIterator, Field,
 };
 
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use crate::prelude::*;
 
@@ -70,7 +70,7 @@ mod montgomery_affine_impl {
             Ok((montgomery_point.x, montgomery_point.y))
         }
 
-        pub fn from_edwards<CS: ConstraintSystem<ConstraintF>>(
+        pub fn from_edwards<CS: R1CS<ConstraintF>>(
             mut cs: CS,
             p: &TEAffine<P>,
         ) -> Result<Self, SynthesisError> {
@@ -83,7 +83,7 @@ mod montgomery_affine_impl {
             Ok(Self::new(u, v))
         }
 
-        pub fn into_edwards<CS: ConstraintSystem<ConstraintF>>(
+        pub fn into_edwards<CS: R1CS<ConstraintF>>(
             &self,
             mut cs: CS,
         ) -> Result<AffineGadget<P, ConstraintF, F>, SynthesisError> {
@@ -130,7 +130,7 @@ mod montgomery_affine_impl {
             Ok(AffineGadget::new(u, v))
         }
 
-        pub fn add<CS: ConstraintSystem<ConstraintF>>(
+        pub fn add<CS: R1CS<ConstraintF>>(
             &self,
             mut cs: CS,
             other: &Self,
@@ -219,7 +219,7 @@ impl<P: TEModelParameters, ConstraintF: Field, F: FieldGadget<P::BaseField, Cons
         }
     }
 
-    pub fn alloc_without_check<FN, CS: ConstraintSystem<ConstraintF>>(
+    pub fn alloc_without_check<FN, CS: R1CS<ConstraintF>>(
         mut cs: CS,
         value_gen: F,
     ) -> Result<Self, SynthesisError>
@@ -289,7 +289,7 @@ mod affine_impl {
         }
 
         #[inline]
-        fn zero<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+        fn zero<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
             Ok(Self::new(
                 F::zero(cs.ns(|| "zero"))?,
                 F::one(cs.ns(|| "one"))?,
@@ -299,7 +299,7 @@ mod affine_impl {
         /// Optimized constraints for checking Edwards point addition from ZCash
         /// developers Daira Hopwood and Sean Bowe. Requires only 6 constraints
         /// compared to 7 for the straightforward version we had earlier.
-        fn add<CS: ConstraintSystem<ConstraintF>>(
+        fn add<CS: R1CS<ConstraintF>>(
             &self,
             mut cs: CS,
             other: &Self,
@@ -360,7 +360,7 @@ mod affine_impl {
             Ok(Self::new(x3, y3))
         }
 
-        fn add_constant<CS: ConstraintSystem<ConstraintF>>(
+        fn add_constant<CS: R1CS<ConstraintF>>(
             &self,
             mut cs: CS,
             other: &TEAffine<P>,
@@ -423,7 +423,7 @@ mod affine_impl {
             Ok(Self::new(x3, y3))
         }
 
-        fn double_in_place<CS: ConstraintSystem<ConstraintF>>(
+        fn double_in_place<CS: R1CS<ConstraintF>>(
             &mut self,
             mut cs: CS,
         ) -> Result<(), SynthesisError> {
@@ -472,7 +472,7 @@ mod affine_impl {
             Ok(())
         }
 
-        fn negate<CS: ConstraintSystem<ConstraintF>>(
+        fn negate<CS: R1CS<ConstraintF>>(
             &self,
             mut cs: CS,
         ) -> Result<Self, SynthesisError> {
@@ -498,7 +498,7 @@ mod affine_impl {
         F: FieldGadget<P::BaseField, ConstraintF>,
         Self: GroupGadget<TEAffine<P>, ConstraintF>,
     {
-        fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
+        fn alloc<FN, T, CS: R1CS<ConstraintF>>(
             mut cs: CS,
             value_gen: FN,
         ) -> Result<Self, SynthesisError>
@@ -541,7 +541,7 @@ mod affine_impl {
             Ok(Self::new(x, y))
         }
 
-        fn alloc_checked<FN, T, CS: ConstraintSystem<ConstraintF>>(
+        fn alloc_checked<FN, T, CS: R1CS<ConstraintF>>(
             mut cs: CS,
             value_gen: FN,
         ) -> Result<Self, SynthesisError>
@@ -615,7 +615,7 @@ mod affine_impl {
             }
         }
 
-        fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
+        fn alloc_input<FN, T, CS: R1CS<ConstraintF>>(
             mut cs: CS,
             value_gen: FN,
         ) -> Result<Self, SynthesisError>
@@ -693,7 +693,7 @@ mod projective_impl {
         }
 
         #[inline]
-        fn zero<CS: ConstraintSystem<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
+        fn zero<CS: R1CS<ConstraintF>>(mut cs: CS) -> Result<Self, SynthesisError> {
             Ok(Self::new(
                 F::zero(cs.ns(|| "zero"))?,
                 F::one(cs.ns(|| "one"))?,
@@ -703,7 +703,7 @@ mod projective_impl {
         /// Optimized constraints for checking Edwards point addition from ZCash
         /// developers Daira Hopwood and Sean Bowe. Requires only 6 constraints
         /// compared to 7 for the straightforward version we had earlier.
-        fn add<CS: ConstraintSystem<ConstraintF>>(
+        fn add<CS: R1CS<ConstraintF>>(
             &self,
             mut cs: CS,
             other: &Self,
@@ -764,7 +764,7 @@ mod projective_impl {
             Ok(Self::new(x3, y3))
         }
 
-        fn add_constant<CS: ConstraintSystem<ConstraintF>>(
+        fn add_constant<CS: R1CS<ConstraintF>>(
             &self,
             mut cs: CS,
             other: &TEProjective<P>,
@@ -828,7 +828,7 @@ mod projective_impl {
             Ok(Self::new(x3, y3))
         }
 
-        fn double_in_place<CS: ConstraintSystem<ConstraintF>>(
+        fn double_in_place<CS: R1CS<ConstraintF>>(
             &mut self,
             mut cs: CS,
         ) -> Result<(), SynthesisError> {
@@ -877,7 +877,7 @@ mod projective_impl {
             Ok(())
         }
 
-        fn negate<CS: ConstraintSystem<ConstraintF>>(
+        fn negate<CS: R1CS<ConstraintF>>(
             &self,
             mut cs: CS,
         ) -> Result<Self, SynthesisError> {
@@ -893,7 +893,7 @@ mod projective_impl {
             scalar_bits_with_base_powers: I,
         ) -> Result<(), SynthesisError>
         where
-            CS: ConstraintSystem<ConstraintF>,
+            CS: R1CS<ConstraintF>,
             I: Iterator<Item = (B, &'a TEProjective<P>)>,
             B: Borrow<Boolean>,
         {
@@ -949,7 +949,7 @@ mod projective_impl {
             scalars: &[J],
         ) -> Result<Self, SynthesisError>
         where
-            CS: ConstraintSystem<ConstraintF>,
+            CS: R1CS<ConstraintF>,
             I: Borrow<[Boolean]>,
             J: Borrow<[I]>,
             B: Borrow<[TEProjective<P>]>,
@@ -1095,7 +1095,7 @@ mod projective_impl {
         F: FieldGadget<P::BaseField, ConstraintF>,
         Self: GroupGadget<TEProjective<P>, ConstraintF>,
     {
-        fn alloc<FN, T, CS: ConstraintSystem<ConstraintF>>(
+        fn alloc<FN, T, CS: R1CS<ConstraintF>>(
             mut cs: CS,
             value_gen: FN,
         ) -> Result<Self, SynthesisError>
@@ -1138,7 +1138,7 @@ mod projective_impl {
             Ok(Self::new(x, y))
         }
 
-        fn alloc_checked<FN, T, CS: ConstraintSystem<ConstraintF>>(
+        fn alloc_checked<FN, T, CS: R1CS<ConstraintF>>(
             mut cs: CS,
             value_gen: FN,
         ) -> Result<Self, SynthesisError>
@@ -1217,7 +1217,7 @@ mod projective_impl {
             }
         }
 
-        fn alloc_input<FN, T, CS: ConstraintSystem<ConstraintF>>(
+        fn alloc_input<FN, T, CS: R1CS<ConstraintF>>(
             mut cs: CS,
             value_gen: FN,
         ) -> Result<Self, SynthesisError>
@@ -1269,7 +1269,7 @@ where
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
     #[inline]
-    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_select<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -1301,7 +1301,7 @@ where
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
     #[inline]
-    fn conditional_enforce_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn conditional_enforce_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -1332,7 +1332,7 @@ where
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
     #[inline]
-    fn enforce_not_equal<CS: ConstraintSystem<ConstraintF>>(
+    fn enforce_not_equal<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -1355,7 +1355,7 @@ where
     ConstraintF: Field,
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
-    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -1365,7 +1365,7 @@ where
         Ok(x_bits)
     }
 
-    fn to_bits_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bits_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
@@ -1383,7 +1383,7 @@ where
     ConstraintF: Field,
     F: FieldGadget<P::BaseField, ConstraintF>,
 {
-    fn to_bytes<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {
@@ -1393,7 +1393,7 @@ where
         Ok(x_bytes)
     }
 
-    fn to_bytes_strict<CS: ConstraintSystem<ConstraintF>>(
+    fn to_bytes_strict<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
     ) -> Result<Vec<UInt8>, SynthesisError> {

--- a/r1cs-std/src/groups/curves/twisted_edwards/test.rs
+++ b/r1cs-std/src/groups/curves/twisted_edwards/test.rs
@@ -7,14 +7,14 @@ use algebra::{
     BitIterator, Field, Group, PrimeField, UniformRand,
 };
 
-use r1cs_core::ConstraintSystem;
+use r1cs_core::R1CS;
 
 pub(crate) fn edwards_test<ConstraintF, P, GG, CS>(cs: &mut CS)
 where
     ConstraintF: Field,
     P: TEModelParameters,
     GG: GroupGadget<TEAffine<P>, ConstraintF, Value = TEAffine<P>>,
-    CS: ConstraintSystem<ConstraintF>,
+    CS: R1CS<ConstraintF>,
 {
     let a: TEAffine<P> = UniformRand::rand(&mut thread_rng());
     let b: TEAffine<P> = UniformRand::rand(&mut thread_rng());
@@ -49,7 +49,7 @@ where
     ConstraintF: Field,
     P: TEModelParameters,
     GG: GroupGadget<TEAffine<P>, ConstraintF, Value = TEAffine<P>>,
-    CS: ConstraintSystem<ConstraintF>,
+    CS: R1CS<ConstraintF>,
 {
     use crate::boolean::AllocatedBit;
 

--- a/r1cs-std/src/groups/mod.rs
+++ b/r1cs-std/src/groups/mod.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use algebra::{Field, Group};
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use std::{borrow::Borrow, fmt::Debug};
 
@@ -29,15 +29,15 @@ pub trait GroupGadget<G: Group, ConstraintF: Field>:
 
     fn get_variable(&self) -> Self::Variable;
 
-    fn zero<CS: ConstraintSystem<ConstraintF>>(cs: CS) -> Result<Self, SynthesisError>;
+    fn zero<CS: R1CS<ConstraintF>>(cs: CS) -> Result<Self, SynthesisError>;
 
-    fn add<CS: ConstraintSystem<ConstraintF>>(
+    fn add<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         other: &Self,
     ) -> Result<Self, SynthesisError>;
 
-    fn sub<CS: ConstraintSystem<ConstraintF>>(
+    fn sub<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &Self,
@@ -46,13 +46,13 @@ pub trait GroupGadget<G: Group, ConstraintF: Field>:
         self.add(cs.ns(|| "Self - other"), &neg_other)
     }
 
-    fn add_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn add_constant<CS: R1CS<ConstraintF>>(
         &self,
         cs: CS,
         other: &G,
     ) -> Result<Self, SynthesisError>;
 
-    fn sub_constant<CS: ConstraintSystem<ConstraintF>>(
+    fn sub_constant<CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         other: &G,
@@ -61,17 +61,17 @@ pub trait GroupGadget<G: Group, ConstraintF: Field>:
         self.add_constant(cs.ns(|| "Self - other"), &neg_other)
     }
 
-    fn double_in_place<CS: ConstraintSystem<ConstraintF>>(
+    fn double_in_place<CS: R1CS<ConstraintF>>(
         &mut self,
         cs: CS,
     ) -> Result<(), SynthesisError>;
 
-    fn negate<CS: ConstraintSystem<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError>;
+    fn negate<CS: R1CS<ConstraintF>>(&self, cs: CS) -> Result<Self, SynthesisError>;
 
     /// Inputs must be specified in *little-endian* form.
     /// If the addition law is incomplete for the identity element,
     /// `result` must not be the identity element.
-    fn mul_bits<'a, CS: ConstraintSystem<ConstraintF>>(
+    fn mul_bits<'a, CS: R1CS<ConstraintF>>(
         &self,
         mut cs: CS,
         result: &Self,
@@ -98,7 +98,7 @@ pub trait GroupGadget<G: Group, ConstraintF: Field>:
         scalar_bits_with_base_powers: I,
     ) -> Result<(), SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
         I: Iterator<Item = (B, &'a G)>,
         B: Borrow<Boolean>,
         G: 'a,
@@ -124,7 +124,7 @@ pub trait GroupGadget<G: Group, ConstraintF: Field>:
         _: &[J],
     ) -> Result<Self, SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
         I: Borrow<[Boolean]>,
         J: Borrow<[I]>,
         B: Borrow<[G]>,
@@ -138,7 +138,7 @@ pub trait GroupGadget<G: Group, ConstraintF: Field>:
         scalars: I,
     ) -> Result<Self, SynthesisError>
     where
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
         T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
         I: Iterator<Item = &'a T>,
         B: Borrow<[G]>,
@@ -164,9 +164,9 @@ pub trait GroupGadget<G: Group, ConstraintF: Field>:
 #[cfg(test)]
 mod test {
     use algebra::Field;
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
 
-    use crate::{prelude::*, test_constraint_system::TestConstraintSystem};
+    use crate::{prelude::*, test_constraint_system::TestR1CS};
     use algebra::groups::Group;
     use rand;
 
@@ -174,7 +174,7 @@ mod test {
         ConstraintF: Field,
         G: Group,
         GG: GroupGadget<G, ConstraintF>,
-        CS: ConstraintSystem<ConstraintF>,
+        CS: R1CS<ConstraintF>,
     >(
         cs: &mut CS,
         a: GG,
@@ -224,7 +224,7 @@ mod test {
         use crate::groups::jubjub::JubJubGadget;
         use algebra::{curves::jubjub::JubJubProjective, fields::jubjub::fq::Fq};
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         let a: JubJubProjective = rand::random();
         let b: JubJubProjective = rand::random();

--- a/r1cs-std/src/pairing/bls12/mod.rs
+++ b/r1cs-std/src/pairing/bls12/mod.rs
@@ -1,4 +1,4 @@
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 use super::PairingGadget as PG;
 
@@ -27,7 +27,7 @@ type Fp2G<P> = Fp2Gadget<<P as Bls12Parameters>::Fp2Params, <P as Bls12Parameter
 
 impl<P: Bls12Parameters> PairingGadget<P> {
     // Evaluate the line function at point p.
-    fn ell<CS: ConstraintSystem<P::Fp>>(
+    fn ell<CS: R1CS<P::Fp>>(
         mut cs: CS,
         f: &mut Fp12Gadget<P::Fp12Params, P::Fp>,
         coeffs: &(Fp2G<P>, Fp2G<P>),
@@ -59,7 +59,7 @@ impl<P: Bls12Parameters> PairingGadget<P> {
         }
     }
 
-    fn exp_by_x<CS: ConstraintSystem<P::Fp>>(
+    fn exp_by_x<CS: R1CS<P::Fp>>(
         mut cs: CS,
         f: &Fp12Gadget<P::Fp12Params, P::Fp>,
     ) -> Result<Fp12Gadget<P::Fp12Params, P::Fp>, SynthesisError> {
@@ -96,7 +96,7 @@ where
     type G2PreparedGadget = G2PreparedGadget<P>;
     type GTGadget = Fp12Gadget<P::Fp12Params, P::Fp>;
 
-    fn miller_loop<CS: ConstraintSystem<P::Fp>>(
+    fn miller_loop<CS: R1CS<P::Fp>>(
         mut cs: CS,
         ps: &[Self::G1PreparedGadget],
         qs: &[Self::G2PreparedGadget],
@@ -131,7 +131,7 @@ where
         Ok(f)
     }
 
-    fn final_exponentiation<CS: ConstraintSystem<P::Fp>>(
+    fn final_exponentiation<CS: R1CS<P::Fp>>(
         mut cs: CS,
         f: &Self::GTGadget,
     ) -> Result<Self::GTGadget, SynthesisError> {
@@ -190,14 +190,14 @@ where
         })
     }
 
-    fn prepare_g1<CS: ConstraintSystem<P::Fp>>(
+    fn prepare_g1<CS: R1CS<P::Fp>>(
         cs: CS,
         p: &Self::G1Gadget,
     ) -> Result<Self::G1PreparedGadget, SynthesisError> {
         Self::G1PreparedGadget::from_affine(cs, p)
     }
 
-    fn prepare_g2<CS: ConstraintSystem<P::Fp>>(
+    fn prepare_g2<CS: R1CS<P::Fp>>(
         cs: CS,
         q: &Self::G2Gadget,
     ) -> Result<Self::G2PreparedGadget, SynthesisError> {

--- a/r1cs-std/src/pairing/mod.rs
+++ b/r1cs-std/src/pairing/mod.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use algebra::{Field, PairingEngine};
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 use std::fmt::Debug;
 
 pub mod bls12;
@@ -13,18 +13,18 @@ pub trait PairingGadget<PairingE: PairingEngine, ConstraintF: Field> {
     type G2PreparedGadget: ToBytesGadget<ConstraintF> + Clone + Debug;
     type GTGadget: FieldGadget<PairingE::Fqk, ConstraintF> + Clone;
 
-    fn miller_loop<CS: ConstraintSystem<ConstraintF>>(
+    fn miller_loop<CS: R1CS<ConstraintF>>(
         cs: CS,
         p: &[Self::G1PreparedGadget],
         q: &[Self::G2PreparedGadget],
     ) -> Result<Self::GTGadget, SynthesisError>;
 
-    fn final_exponentiation<CS: ConstraintSystem<ConstraintF>>(
+    fn final_exponentiation<CS: R1CS<ConstraintF>>(
         cs: CS,
         p: &Self::GTGadget,
     ) -> Result<Self::GTGadget, SynthesisError>;
 
-    fn pairing<CS: ConstraintSystem<ConstraintF>>(
+    fn pairing<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         p: Self::G1PreparedGadget,
         q: Self::G2PreparedGadget,
@@ -35,7 +35,7 @@ pub trait PairingGadget<PairingE: PairingEngine, ConstraintF: Field> {
 
     /// Computes a product of pairings.
     #[must_use]
-    fn product_of_pairings<CS: ConstraintSystem<ConstraintF>>(
+    fn product_of_pairings<CS: R1CS<ConstraintF>>(
         mut cs: CS,
         p: &[Self::G1PreparedGadget],
         q: &[Self::G2PreparedGadget],
@@ -44,12 +44,12 @@ pub trait PairingGadget<PairingE: PairingEngine, ConstraintF: Field> {
         Self::final_exponentiation(&mut cs.ns(|| "Final Exp"), &miller_result)
     }
 
-    fn prepare_g1<CS: ConstraintSystem<ConstraintF>>(
+    fn prepare_g1<CS: R1CS<ConstraintF>>(
         cs: CS,
         q: &Self::G1Gadget,
     ) -> Result<Self::G1PreparedGadget, SynthesisError>;
 
-    fn prepare_g2<CS: ConstraintSystem<ConstraintF>>(
+    fn prepare_g2<CS: R1CS<ConstraintF>>(
         cs: CS,
         q: &Self::G2Gadget,
     ) -> Result<Self::G2PreparedGadget, SynthesisError>;
@@ -58,9 +58,9 @@ pub trait PairingGadget<PairingE: PairingEngine, ConstraintF: Field> {
 #[cfg(test)]
 mod test {
     // use rand;
-    use crate::test_constraint_system::TestConstraintSystem;
+    use crate::test_constraint_system::TestR1CS;
     use algebra::{BitIterator, Field};
-    use r1cs_core::ConstraintSystem;
+    use r1cs_core::R1CS;
 
     #[test]
     fn bls12_377_gadget_bilinearity_test() {
@@ -81,7 +81,7 @@ mod test {
         use algebra::curves::bls12_377::{Bls12_377, G1Projective, G2Projective};
         use std::ops::Mul;
 
-        let mut cs = TestConstraintSystem::<Fq>::new();
+        let mut cs = TestR1CS::<Fq>::new();
 
         // let a: G1Projective = rand::random();
         // let b: G2Projective = rand::random();

--- a/r1cs-std/src/select.rs
+++ b/r1cs-std/src/select.rs
@@ -1,13 +1,13 @@
 use crate::prelude::*;
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_core::{R1CS, SynthesisError};
 
 /// If condition is `true`, return `first`; else, select `second`.
 pub trait CondSelectGadget<ConstraintF: Field>
 where
     Self: Sized,
 {
-    fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
+    fn conditionally_select<CS: R1CS<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
         first: &Self,
@@ -23,7 +23,7 @@ where
     Self: Sized,
 {
     type TableConstant;
-    fn two_bit_lookup<CS: ConstraintSystem<ConstraintF>>(
+    fn two_bit_lookup<CS: R1CS<ConstraintF>>(
         cs: CS,
         bits: &[Boolean],
         constants: &[Self::TableConstant],
@@ -39,7 +39,7 @@ where
     Self: Sized,
 {
     type TableConstant;
-    fn three_bit_cond_neg_lookup<CS: ConstraintSystem<ConstraintF>>(
+    fn three_bit_cond_neg_lookup<CS: R1CS<ConstraintF>>(
         cs: CS,
         bits: &[Boolean],
         b0b1: &Boolean,

--- a/r1cs-std/src/test_constraint_system.rs
+++ b/r1cs-std/src/test_constraint_system.rs
@@ -1,5 +1,5 @@
 use algebra::Field;
-use r1cs_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use r1cs_core::{R1CS, Index, LinearCombination, SynthesisError, Variable};
 
 use radix_trie::Trie;
 
@@ -11,7 +11,7 @@ enum NamedObject {
 }
 
 /// Constraint system for testing purposes.
-pub struct TestConstraintSystem<ConstraintF: Field> {
+pub struct TestR1CS<ConstraintF: Field> {
     named_objects:     Trie<String, NamedObject>,
     current_namespace: Vec<String>,
     pub constraints: Vec<(
@@ -24,7 +24,7 @@ pub struct TestConstraintSystem<ConstraintF: Field> {
     aux:               Vec<(ConstraintF, String)>,
 }
 
-impl<ConstraintF: Field> TestConstraintSystem<ConstraintF> {
+impl<ConstraintF: Field> TestR1CS<ConstraintF> {
     fn eval_lc(
         terms: &[(Variable, ConstraintF)],
         inputs: &[(ConstraintF, String)],
@@ -46,15 +46,15 @@ impl<ConstraintF: Field> TestConstraintSystem<ConstraintF> {
     }
 }
 
-impl<ConstraintF: Field> TestConstraintSystem<ConstraintF> {
-    pub fn new() -> TestConstraintSystem<ConstraintF> {
+impl<ConstraintF: Field> TestR1CS<ConstraintF> {
+    pub fn new() -> TestR1CS<ConstraintF> {
         let mut map = Trie::new();
         map.insert(
             "ONE".into(),
-            NamedObject::Var(TestConstraintSystem::<ConstraintF>::one()),
+            NamedObject::Var(TestR1CS::<ConstraintF>::one()),
         );
 
-        TestConstraintSystem {
+        TestR1CS {
             named_objects:     map,
             current_namespace: vec![],
             constraints:       vec![],
@@ -150,7 +150,7 @@ fn compute_path(ns: &[String], this: String) -> String {
     name
 }
 
-impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for TestConstraintSystem<ConstraintF> {
+impl<ConstraintF: Field> R1CS<ConstraintF> for TestR1CS<ConstraintF> {
     type Root = Self;
 
     fn alloc<F, A, AR>(&mut self, annotation: A, f: F) -> Result<Variable, SynthesisError>


### PR DESCRIPTION
This is a straight forward s/ConstraintSystem/R1CS/. `cargo test` passes. If anything beyond this was implied by the item in #50 let me know. (Maybe renaming all the `cs: CS`?)
