### PR TITLE
Convert identity functions in Field, Group, and {Projective,Affine}Curve traits with One/Zero traits from num_traits.

### DIFF
--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -25,6 +25,7 @@ edition = "2018"
 byteorder = { version = "1" }
 rand = { version = "0.7" }
 derivative = { version = "1" }
+num-traits = { version = "0.2.11"}
 
 colored = { version = "1", optional = true }
 rayon = { version = "1", optional = true }

--- a/algebra/src/curves/bls12_377/g1.rs
+++ b/algebra/src/curves/bls12_377/g1.rs
@@ -4,9 +4,9 @@ use crate::{
     curves::models::{ModelParameters, SWModelParameters},
     fields::{
         bls12_377::{Fq, Fr},
-        Field,
     },
 };
+use num_traits::Zero;
 
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub struct Bls12_377G1Parameters;

--- a/algebra/src/curves/bls12_377/g2.rs
+++ b/algebra/src/curves/bls12_377/g2.rs
@@ -5,9 +5,9 @@ use crate::{
     curves::models::{ModelParameters, SWModelParameters},
     fields::{
         bls12_377::{Fq, Fq2, Fr},
-        Field,
     },
 };
+use num_traits::Zero;
 
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub struct Bls12_377G2Parameters;

--- a/algebra/src/curves/bls12_377/tests.rs
+++ b/algebra/src/curves/bls12_377/tests.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     groups::tests::group_test,
 };
+use num_traits::{One, Zero};
 use std::ops::{AddAssign, MulAssign};
 
 #[test]

--- a/algebra/src/curves/bls12_381/g1.rs
+++ b/algebra/src/curves/bls12_381/g1.rs
@@ -9,9 +9,9 @@ use crate::{
     },
     fields::{
         bls12_381::{Fq, Fq12, Fr},
-        Field,
     },
 };
+use num_traits::Zero;
 
 pub type G1Affine = Bls12G1Affine<Bls12_381Parameters>;
 pub type G1Projective = Bls12G1Projective<Bls12_381Parameters>;

--- a/algebra/src/curves/bls12_381/g2.rs
+++ b/algebra/src/curves/bls12_381/g2.rs
@@ -12,9 +12,9 @@ use crate::{
     },
     fields::{
         bls12_381::{Fq, Fq12, Fq2, Fr},
-        Field,
     },
 };
+use num_traits::Zero;
 
 pub type G2Affine = Bls12G2Affine<Bls12_381Parameters>;
 pub type G2Projective = Bls12G2Projective<Bls12_381Parameters>;

--- a/algebra/src/curves/bls12_381/tests.rs
+++ b/algebra/src/curves/bls12_381/tests.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     groups::tests::group_test,
 };
+use num_traits::{One, Zero};
 use rand;
 use std::ops::{AddAssign, MulAssign};
 

--- a/algebra/src/curves/jubjub/tests.rs
+++ b/algebra/src/curves/jubjub/tests.rs
@@ -85,13 +85,13 @@ fn test_scalar_multiplication() {
     assert!(!g.is_zero());
     assert!(!f1f2g.is_zero());
 
-    let f1g = g * &f1;
+    let f1g = g * f1;
     println!("f1: {:?}", f1);
     println!("f2: {:?}", f2);
     println!("g: {:?}", g);
     println!("f1f2g: {:?}", f1f2g);
-    assert_eq!(g * &(f1 * &f2), f1f2g);
-    assert_eq!(f1g * &f2, f1f2g);
+    assert_eq!(g * (f1 * &f2), f1f2g);
+    assert_eq!(f1g * f2, f1f2g);
 }
 
 #[test]

--- a/algebra/src/curves/jubjub/tests.rs
+++ b/algebra/src/curves/jubjub/tests.rs
@@ -1,9 +1,13 @@
 use crate::{
     bytes::{FromBytes, ToBytes},
-    curves::{jubjub::*, tests::curve_tests, AffineCurve, ProjectiveCurve, models::twisted_edwards_extended::tests::montgomery_conversion_test},
+    curves::{
+        jubjub::*, models::twisted_edwards_extended::tests::montgomery_conversion_test,
+        tests::curve_tests, AffineCurve, ProjectiveCurve,
+    },
     fields::jubjub::fr::Fr,
     groups::tests::group_test,
 };
+use num_traits::Zero;
 use rand;
 use std::str::FromStr;
 

--- a/algebra/src/curves/mnt6/mod.rs
+++ b/algebra/src/curves/mnt6/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         BitIterator, Field, FpParameters,
     },
 };
+use num_traits::{One, Zero};
 
 pub mod g1;
 pub mod g2;

--- a/algebra/src/curves/mnt6/tests.rs
+++ b/algebra/src/curves/mnt6/tests.rs
@@ -7,6 +7,7 @@ use crate::{
     fields::mnt6::fr::Fr,
     groups::tests::group_test,
 };
+use num_traits::One;
 use rand;
 
 #[test]

--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -132,7 +132,6 @@ pub trait ProjectiveCurve:
     + Neg<Output = Self>
     + for<'a> Add<&'a Self, Output = Self>
     + Add<Self, Output = Self>
-    + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>

--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     groups::Group,
 };
 use crate::UniformRand;
+use num_traits::Zero;
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
@@ -126,9 +127,11 @@ pub trait ProjectiveCurve:
     + Debug
     + Display
     + UniformRand
+    + Zero
     + 'static
     + Neg<Output = Self>
     + for<'a> Add<&'a Self, Output = Self>
+    + Add<Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>
@@ -137,17 +140,9 @@ pub trait ProjectiveCurve:
     type BaseField: Field;
     type Affine: AffineCurve<Projective = Self, ScalarField = Self::ScalarField>;
 
-    /// Returns the additive identity.
-    #[must_use]
-    fn zero() -> Self;
-
     /// Returns a fixed generator of unknown exponent.
     #[must_use]
     fn prime_subgroup_generator() -> Self;
-
-    /// Determines if this point is the point at infinity.
-    #[must_use]
-    fn is_zero(&self) -> bool;
 
     /// Normalizes a slice of projective elements so that
     /// conversion to affine is cheap.
@@ -205,6 +200,7 @@ pub trait AffineCurve:
     + Hash
     + Debug
     + Display
+    + Zero
     + Neg<Output = Self>
     + 'static
 {
@@ -212,18 +208,9 @@ pub trait AffineCurve:
     type BaseField: Field;
     type Projective: ProjectiveCurve<Affine = Self, ScalarField = Self::ScalarField>;
 
-    /// Returns the additive identity.
-    #[must_use]
-    fn zero() -> Self;
-
     /// Returns a fixed generator of unknown exponent.
     #[must_use]
     fn prime_subgroup_generator() -> Self;
-
-    /// Determines if this point represents the point at infinity; the
-    /// additive identity.
-    #[must_use]
-    fn is_zero(&self) -> bool;
 
     /// Performs scalar multiplication of this element with mixed addition.
     #[must_use]
@@ -261,15 +248,6 @@ pub trait PairingCurve: AffineCurve {
 
 impl<C: ProjectiveCurve> Group for C {
     type ScalarField = C::ScalarField;
-    #[must_use]
-    fn zero() -> Self {
-        <C as ProjectiveCurve>::zero()
-    }
-
-    #[must_use]
-    fn is_zero(&self) -> bool {
-        <C as ProjectiveCurve>::is_zero(&self)
-    }
 
     #[inline]
     #[must_use]

--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -132,6 +132,7 @@ pub trait ProjectiveCurve:
     + Neg<Output = Self>
     + for<'a> Add<&'a Self, Output = Self>
     + Add<Self, Output = Self>
+    + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>

--- a/algebra/src/curves/models/bls12/g1.rs
+++ b/algebra/src/curves/models/bls12/g1.rs
@@ -6,6 +6,7 @@ use crate::{
         AffineCurve,
     },
 };
+use num_traits::Zero;
 use std::io::{Result as IoResult, Write};
 
 pub type G1Affine<P> = GroupAffine<<P as Bls12Parameters>::G1Parameters>;

--- a/algebra/src/curves/models/bls12/g2.rs
+++ b/algebra/src/curves/models/bls12/g2.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     fields::{BitIterator, Field, Fp2},
 };
+use num_traits::{One, Zero};
 use std::io::{Result as IoResult, Write};
 
 pub type G2Affine<P> = GroupAffine<<P as Bls12Parameters>::G2Parameters>;

--- a/algebra/src/curves/models/bls12/mod.rs
+++ b/algebra/src/curves/models/bls12/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         BitIterator, Field, Fp2, PrimeField, SquareRootField,
     },
 };
+use num_traits::One;
 
 use std::marker::PhantomData;
 

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -126,12 +126,9 @@ impl<P: Parameters> Add<Self> for GroupAffine<P> {
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupAffine<P> {
     fn add_assign(&mut self, other: &'a Self) {
-        let lambda = (other.y - &self.y) / &(other.x - &self.y);
-        let x3 = lambda * &lambda - &self.x - &other.x;
-        let y3 = (self.x - &x3) * &lambda - &self.y;
-
-        self.x = x3;
-        self.y = y3;
+        let mut s_proj = self.into_projective();
+        s_proj.add_assign_mixed(&other);
+        *self = s_proj.into_affine();
     }
 }
 

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -247,10 +247,11 @@ impl<P: Parameters> PartialEq for GroupProjective<P> {
 
         if self.x * &z2 != other.x * &z1 {
             false
-        } else { self.y * &(z2 * &other.z) == other.y * &(z1 * &self.z) }
+        } else {
+            self.y * &(z2 * &other.z) == other.y * &(z1 * &self.z)
+        }
     }
 }
-
 
 impl<P: Parameters> Distribution<GroupProjective<P>> for Standard {
     #[inline]
@@ -587,6 +588,17 @@ impl<P: Parameters> Add<Self> for GroupProjective<P> {
     fn add(self, other: Self) -> Self {
         let mut copy = self;
         copy += &other;
+        copy
+    }
+}
+
+impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: &'a Self) -> Self {
+        let mut copy = self;
+        copy += other;
         copy
     }
 }

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -127,8 +127,8 @@ impl<P: Parameters> Add<Self> for GroupAffine<P> {
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupAffine<P> {
     fn add_assign(&mut self, other: &'a Self) {
         let lambda = (other.y - &self.y) / &(other.x - &self.y);
-        let x3 = lambda * lambda - &self.x - &other.x;
-        let y3 = (self.x - &x3) * lambda - &self.y;
+        let x3 = lambda * &lambda - &self.x - &other.x;
+        let y3 = (self.x - &x3) * &lambda - &self.y;
 
         self.x = x3;
         self.y = y3;

--- a/algebra/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra/src/curves/models/short_weierstrass_projective.rs
@@ -130,8 +130,8 @@ impl<P: Parameters> Add<Self> for GroupAffine<P> {
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupAffine<P> {
     fn add_assign(&mut self, other: &'a Self) {
         let lambda = (other.y - &self.y) / &(other.x - &self.y);
-        let x3 = lambda * lambda - &self.x - &other.x;
-        let y3 = (self.x - &x3) * lambda - &self.y;
+        let x3 = lambda * &lambda - &self.x - &other.x;
+        let y3 = (self.x - &x3) * &lambda - &self.y;
 
         self.x = x3;
         self.y = y3;

--- a/algebra/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra/src/curves/models/short_weierstrass_projective.rs
@@ -241,7 +241,9 @@ impl<P: Parameters> PartialEq for GroupProjective<P> {
         // x1/z1 == x2/z2  <==> x1 * z2 == x2 * z1
         if (self.x * &other.z) != (other.x * &self.z) {
             false
-        } else { (self.y * &other.z) == (other.y * &self.z) }
+        } else {
+            (self.y * &other.z) == (other.y * &self.z)
+        }
     }
 }
 
@@ -493,6 +495,15 @@ impl<P: Parameters> Add<Self> for GroupProjective<P> {
     fn add(self, other: Self) -> Self {
         let mut copy = self;
         copy += &other;
+        copy
+    }
+}
+
+impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
+    type Output = Self;
+    fn add(self, other: &'a Self) -> Self {
+        let mut copy = self;
+        copy += other;
         copy
     }
 }

--- a/algebra/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra/src/curves/models/short_weierstrass_projective.rs
@@ -129,12 +129,9 @@ impl<P: Parameters> Add<Self> for GroupAffine<P> {
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupAffine<P> {
     fn add_assign(&mut self, other: &'a Self) {
-        let lambda = (other.y - &self.y) / &(other.x - &self.y);
-        let x3 = lambda * &lambda - &self.x - &other.x;
-        let y3 = (self.x - &x3) * &lambda - &self.y;
-
-        self.x = x3;
-        self.y = y3;
+        let mut s_proj = self.into_projective();
+        s_proj.add_assign_mixed(&other);
+        *self = s_proj.into_affine();
     }
 }
 

--- a/algebra/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra/src/curves/models/short_weierstrass_projective.rs
@@ -1,6 +1,7 @@
 use crate::curves::models::SWModelParameters as Parameters;
 use rand::{Rng, distributions::{Standard, Distribution}};
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use std::{
     fmt::{Display, Formatter, Result as FmtResult},
     io::{Read, Result as IoResult, Write},
@@ -107,14 +108,40 @@ impl<P: Parameters> GroupAffine<P> {
     }
 }
 
+impl<P: Parameters> Zero for GroupAffine<P> {
+    fn zero() -> Self {
+        Self::new(P::BaseField::zero(), P::BaseField::one(), true)
+    }
+
+    fn is_zero(&self) -> bool {
+        self.infinity
+    }
+}
+
+impl<P: Parameters> Add<Self> for GroupAffine<P> {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        let mut copy = self;
+        copy += &other;
+        copy
+    }
+}
+
+impl<'a, P: Parameters> AddAssign<&'a Self> for GroupAffine<P> {
+    fn add_assign(&mut self, other: &'a Self) {
+        let lambda = (other.y - &self.y) / &(other.x - &self.y);
+        let x3 = lambda * lambda - &self.x - &other.x;
+        let y3 = (self.x - &x3) * lambda - &self.y;
+
+        self.x = x3;
+        self.y = y3;
+    }
+}
+
 impl<P: Parameters> AffineCurve for GroupAffine<P> {
     type BaseField = P::BaseField;
     type ScalarField = P::ScalarField;
     type Projective = GroupProjective<P>;
-
-    fn zero() -> Self {
-        Self::new(Self::BaseField::zero(), Self::BaseField::one(), true)
-    }
 
     fn prime_subgroup_generator() -> Self {
         Self::new(
@@ -122,10 +149,6 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
             P::AFFINE_GENERATOR_COEFFS.1,
             false,
         )
-    }
-
-    fn is_zero(&self) -> bool {
-        self.infinity
     }
 
     fn mul<S: Into<<Self::ScalarField as PrimeField>::BigInt>>(&self, by: S) -> GroupProjective<P> {
@@ -231,9 +254,6 @@ impl<P: Parameters> Distribution<GroupProjective<P>> for Standard {
     }
 }
 
-
-
-
 impl<P: Parameters> ToBytes for GroupProjective<P> {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
@@ -271,11 +291,7 @@ impl<P: Parameters> GroupProjective<P> {
     }
 }
 
-impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
-    type BaseField = P::BaseField;
-    type ScalarField = P::ScalarField;
-    type Affine = GroupAffine<P>;
-
+impl<P: Parameters> Zero for GroupProjective<P> {
     // The point at infinity is always represented by Z = 0.
     #[inline]
     fn zero() -> Self {
@@ -286,16 +302,22 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         )
     }
 
-    #[inline]
-    fn prime_subgroup_generator() -> Self {
-        GroupAffine::prime_subgroup_generator().into()
-    }
-
     // The point at infinity is always represented by
     // Z = 0.
     #[inline]
     fn is_zero(&self) -> bool {
         self.z.is_zero()
+    }
+}
+
+impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
+    type BaseField = P::BaseField;
+    type ScalarField = P::ScalarField;
+    type Affine = GroupAffine<P>;
+
+    #[inline]
+    fn prime_subgroup_generator() -> Self {
+        GroupAffine::prime_subgroup_generator().into()
     }
 
     #[inline]
@@ -466,11 +488,11 @@ impl<P: Parameters> Neg for GroupProjective<P> {
     }
 }
 
-impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
+impl<P: Parameters> Add<Self> for GroupProjective<P> {
     type Output = Self;
-    fn add(self, other: &'a Self) -> Self {
+    fn add(self, other: Self) -> Self {
         let mut copy = self;
-        copy += other;
+        copy += &other;
         copy
     }
 }

--- a/algebra/src/curves/models/twisted_edwards_extended/mod.rs
+++ b/algebra/src/curves/models/twisted_edwards_extended/mod.rs
@@ -527,6 +527,15 @@ impl<P: Parameters> Add<Self> for GroupProjective<P> {
     }
 }
 
+impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
+    type Output = Self;
+    fn add(self, other: &'a Self) -> Self {
+        let mut copy = self;
+        copy += other;
+        copy
+    }
+}
+
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
     fn add_assign(&mut self, other: &'a Self) {
         // See "Twisted Edwards Curves Revisited"

--- a/algebra/src/curves/models/twisted_edwards_extended/tests.rs
+++ b/algebra/src/curves/models/twisted_edwards_extended/tests.rs
@@ -1,4 +1,5 @@
 use crate::{fields::Field, TEModelParameters, MontgomeryModelParameters};
+use num_traits::One;
 
 pub(crate) fn montgomery_conversion_test<P>()
     where

--- a/algebra/src/curves/sw6/mod.rs
+++ b/algebra/src/curves/sw6/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         BitIterator, Field, FpParameters,
     },
 };
+use num_traits::One;
 
 pub mod g1;
 pub use self::g1::{G1Affine, G1Projective};

--- a/algebra/src/curves/sw6/tests.rs
+++ b/algebra/src/curves/sw6/tests.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     groups::tests::group_test,
 };
+use num_traits::One;
 
 #[test]
 fn test_g1_projective_curve() {

--- a/algebra/src/curves/tests.rs
+++ b/algebra/src/curves/tests.rs
@@ -1,8 +1,9 @@
 use crate::{
     curves::{AffineCurve, ProjectiveCurve},
-    fields::{Field, PrimeField},
+    fields::PrimeField,
 };
 use crate::UniformRand;
+use num_traits::Zero;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 

--- a/algebra/src/fields/bls12_377/fq6.rs
+++ b/algebra/src/fields/bls12_377/fq6.rs
@@ -193,8 +193,9 @@ impl Fp6Parameters for Fq6Parameters {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::fields::Field;
+    
     use crate::UniformRand;
+    use num_traits::{One, Zero};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 

--- a/algebra/src/fields/bls12_377/tests.rs
+++ b/algebra/src/fields/bls12_377/tests.rs
@@ -8,6 +8,7 @@ use crate::{
     },
 };
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::{

--- a/algebra/src/fields/bls12_381/fq12.rs
+++ b/algebra/src/fields/bls12_381/fq12.rs
@@ -210,9 +210,9 @@ mod test {
     use super::*;
     use crate::fields::{
         bls12_381::{fq2::Fq2, fq6::Fq6},
-        Field,
     };
     use crate::UniformRand;
+    use num_traits::{One, Zero};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 

--- a/algebra/src/fields/bls12_381/tests.rs
+++ b/algebra/src/fields/bls12_381/tests.rs
@@ -11,6 +11,7 @@ use crate::{
     },
 };
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::{

--- a/algebra/src/fields/jubjub/tests.rs
+++ b/algebra/src/fields/jubjub/tests.rs
@@ -9,6 +9,7 @@ use crate::{
         PrimeField, SquareRootField,
     },
 };
+use num_traits::{One, Zero};
 use std::str::FromStr;
 
 #[test]

--- a/algebra/src/fields/mod.rs
+++ b/algebra/src/fields/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     UniformRand,
 };
+use num_traits::{One, Zero};
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
@@ -64,9 +65,11 @@ pub trait Field:
     + Sync
     + 'static
     + Eq
+    + One
     + Ord
     + Neg<Output = Self>
     + UniformRand
+    + Zero
     + Sized
     + Hash
     + From<u128>
@@ -75,26 +78,16 @@ pub trait Field:
     + From<u16>
     + From<u8>
     + for<'a> Add<&'a Self, Output = Self>
+    + Add<Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> Mul<&'a Self, Output = Self>
+    + Mul<Self, Output = Self>
     + for<'a> Div<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>
     + for<'a> MulAssign<&'a Self>
     + for<'a> DivAssign<&'a Self>
 {
-    /// Returns the zero element of the field, the additive identity.
-    fn zero() -> Self;
-
-    /// Returns true if and only if `self == Self::zero()`.
-    fn is_zero(&self) -> bool;
-
-    /// Returns the one element of the field, a field generator.
-    fn one() -> Self;
-
-    /// Returns true if and only if `self == Self::one()`.
-    fn is_one(&self) -> bool;
-
     /// Returns the characteristic of the field.
     fn characteristic<'a>() -> &'a [u64];
 

--- a/algebra/src/fields/mod.rs
+++ b/algebra/src/fields/mod.rs
@@ -77,11 +77,11 @@ pub trait Field:
     + From<u32>
     + From<u16>
     + From<u8>
-    + for<'a> Add<&'a Self, Output = Self>
     + Add<Self, Output = Self>
+    + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
-    + for<'a> Mul<&'a Self, Output = Self>
     + Mul<Self, Output = Self>
+    + for<'a> Mul<&'a Self, Output = Self>
     + for<'a> Div<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>
@@ -339,7 +339,7 @@ pub fn batch_inversion<F: Field>(v: &mut [F]) {
         .zip(prod.into_iter().rev().skip(1).chain(Some(F::one())))
     {
         // tmp := tmp * g.z; g.z := tmp * s = 1/z
-        let newtmp = tmp * &f;
+        let newtmp = tmp * *f;
         *f = tmp * &s;
         tmp = newtmp;
     }

--- a/algebra/src/fields/models/fp12_2over3over2.rs
+++ b/algebra/src/fields/models/fp12_2over3over2.rs
@@ -1,5 +1,6 @@
 use rand::{Rng, distributions::{Standard, Distribution}};
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use std::{
     cmp::Ordering,
     io::{Read, Result as IoResult, Write},
@@ -216,23 +217,26 @@ impl<P: Fp12Parameters> Distribution<Fp12<P>> for Standard {
     }
 }
 
-impl<P: Fp12Parameters> Field for Fp12<P> {
+impl<P: Fp12Parameters> Zero for Fp12<P> {
     fn zero() -> Self {
         Self::new(Fp6::zero(), Fp6::zero())
-    }
-
-    fn one() -> Self {
-        Self::new(Fp6::one(), Fp6::zero())
     }
 
     fn is_zero(&self) -> bool {
         self.c0.is_zero() && self.c1.is_zero()
     }
+}
 
+impl<P: Fp12Parameters> One for Fp12<P> {
+    fn one() -> Self {
+        Self::new(Fp6::one(), Fp6::zero())
+    }
     fn is_one(&self) -> bool {
         self.c0.is_one() && self.c1.is_zero()
     }
+}
 
+impl<P: Fp12Parameters> Field for Fp12<P> {
     #[inline]
     fn characteristic<'a>() -> &'a [u64] {
         Fp6::<P::Fp6Params>::characteristic()

--- a/algebra/src/fields/models/fp2.rs
+++ b/algebra/src/fields/models/fp2.rs
@@ -1,4 +1,5 @@
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -73,7 +74,7 @@ impl<P: Fp2Parameters> Fp2<P> {
     }
 }
 
-impl<P: Fp2Parameters> Field for Fp2<P> {
+impl<P: Fp2Parameters> Zero for Fp2<P> {
     fn zero() -> Self {
         Fp2::new(P::Fp::zero(), P::Fp::zero())
     }
@@ -81,7 +82,9 @@ impl<P: Fp2Parameters> Field for Fp2<P> {
     fn is_zero(&self) -> bool {
         self.c0.is_zero() && self.c1.is_zero()
     }
+}
 
+impl<P: Fp2Parameters> One for Fp2<P> {
     fn one() -> Self {
         Fp2::new(P::Fp::one(), P::Fp::zero())
     }
@@ -89,7 +92,9 @@ impl<P: Fp2Parameters> Field for Fp2<P> {
     fn is_one(&self) -> bool {
         self.c0.is_one() && self.c1.is_zero()
     }
+}
 
+impl<P: Fp2Parameters> Field for Fp2<P> {
     #[inline]
     fn characteristic<'a>() -> &'a [u64] {
         P::Fp::characteristic()

--- a/algebra/src/fields/models/fp3.rs
+++ b/algebra/src/fields/models/fp3.rs
@@ -1,4 +1,5 @@
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -91,7 +92,7 @@ impl<P: Fp3Parameters> Fp3<P> {
     }
 }
 
-impl<P: Fp3Parameters> Field for Fp3<P> {
+impl<P: Fp3Parameters> Zero for Fp3<P> {
     fn zero() -> Self {
         Fp3 {
             c0:          P::Fp::zero(),
@@ -104,7 +105,9 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
     fn is_zero(&self) -> bool {
         self.c0.is_zero() && self.c1.is_zero() && self.c2.is_zero()
     }
+}
 
+impl<P: Fp3Parameters> One for Fp3<P> {
     fn one() -> Self {
         Fp3 {
             c0:          P::Fp::one(),
@@ -117,7 +120,9 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
     fn is_one(&self) -> bool {
         self.c0.is_one() && self.c1.is_zero() && self.c2.is_zero()
     }
+}
 
+impl<P: Fp3Parameters> Field for Fp3<P> {
     #[inline]
     fn characteristic<'a>() -> &'a [u64] {
         P::Fp::characteristic()

--- a/algebra/src/fields/models/fp6_2over3.rs
+++ b/algebra/src/fields/models/fp6_2over3.rs
@@ -1,4 +1,5 @@
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -99,7 +100,7 @@ impl<P: Fp6Parameters> Fp6<P> {
     }
 }
 
-impl<P: Fp6Parameters> Field for Fp6<P> {
+impl<P: Fp6Parameters> Zero for Fp6<P> {
     fn zero() -> Self {
         Fp6 {
             c0:          Fp3::zero(),
@@ -111,7 +112,9 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     fn is_zero(&self) -> bool {
         self.c0.is_zero() && self.c1.is_zero()
     }
+}
 
+impl<P: Fp6Parameters> One for Fp6<P> {
     fn one() -> Self {
         Fp6 {
             c0:          Fp3::one(),
@@ -123,7 +126,9 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     fn is_one(&self) -> bool {
         self.c0.is_one() && self.c1.is_zero()
     }
+}
 
+impl<P: Fp6Parameters> Field for Fp6<P> {
     #[inline]
     fn characteristic<'a>() -> &'a [u64] {
         Fp3::<P::Fp3Params>::characteristic()

--- a/algebra/src/fields/models/fp6_3over2.rs
+++ b/algebra/src/fields/models/fp6_3over2.rs
@@ -1,4 +1,5 @@
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -144,7 +145,7 @@ impl<P: Fp6Parameters> Fp6<P> {
     }
 }
 
-impl<P: Fp6Parameters> Field for Fp6<P> {
+impl<P: Fp6Parameters> Zero for Fp6<P> {
     fn zero() -> Self {
         Self::new(Fp2::zero(), Fp2::zero(), Fp2::zero())
     }
@@ -152,7 +153,9 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     fn is_zero(&self) -> bool {
         self.c0.is_zero() && self.c1.is_zero() && self.c2.is_zero()
     }
+}
 
+impl<P: Fp6Parameters> One for Fp6<P> {
     fn one() -> Self {
         Self::new(Fp2::one(), Fp2::zero(), Fp2::zero())
     }
@@ -160,7 +163,9 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     fn is_one(&self) -> bool {
         self.c0.is_one() && self.c1.is_zero() && self.c2.is_zero()
     }
+}
 
+impl<P: Fp6Parameters> Field for Fp6<P> {
     #[inline]
     fn characteristic<'a>() -> &'a [u64] {
         Fp2::<P::Fp2Params>::characteristic()

--- a/algebra/src/fields/models/fp_256.rs
+++ b/algebra/src/fields/models/fp_256.rs
@@ -1,3 +1,4 @@
+use num_traits::{One, Zero};
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Display, Formatter, Result as FmtResult},
@@ -105,7 +106,7 @@ impl<P: Fp256Parameters> Fp256<P> {
     }
 }
 
-impl<P: Fp256Parameters> Field for Fp256<P> {
+impl<P: Fp256Parameters> Zero for Fp256<P> {
     #[inline]
     fn zero() -> Self {
         Fp256::<P>(BigInteger::from(0), PhantomData)
@@ -115,7 +116,21 @@ impl<P: Fp256Parameters> Field for Fp256<P> {
     fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
+}
 
+impl<P: Fp256Parameters> One for Fp256<P> {
+    #[inline]
+    fn one() -> Self {
+        Fp256::<P>(P::R, PhantomData)
+    }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        self == &Self::one()
+    }
+}
+
+impl<P: Fp256Parameters> Field for Fp256<P> {
     #[inline]
     fn double(&self) -> Self {
         let mut temp = *self;
@@ -130,16 +145,6 @@ impl<P: Fp256Parameters> Field for Fp256<P> {
         // However, it may need to be reduced.
         self.reduce();
         self
-    }
-
-    #[inline]
-    fn one() -> Self {
-        Fp256::<P>(P::R, PhantomData)
-    }
-
-    #[inline]
-    fn is_one(&self) -> bool {
-        self == &Self::one()
     }
 
     #[inline]

--- a/algebra/src/fields/models/fp_320.rs
+++ b/algebra/src/fields/models/fp_320.rs
@@ -1,3 +1,4 @@
+use num_traits::{One, Zero};
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Display, Formatter, Result as FmtResult},
@@ -121,7 +122,7 @@ impl<P: Fp320Parameters> Fp320<P> {
     }
 }
 
-impl<P: Fp320Parameters> Field for Fp320<P> {
+impl<P: Fp320Parameters> Zero for Fp320<P> {
     #[inline]
     fn zero() -> Self {
         Fp320::<P>(BigInteger::from(0), PhantomData)
@@ -131,7 +132,21 @@ impl<P: Fp320Parameters> Field for Fp320<P> {
     fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
+}
 
+impl<P: Fp320Parameters> One for Fp320<P> {
+    #[inline]
+    fn one() -> Self {
+        Fp320::<P>(P::R, PhantomData)
+    }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.0 == P::R
+    }
+}
+
+impl<P: Fp320Parameters> Field for Fp320<P> {
     #[inline]
     fn double(&self) -> Self {
         let mut temp = *self;
@@ -146,16 +161,6 @@ impl<P: Fp320Parameters> Field for Fp320<P> {
         // However, it may need to be reduced.
         self.reduce();
         self
-    }
-
-    #[inline]
-    fn one() -> Self {
-        Fp320::<P>(P::R, PhantomData)
-    }
-
-    #[inline]
-    fn is_one(&self) -> bool {
-        self.0 == P::R
     }
 
     #[inline]

--- a/algebra/src/fields/models/fp_384.rs
+++ b/algebra/src/fields/models/fp_384.rs
@@ -1,3 +1,4 @@
+use num_traits::{One, Zero};
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Display, Formatter, Result as FmtResult},
@@ -139,7 +140,7 @@ impl<P: Fp384Parameters> Fp384<P> {
     }
 }
 
-impl<P: Fp384Parameters> Field for Fp384<P> {
+impl<P: Fp384Parameters> Zero for Fp384<P> {
     #[inline]
     fn zero() -> Self {
         Fp384::<P>(BigInteger::from(0), PhantomData)
@@ -149,7 +150,21 @@ impl<P: Fp384Parameters> Field for Fp384<P> {
     fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
+}
 
+impl<P: Fp384Parameters> One for Fp384<P> {
+    #[inline]
+    fn one() -> Self {
+        Fp384::<P>(P::R, PhantomData)
+    }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.0 == P::R
+    }
+}
+
+impl<P: Fp384Parameters> Field for Fp384<P> {
     #[inline]
     fn double(&self) -> Self {
         let mut temp = *self;
@@ -164,16 +179,6 @@ impl<P: Fp384Parameters> Field for Fp384<P> {
         // However, it may need to be reduced.
         self.reduce();
         self
-    }
-
-    #[inline]
-    fn one() -> Self {
-        Fp384::<P>(P::R, PhantomData)
-    }
-
-    #[inline]
-    fn is_one(&self) -> bool {
-        self.0 == P::R
     }
 
     #[inline]

--- a/algebra/src/fields/models/fp_768.rs
+++ b/algebra/src/fields/models/fp_768.rs
@@ -1,3 +1,4 @@
+use num_traits::{One, Zero};
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Display, Formatter, Result as FmtResult},
@@ -284,7 +285,7 @@ impl<P: Fp768Parameters> Fp768<P> {
     }
 }
 
-impl<P: Fp768Parameters> Field for Fp768<P> {
+impl<P: Fp768Parameters> Zero for Fp768<P> {
     #[inline]
     fn zero() -> Self {
         Fp768::<P>(BigInteger::from(0), PhantomData)
@@ -294,7 +295,21 @@ impl<P: Fp768Parameters> Field for Fp768<P> {
     fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
+}
 
+impl<P: Fp768Parameters> One for Fp768<P> {
+    #[inline]
+    fn one() -> Self {
+        Fp768::<P>(P::R, PhantomData)
+    }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.0 == P::R
+    }
+}
+
+impl<P: Fp768Parameters> Field for Fp768<P> {
     #[inline]
     fn double(&self) -> Self {
         let mut temp = *self;
@@ -309,16 +324,6 @@ impl<P: Fp768Parameters> Field for Fp768<P> {
         // However, it may need to be reduced.
         self.reduce();
         self
-    }
-
-    #[inline]
-    fn one() -> Self {
-        Fp768::<P>(P::R, PhantomData)
-    }
-
-    #[inline]
-    fn is_one(&self) -> bool {
-        self.0 == P::R
     }
 
     #[inline]

--- a/algebra/src/fields/models/fp_832.rs
+++ b/algebra/src/fields/models/fp_832.rs
@@ -3,6 +3,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
+use num_traits::{One, Zero};
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Display, Formatter, Result as FmtResult},
@@ -315,7 +316,7 @@ impl<P: Fp832Parameters> Fp832<P> {
     }
 }
 
-impl<P: Fp832Parameters> Field for Fp832<P> {
+impl<P: Fp832Parameters> Zero for Fp832<P> {
     #[inline]
     fn zero() -> Self {
         Fp832::<P>(BigInteger::from(0), PhantomData)
@@ -325,7 +326,21 @@ impl<P: Fp832Parameters> Field for Fp832<P> {
     fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
+}
 
+impl<P: Fp832Parameters> One for Fp832<P> {
+    #[inline]
+    fn one() -> Self {
+        Fp832::<P>(P::R, PhantomData)
+    }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.0 == P::R
+    }
+}
+
+impl<P: Fp832Parameters> Field for Fp832<P> {
     #[inline]
     fn double(&self) -> Self {
         let mut temp = *self;
@@ -340,16 +355,6 @@ impl<P: Fp832Parameters> Field for Fp832<P> {
         // However, it may need to be reduced.
         self.reduce();
         self
-    }
-
-    #[inline]
-    fn one() -> Self {
-        Fp832::<P>(P::R, PhantomData)
-    }
-
-    #[inline]
-    fn is_one(&self) -> bool {
-        self.0 == P::R
     }
 
     #[inline]

--- a/algebra/src/groups/mod.rs
+++ b/algebra/src/groups/mod.rs
@@ -32,6 +32,7 @@ pub trait Group:
     + UniformRand
     + Zero
     + Add<Self, Output = Self>
+    + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>

--- a/algebra/src/groups/mod.rs
+++ b/algebra/src/groups/mod.rs
@@ -1,5 +1,6 @@
 use crate::BitIterator;
 use crate::UniformRand;
+use num_traits::Zero;
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
@@ -29,18 +30,13 @@ pub trait Group:
     + Hash
     + Neg<Output = Self>
     + UniformRand
-    + for<'a> Add<&'a Self, Output = Self>
+    + Zero
+    + Add<Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>
 {
     type ScalarField: PrimeField + Into<<Self::ScalarField as PrimeField>::BigInt>;
-
-    /// Returns the additive identity.
-    fn zero() -> Self;
-
-    /// Returns `self == zero`.
-    fn is_zero(&self) -> bool;
 
     /// Returns `self + self`.
     #[must_use]

--- a/algebra/src/groups/tests.rs
+++ b/algebra/src/groups/tests.rs
@@ -1,6 +1,6 @@
 use super::Group;
-use crate::fields::Field;
 use crate::UniformRand;
+use num_traits::{One, Zero};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 

--- a/algebra/src/msm/variable_base.rs
+++ b/algebra/src/msm/variable_base.rs
@@ -1,8 +1,8 @@
 use crate::{
-    AffineCurve, BigInteger, Field, FpParameters, PrimeField,
+    AffineCurve, BigInteger, FpParameters, PrimeField,
     ProjectiveCurve,
 };
-#[cfg(feature = "parallel")]
+use num_traits::{One, Zero};
 use rayon::prelude::*;
 
 pub struct VariableBaseMSM;
@@ -84,7 +84,7 @@ impl VariableBaseMSM {
                 total.double_in_place();
             }
             total
-        }) + lowest
+        }) + *lowest
     }
 
     pub fn multi_scalar_mul<G: AffineCurve>(
@@ -134,7 +134,6 @@ mod test {
 
         assert_eq!(naive.into_affine(), fast.into_affine());
     }
-
 
     #[test]
     fn test_with_bls12_unequal_numbers() {

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -32,6 +32,7 @@ bench-utils = { path = "../bench-utils" }
 digest = "0.7"
 blake2 = "0.7"
 
+num-traits = { version = "0.2.11" }
 rand = { version = "0.7" }
 derivative = "1"
 rayon = "1"

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -372,6 +372,7 @@ mod test {
         merkle_tree::*,
     };
     use algebra::curves::jubjub::JubJubAffine as JubJub;
+    use num_traits::Zero;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
@@ -419,7 +420,6 @@ mod test {
     }
 
     fn bad_merkle_tree_verify<L: ToBytes + Clone + Eq>(leaves: &[L]) -> () {
-        use algebra::groups::Group;
         let mut rng = XorShiftRng::seed_from_u64(13423423u64);
 
         let crh_parameters = Rc::new(H::setup(&mut rng).unwrap());

--- a/crypto-primitives/src/nizk/mod.rs
+++ b/crypto-primitives/src/nizk/mod.rs
@@ -59,7 +59,8 @@ mod test {
     #[test]
     fn test_gm17() {
         use crate::nizk::{gm17::Gm17, NIZK};
-        use algebra::{curves::bls12_381::Bls12_381, fields::bls12_381::Fr, Field};
+        use algebra::{curves::bls12_381::Bls12_381, fields::bls12_381::Fr};
+        use num_traits::One;
         use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
 
         #[derive(Copy, Clone)]

--- a/crypto-primitives/src/signature/schnorr/mod.rs
+++ b/crypto-primitives/src/signature/schnorr/mod.rs
@@ -6,6 +6,7 @@ use algebra::{
     to_bytes, ToConstraintField, UniformRand,
 };
 use digest::Digest;
+use num_traits::{One, Zero};
 use rand::Rng;
 use std::{
     hash::Hash,

--- a/ff-fft/Cargo.toml
+++ b/ff-fft/Cargo.toml
@@ -20,6 +20,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
+num-traits = { version = "0.2.11" }
 rand = { version = "0.7" }
 algebra = { path = "../algebra", features = [ "parallel" ] }
 rayon = { version = "1" }

--- a/ff-fft/src/domain.rs
+++ b/ff-fft/src/domain.rs
@@ -210,7 +210,7 @@ impl<F: PrimeField> EvaluationDomain<F> {
 
             batch_inversion(u.as_mut_slice());
             u.par_iter_mut().zip(ls).for_each(|(tau_minus_r, l)| {
-                *tau_minus_r = l * tau_minus_r;
+                *tau_minus_r = l * *tau_minus_r;
             });
             u
         }
@@ -223,7 +223,8 @@ impl<F: PrimeField> EvaluationDomain<F> {
     }
 
     /// This evaluates the vanishing polynomial for this domain at tau.
-    /// For multiplicative subgroups, this polynomial is `z(X) = X^self.size - 1`.
+    /// For multiplicative subgroups, this polynomial is `z(X) = X^self.size -
+    /// 1`.
     pub fn evaluate_vanishing_polynomial(&self, tau: F) -> F {
         tau.pow(&[self.size]) - &F::one()
     }

--- a/ff-fft/src/domain.rs
+++ b/ff-fft/src/domain.rs
@@ -42,7 +42,6 @@ impl<F: PrimeField> fmt::Debug for EvaluationDomain<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Multiplicative subgroup of size {}", self.size)
     }
-
 }
 
 impl<F: PrimeField> EvaluationDomain<F> {
@@ -58,7 +57,6 @@ impl<F: PrimeField> EvaluationDomain<F> {
         }
         t
     }
-
 
     /// Construct a domain that is large enough for evaluations of a polynomial
     /// having `num_coeffs` coefficients.
@@ -442,6 +440,7 @@ mod tests {
     use algebra::Field;
     use algebra::fields::bls12_381::fr::Fr;
     use rand::{Rng, thread_rng};
+    use num_traits::Zero;
 
     #[test]
     fn vanishing_polynomial_evaluation() {

--- a/ff-fft/src/polynomial/dense.rs
+++ b/ff-fft/src/polynomial/dense.rs
@@ -181,7 +181,6 @@ impl<'a, 'b, F: Field> AddAssign<&'a DensePolynomial<F>> for DensePolynomial<F> 
             self.coeffs.truncate(0);
             self.coeffs.extend_from_slice(&other.coeffs);
         } else if other.is_zero() {
-
         } else if self.degree() >= other.degree() {
             for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
                 *a += b
@@ -298,7 +297,6 @@ impl<'a, 'b, F: Field> SubAssign<&'a DensePolynomial<F>> for DensePolynomial<F> 
                 self.coeffs[i] -= coeff;
             }
         } else if other.is_zero() {
-
         } else if self.degree() >= other.degree() {
             for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
                 *a -= b
@@ -351,6 +349,7 @@ mod tests {
     use crate::polynomial::*;
     use algebra::fields::{bls12_381::fr::Fr, Field};
     use algebra::UniformRand; 
+    use num_traits::{One, Zero};
     use rand::thread_rng;
 
     #[test]

--- a/ff-fft/src/polynomial/mod.rs
+++ b/ff-fft/src/polynomial/mod.rs
@@ -34,7 +34,6 @@ impl<'a, F: 'a + Field> From<&'a DensePolynomial<F>> for DenseOrSparsePolynomial
     }
 }
 
-
 impl<F: Field> From<SparsePolynomial<F>> for DenseOrSparsePolynomial<'_, F> {
     fn from(other: SparsePolynomial<F>) -> Self {
         SPolynomial(Cow::Owned(other))
@@ -46,7 +45,6 @@ impl<'a, F: Field> From<&'a SparsePolynomial<F>> for DenseOrSparsePolynomial<'a,
         SPolynomial(Cow::Borrowed(other))
     }
 }
-
 
 impl<F: Field> Into<DensePolynomial<F>> for DenseOrSparsePolynomial<'_, F> {
     fn into(self) -> DensePolynomial<F> {

--- a/ff-fft/src/polynomial/sparse.rs
+++ b/ff-fft/src/polynomial/sparse.rs
@@ -129,7 +129,7 @@ impl<F: Field> Into<DensePolynomial<F>> for SparsePolynomial<F> {
 mod tests {
     use crate::{EvaluationDomain, DensePolynomial, SparsePolynomial};
     use algebra::fields::bls12_381::fr::Fr;
-    use algebra::Field;
+    use num_traits::One;
 
     #[test]
     fn evaluate_over_domain() {

--- a/gm17/Cargo.toml
+++ b/gm17/Cargo.toml
@@ -27,6 +27,7 @@ ff-fft = { path = "../ff-fft" }
 r1cs-core = { path = "../r1cs-core" }
 bench-utils = { path = "../bench-utils" }
 
+num-traits = { version = "0.2.11" }
 rand = { version = "0.7" }
 rayon = { version = "1" }
 smallvec = { version = "0.6" }

--- a/gm17/examples/snark-scalability/gm17.rs
+++ b/gm17/examples/snark-scalability/gm17.rs
@@ -27,6 +27,7 @@
 
 use csv;
 
+use num_traits::One;
 // For randomness (during paramgen and proof generation)
 use rand::thread_rng;
 
@@ -39,7 +40,7 @@ use std::{
 // Bring in some tools for using pairing-friendly curves
 // We're going to use the BLS12-377 pairing-friendly elliptic curve.
 use algebra::curves::bls12_377::Bls12_377;
-use algebra::fields::{bls12_377::fr::Fr, Field};
+use algebra::fields::bls12_377::fr::Fr;
 
 // We're going to use the Groth-Maller 17 proving system.
 use gm17::{

--- a/gm17/src/generator.rs
+++ b/gm17/src/generator.rs
@@ -4,6 +4,7 @@ use algebra::{
     AffineCurve, Field, PairingEngine, PrimeField, ProjectiveCurve,
 };
 
+use num_traits::{One, Zero};
 use rand::Rng;
 use rayon::prelude::*;
 use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
@@ -297,8 +298,6 @@ where
         &a,
     );
     end_timer!(b_time);
-
-
 
     end_timer!(proving_key_time);
 

--- a/gm17/src/prover.rs
+++ b/gm17/src/prover.rs
@@ -312,7 +312,7 @@ where
     let c2_inputs_acc = VariableBaseMSM::multi_scalar_mul(c2_inputs_source, &input_assignment);
     let c2_aux_acc = VariableBaseMSM::multi_scalar_mul(c2_aux_source, &aux_assignment);
 
-    let c2_acc = c2_inputs_acc + &c2_aux_acc;
+    let c2_acc = c2_inputs_acc + c2_aux_acc;
     end_timer!(c2_acc_time);
 
     // Compute G
@@ -322,7 +322,7 @@ where
     let g_inputs_acc = VariableBaseMSM::multi_scalar_mul(g_inputs_source, &h_input);
     let g_aux_acc = VariableBaseMSM::multi_scalar_mul(g_aux_source, &h_aux);
 
-    let g_acc = g_inputs_acc + &g_aux_acc;
+    let g_acc = g_inputs_acc + g_aux_acc;
     end_timer!(g_acc_time);
 
     let r2_g_gamma2_z2 = params.get_g_gamma2_z2()?.mul(r2);

--- a/gm17/src/prover.rs
+++ b/gm17/src/prover.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 use rayon::prelude::*;
 
 use algebra::{
-    UniformRand, msm::VariableBaseMSM, AffineCurve, Field, PairingEngine, PrimeField, ProjectiveCurve,
+    UniformRand, msm::VariableBaseMSM, AffineCurve, PairingEngine, PrimeField, ProjectiveCurve,
 };
 
 use crate::{Parameters, Proof};
@@ -10,6 +10,7 @@ use crate::r1cs_to_sap::R1CStoSAP;
 
 use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 
+use num_traits::{One, Zero};
 use smallvec::SmallVec;
 
 use std::{

--- a/gm17/src/r1cs_to_sap.rs
+++ b/gm17/src/r1cs_to_sap.rs
@@ -228,7 +228,7 @@ impl R1CStoSAP {
             tmp.double_in_place();
 
             let assignment = full_input_assignment[extra_var_offset2 + i];
-            c[extra_constr_offset + 2 * i - 1] = tmp + assignment;
+            c[extra_constr_offset + 2 * i - 1] = tmp + &assignment;
             c[extra_constr_offset + 2 * i] = assignment;
         }
 

--- a/gm17/src/r1cs_to_sap.rs
+++ b/gm17/src/r1cs_to_sap.rs
@@ -2,6 +2,7 @@ use ff_fft::EvaluationDomain;
 use algebra::{Field, PairingEngine};
 
 use crate::{generator::KeypairAssembly, prover::ProvingAssignment};
+use num_traits::{One, Zero};
 use r1cs_core::{Index, SynthesisError};
 
 use rayon::prelude::*;
@@ -227,7 +228,7 @@ impl R1CStoSAP {
             tmp.double_in_place();
 
             let assignment = full_input_assignment[extra_var_offset2 + i];
-            c[extra_constr_offset + 2 * i - 1] = tmp + &assignment;
+            c[extra_constr_offset + 2 * i - 1] = tmp + assignment;
             c[extra_constr_offset + 2 * i] = assignment;
         }
 

--- a/gm17/src/test.rs
+++ b/gm17/src/test.rs
@@ -1,5 +1,7 @@
-use algebra::Field;
+use algebra::fields::Field;
+use num_traits::Zero;
 use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+
 struct MySillyCircuit<F: Field> {
     a: Option<F>,
     b: Option<F>,
@@ -79,7 +81,7 @@ mod sw6 {
 
     use rand::thread_rng;
 
-    use algebra::{UniformRand, curves::sw6::SW6, fields::sw6::Fr as SW6Fr, Field};
+    use algebra::{UniformRand, curves::sw6::SW6, fields::sw6::Fr as SW6Fr};
 
     #[test]
     fn prove_and_verify() {

--- a/gm17/src/verifier.rs
+++ b/gm17/src/verifier.rs
@@ -1,4 +1,5 @@
-use algebra::{AffineCurve, Field, PairingCurve, PairingEngine, PrimeField, ProjectiveCurve};
+use algebra::{AffineCurve, PairingCurve, PairingEngine, PrimeField, ProjectiveCurve};
+use num_traits::One;
 
 use super::{PreparedVerifyingKey, Proof, VerifyingKey};
 

--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -28,6 +28,7 @@ ff-fft = { path = "../ff-fft" }
 r1cs-core = { path = "../r1cs-core" }
 bench-utils = { path = "../bench-utils" }
 
+num-traits = { version = "0.2.11" }
 rand = { version = "0.7" }
 rayon = { version = "1" }
 smallvec = { version = "0.6" }

--- a/groth16/examples/snark-scalability/groth16.rs
+++ b/groth16/examples/snark-scalability/groth16.rs
@@ -40,7 +40,7 @@ use std::{
 // We're going to use the BLS12-377 pairing-friendly elliptic curve.
 use algebra::{
     curves::bls12_377::Bls12_377,
-    fields::{bls12_377::fr::Fr, Field},
+    fields::bls12_377::fr::Fr,
 };
 
 // We're going to use the Groth 16 proving system.
@@ -48,6 +48,7 @@ use groth16::{
     create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
 };
 
+use num_traits::One;
 use std::{env, fs::OpenOptions, path::PathBuf, process};
 
 mod constraints;

--- a/groth16/src/generator.rs
+++ b/groth16/src/generator.rs
@@ -4,6 +4,7 @@ use algebra::{
 };
 use ff_fft::EvaluationDomain;
 
+use num_traits::{One, Zero};
 use r1cs_core::{
     ConstraintSynthesizer, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable,
 };

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -2,11 +2,12 @@ use rand::Rng;
 use rayon::prelude::*;
 
 use algebra::{
-    groups::Group, msm::VariableBaseMSM, AffineCurve, Field, PairingEngine, PrimeField,
+    groups::Group, msm::VariableBaseMSM, AffineCurve, PairingEngine, PrimeField,
     ProjectiveCurve, UniformRand,
 };
 
 use crate::{r1cs_to_qap::R1CStoQAP, Parameters, Proof};
+use num_traits::{One, Zero};
 
 use r1cs_core::{
     ConstraintSynthesizer, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable,

--- a/groth16/src/r1cs_to_qap.rs
+++ b/groth16/src/r1cs_to_qap.rs
@@ -1,7 +1,8 @@
-use algebra::{Field, PairingEngine};
+use algebra::PairingEngine;
 use ff_fft::EvaluationDomain;
 
 use crate::{generator::KeypairAssembly, prover::ProvingAssignment};
+use num_traits::{One, Zero};
 use r1cs_core::{Index, SynthesisError};
 
 use rayon::prelude::*;

--- a/groth16/src/test.rs
+++ b/groth16/src/test.rs
@@ -82,9 +82,9 @@ mod sw6 {
         create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     };
 
+    use algebra::{curves::sw6::SW6, fields::sw6::Fr as SW6Fr, UniformRand};
+    use num_traits::Zero;
     use rand::thread_rng;
-
-    use algebra::{curves::sw6::SW6, fields::sw6::Fr as SW6Fr, Field, UniformRand};
 
     #[test]
     fn prove_and_verify() {

--- a/r1cs-std/Cargo.toml
+++ b/r1cs-std/Cargo.toml
@@ -25,6 +25,7 @@ edition = "2018"
 algebra = { path = "../algebra" }
 r1cs-core = { path = "../r1cs-core" }
 derivative = "1"
+num-traits = { version = "0.2.11" }
 radix_trie = "0.1"
 
 [dev-dependencies]

--- a/r1cs-std/src/bits/boolean.rs
+++ b/r1cs-std/src/bits/boolean.rs
@@ -832,13 +832,12 @@ impl<ConstraintF: Field> CondSelectGadget<ConstraintF> for Boolean {
     }
 }
 
-    
-
 #[cfg(test)]
 mod test {
     use super::{AllocatedBit, Boolean};
     use crate::{prelude::*, test_constraint_system::TestConstraintSystem};
     use algebra::{fields::bls12_381::Fr, BitIterator, Field, PrimeField, UniformRand};
+    use num_traits::{One, Zero};
     use r1cs_core::ConstraintSystem;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
@@ -903,8 +902,8 @@ mod test {
                 assert_eq!(c.value.unwrap(), *a_val | *b_val);
 
                 assert!(cs.is_satisfied());
-                assert!(cs.get("a/boolean") == if *a_val { Field::one() } else { Field::zero() });
-                assert!(cs.get("b/boolean") == if *b_val { Field::one() } else { Field::zero() });
+                assert!(cs.get("a/boolean") == if *a_val { Fr::one() } else { Fr::zero() });
+                assert!(cs.get("b/boolean") == if *b_val { Fr::one() } else { Fr::zero() });
             }
         }
     }
@@ -920,14 +919,14 @@ mod test {
                 assert_eq!(c.value.unwrap(), *a_val & *b_val);
 
                 assert!(cs.is_satisfied());
-                assert!(cs.get("a/boolean") == if *a_val { Field::one() } else { Field::zero() });
-                assert!(cs.get("b/boolean") == if *b_val { Field::one() } else { Field::zero() });
+                assert!(cs.get("a/boolean") == if *a_val { Fr::one() } else { Fr::zero() });
+                assert!(cs.get("b/boolean") == if *b_val { Fr::one() } else { Fr::zero() });
                 assert!(
                     cs.get("and result")
                         == if *a_val & *b_val {
-                            Field::one()
+                            Fr::one()
                         } else {
-                            Field::zero()
+                            Fr::zero()
                         }
                 );
 
@@ -935,9 +934,9 @@ mod test {
                 cs.set(
                     "and result",
                     if *a_val & *b_val {
-                        Field::zero()
+                        Fr::zero()
                     } else {
-                        Field::one()
+                        Fr::one()
                     },
                 );
                 assert!(!cs.is_satisfied());
@@ -956,14 +955,14 @@ mod test {
                 assert_eq!(c.value.unwrap(), *a_val & !*b_val);
 
                 assert!(cs.is_satisfied());
-                assert!(cs.get("a/boolean") == if *a_val { Field::one() } else { Field::zero() });
-                assert!(cs.get("b/boolean") == if *b_val { Field::one() } else { Field::zero() });
+                assert!(cs.get("a/boolean") == if *a_val { Fr::one() } else { Fr::zero() });
+                assert!(cs.get("b/boolean") == if *b_val { Fr::one() } else { Fr::zero() });
                 assert!(
                     cs.get("and not result")
                         == if *a_val & !*b_val {
-                            Field::one()
+                            Fr::one()
                         } else {
-                            Field::zero()
+                            Fr::zero()
                         }
                 );
 
@@ -971,9 +970,9 @@ mod test {
                 cs.set(
                     "and not result",
                     if *a_val & !*b_val {
-                        Field::zero()
+                        Fr::zero()
                     } else {
-                        Field::one()
+                        Fr::one()
                     },
                 );
                 assert!(!cs.is_satisfied());
@@ -992,14 +991,14 @@ mod test {
                 assert_eq!(c.value.unwrap(), !*a_val & !*b_val);
 
                 assert!(cs.is_satisfied());
-                assert!(cs.get("a/boolean") == if *a_val { Field::one() } else { Field::zero() });
-                assert!(cs.get("b/boolean") == if *b_val { Field::one() } else { Field::zero() });
+                assert!(cs.get("a/boolean") == if *a_val { Fr::one() } else { Fr::zero() });
+                assert!(cs.get("b/boolean") == if *b_val { Fr::one() } else { Fr::zero() });
                 assert!(
                     cs.get("nor result")
                         == if !*a_val & !*b_val {
-                            Field::one()
+                            Fr::one()
                         } else {
-                            Field::zero()
+                            Fr::zero()
                         }
                 );
 
@@ -1007,9 +1006,9 @@ mod test {
                 cs.set(
                     "nor result",
                     if !*a_val & !*b_val {
-                        Field::zero()
+                        Fr::zero()
                     } else {
-                        Field::one()
+                        Fr::one()
                     },
                 );
                 assert!(!cs.is_satisfied());
@@ -1235,7 +1234,7 @@ mod test {
                         OperandType::AllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::zero());
+                        assert!(cs.get("xor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1243,7 +1242,7 @@ mod test {
                         OperandType::AllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::one());
+                        assert!(cs.get("xor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
                     (
@@ -1251,7 +1250,7 @@ mod test {
                         OperandType::NegatedAllocatedTrue,
                         Boolean::Not(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::zero());
+                        assert!(cs.get("xor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1259,7 +1258,7 @@ mod test {
                         OperandType::NegatedAllocatedFalse,
                         Boolean::Not(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::one());
+                        assert!(cs.get("xor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
 
@@ -1270,7 +1269,7 @@ mod test {
                         OperandType::AllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::one());
+                        assert!(cs.get("xor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
                     (
@@ -1278,7 +1277,7 @@ mod test {
                         OperandType::AllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::zero());
+                        assert!(cs.get("xor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1286,7 +1285,7 @@ mod test {
                         OperandType::NegatedAllocatedTrue,
                         Boolean::Not(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::one());
+                        assert!(cs.get("xor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
                     (
@@ -1294,7 +1293,7 @@ mod test {
                         OperandType::NegatedAllocatedFalse,
                         Boolean::Not(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::zero());
+                        assert!(cs.get("xor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
 
@@ -1305,7 +1304,7 @@ mod test {
                         OperandType::AllocatedTrue,
                         Boolean::Not(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::zero());
+                        assert!(cs.get("xor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1313,7 +1312,7 @@ mod test {
                         OperandType::AllocatedFalse,
                         Boolean::Not(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::one());
+                        assert!(cs.get("xor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
                     (
@@ -1321,7 +1320,7 @@ mod test {
                         OperandType::NegatedAllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::zero());
+                        assert!(cs.get("xor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1329,7 +1328,7 @@ mod test {
                         OperandType::NegatedAllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::one());
+                        assert!(cs.get("xor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
 
@@ -1340,7 +1339,7 @@ mod test {
                         OperandType::AllocatedTrue,
                         Boolean::Not(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::one());
+                        assert!(cs.get("xor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
                     (
@@ -1348,7 +1347,7 @@ mod test {
                         OperandType::AllocatedFalse,
                         Boolean::Not(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::zero());
+                        assert!(cs.get("xor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1356,7 +1355,7 @@ mod test {
                         OperandType::NegatedAllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::one());
+                        assert!(cs.get("xor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
                     (
@@ -1364,7 +1363,7 @@ mod test {
                         OperandType::NegatedAllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("xor result") == Field::zero());
+                        assert!(cs.get("xor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
 
@@ -1732,7 +1731,7 @@ mod test {
                         OperandType::AllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and result") == Field::one());
+                        assert!(cs.get("and result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
                     (
@@ -1740,7 +1739,7 @@ mod test {
                         OperandType::AllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and result") == Field::zero());
+                        assert!(cs.get("and result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1748,7 +1747,7 @@ mod test {
                         OperandType::NegatedAllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and not result") == Field::zero());
+                        assert!(cs.get("and not result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1756,7 +1755,7 @@ mod test {
                         OperandType::NegatedAllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and not result") == Field::one());
+                        assert!(cs.get("and not result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
 
@@ -1768,7 +1767,7 @@ mod test {
                         OperandType::AllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and result") == Field::zero());
+                        assert!(cs.get("and result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1776,7 +1775,7 @@ mod test {
                         OperandType::AllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and result") == Field::zero());
+                        assert!(cs.get("and result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1784,7 +1783,7 @@ mod test {
                         OperandType::NegatedAllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and not result") == Field::zero());
+                        assert!(cs.get("and not result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1792,7 +1791,7 @@ mod test {
                         OperandType::NegatedAllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and not result") == Field::zero());
+                        assert!(cs.get("and not result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
 
@@ -1807,7 +1806,7 @@ mod test {
                         OperandType::AllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and not result") == Field::zero());
+                        assert!(cs.get("and not result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1815,7 +1814,7 @@ mod test {
                         OperandType::AllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and not result") == Field::zero());
+                        assert!(cs.get("and not result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1823,7 +1822,7 @@ mod test {
                         OperandType::NegatedAllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("nor result") == Field::zero());
+                        assert!(cs.get("nor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1831,7 +1830,7 @@ mod test {
                         OperandType::NegatedAllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("nor result") == Field::zero());
+                        assert!(cs.get("nor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
 
@@ -1846,7 +1845,7 @@ mod test {
                         OperandType::AllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and not result") == Field::one());
+                        assert!(cs.get("and not result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
                     (
@@ -1854,7 +1853,7 @@ mod test {
                         OperandType::AllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("and not result") == Field::zero());
+                        assert!(cs.get("and not result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1862,7 +1861,7 @@ mod test {
                         OperandType::NegatedAllocatedTrue,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("nor result") == Field::zero());
+                        assert!(cs.get("nor result") == Fr::zero());
                         assert_eq!(v.value, Some(false));
                     },
                     (
@@ -1870,7 +1869,7 @@ mod test {
                         OperandType::NegatedAllocatedFalse,
                         Boolean::Is(ref v),
                     ) => {
-                        assert!(cs.get("nor result") == Field::one());
+                        assert!(cs.get("nor result") == Fr::one());
                         assert_eq!(v.value, Some(true));
                     },
 

--- a/r1cs-std/src/bits/uint32.rs
+++ b/r1cs-std/src/bits/uint32.rs
@@ -344,7 +344,8 @@ impl<ConstraintF: Field> ConditionalEqGadget<ConstraintF> for UInt32 {
 mod test {
     use super::UInt32;
     use crate::{bits::boolean::Boolean, test_constraint_system::TestConstraintSystem};
-    use algebra::fields::{bls12_381::Fr, Field};
+    use algebra::fields::bls12_381::Fr;
+    use num_traits::{One, Zero};
     use r1cs_core::ConstraintSystem;
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
@@ -500,9 +501,9 @@ mod test {
 
             // Flip a bit_gadget and see if the addition constraint still works
             if cs.get("addition/result bit_gadget 0/boolean").is_zero() {
-                cs.set("addition/result bit_gadget 0/boolean", Field::one());
+                cs.set("addition/result bit_gadget 0/boolean", Fr::one());
             } else {
-                cs.set("addition/result bit_gadget 0/boolean", Field::zero());
+                cs.set("addition/result bit_gadget 0/boolean", Fr::zero());
             }
 
             assert!(!cs.is_satisfied());

--- a/r1cs-std/src/fields/fp12.rs
+++ b/r1cs-std/src/fields/fp12.rs
@@ -8,6 +8,7 @@ use algebra::{
     },
     BitIterator, Field, PrimeField,
 };
+use num_traits::One;
 use std::{borrow::Borrow, marker::PhantomData};
 
 use crate::{prelude::*, Assignment};

--- a/r1cs-std/src/groups/curves/short_weierstrass/bls12/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/bls12/mod.rs
@@ -3,6 +3,7 @@ use algebra::{
     fields::Field,
     BitIterator, ProjectiveCurve,
 };
+use num_traits::One;
 use r1cs_core::{ConstraintSystem, SynthesisError};
 
 use crate::{

--- a/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
@@ -5,6 +5,7 @@ use algebra::{
     },
     AffineCurve, BitIterator, Field, PrimeField, ProjectiveCurve,
 };
+use num_traits::{One, Zero};
 use r1cs_core::{ConstraintSystem, SynthesisError};
 use std::{borrow::Borrow, marker::PhantomData, ops::Neg};
 

--- a/r1cs-std/src/groups/curves/twisted_edwards/mod.rs
+++ b/r1cs-std/src/groups/curves/twisted_edwards/mod.rs
@@ -5,6 +5,7 @@ use algebra::{
     },
     BitIterator, Field,
 };
+use num_traits::{One, Zero};
 
 use r1cs_core::{ConstraintSystem, SynthesisError};
 
@@ -38,7 +39,7 @@ pub struct MontgomeryAffineGadget<
 mod montgomery_affine_impl {
     use super::*;
     use crate::Assignment;
-    use algebra::{twisted_edwards_extended::GroupAffine, AffineCurve, Field};
+    use algebra::{twisted_edwards_extended::GroupAffine, Field};
     use std::ops::{AddAssign, MulAssign, SubAssign};
 
     impl<P: TEModelParameters, ConstraintF: Field, F: FieldGadget<P::BaseField, ConstraintF>>

--- a/r1cs-std/src/pairing/mod.rs
+++ b/r1cs-std/src/pairing/mod.rs
@@ -60,6 +60,7 @@ mod test {
     // use rand;
     use crate::test_constraint_system::TestConstraintSystem;
     use algebra::{BitIterator, Field};
+    use num_traits::One;
     use r1cs_core::ConstraintSystem;
 
     #[test]


### PR DESCRIPTION
- contributes to #50,
- depends on #53 and builds on it,
- due ~~to coherence &~~ requirements of `num_traits::{Zero, One}` to implement
  `std::ops::Add<Self, ..>` and (resp.) `std::ops::Mul<Self, ..>`, I've had
  to ~~replace~~ [edit:complement] the afferent `impl<'a, P: ..> (Add|Mul)<&'a Self> for
  Group(Affine|Projective)<P>` ~~by~~ [edit:with] direct implementations on `Self`,
- I did not have to fight the borrow checker for this conversion => I think
  this hints arithmetic operations are called in contexts where the operand
  is owned,
- hence should this end up on a merge track, we may want to open an issue
  to convert the `impl<'a, P:..> (Neg|Sub|..)<&'a Self> for ..<P>` trait
  usage to direct `impl<P:..> (Neg|Sub|..)<Self> for ..<P>`
- ~~the `impl AddAssign for GroupAffine<P>` in
  curves/models/short_weierstrass_jacobian.rs is provided to fit trait
  bounds, and without any guarantee of suitability for any particular purpose~~
- ~~even though I don't think it's used.~~