### PR TITLE
Remove unused / uneeded `Copy` instances in algebra

### DIFF
--- a/algebra/src/curves/bls12_377/g1.rs
+++ b/algebra/src/curves/bls12_377/g1.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct Bls12_377G1Parameters;
 
 impl ModelParameters for Bls12_377G1Parameters {

--- a/algebra/src/curves/bls12_377/g2.rs
+++ b/algebra/src/curves/bls12_377/g2.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct Bls12_377G2Parameters;
 
 impl ModelParameters for Bls12_377G2Parameters {

--- a/algebra/src/curves/bls12_381/g1.rs
+++ b/algebra/src/curves/bls12_381/g1.rs
@@ -31,7 +31,7 @@ impl PairingCurve for G1Affine {
     }
 }
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct Bls12_381G1Parameters;
 
 impl ModelParameters for Bls12_381G1Parameters {

--- a/algebra/src/curves/bls12_381/g2.rs
+++ b/algebra/src/curves/bls12_381/g2.rs
@@ -34,7 +34,7 @@ impl PairingCurve for G2Affine {
     }
 }
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct Bls12_381G2Parameters;
 
 impl ModelParameters for Bls12_381G2Parameters {

--- a/algebra/src/curves/edwards_bls12/mod.rs
+++ b/algebra/src/curves/edwards_bls12/mod.rs
@@ -15,7 +15,7 @@ mod tests;
 pub type EdwardsAffine = GroupAffine<EdwardsParameters>;
 pub type EdwardsProjective = GroupProjective<EdwardsParameters>;
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct EdwardsParameters;
 
 impl ModelParameters for EdwardsParameters {

--- a/algebra/src/curves/edwards_sw6/mod.rs
+++ b/algebra/src/curves/edwards_sw6/mod.rs
@@ -15,7 +15,7 @@ mod tests;
 pub type EdwardsAffine = GroupAffine<EdwardsParameters>;
 pub type EdwardsProjective = GroupProjective<EdwardsParameters>;
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct EdwardsParameters;
 
 impl ModelParameters for EdwardsParameters {

--- a/algebra/src/curves/jubjub/mod.rs
+++ b/algebra/src/curves/jubjub/mod.rs
@@ -49,7 +49,7 @@ const GENERATOR_Y: Fq = field_new!(Fq, BigInteger256([
 /// ```
 /// These parameters and the sage script obtained from:
 /// <https://github.com/zcash/zcash/issues/2230#issuecomment-317182190>
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct JubJubParameters;
 
 impl ModelParameters for JubJubParameters {

--- a/algebra/src/curves/mnt6/g1.rs
+++ b/algebra/src/curves/mnt6/g1.rs
@@ -30,7 +30,7 @@ impl PairingCurve for G1Affine {
     }
 }
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct MNT6G1Parameters;
 
 impl ModelParameters for MNT6G1Parameters {
@@ -93,7 +93,7 @@ pub const G1_GENERATOR_Y: Fq = field_new!(Fq, BigInteger320([
     0x3140fbc3593,
 ]));
 
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct G1Prepared {
     pub x:       Fq,
     pub y:       Fq,

--- a/algebra/src/curves/mnt6/g2.rs
+++ b/algebra/src/curves/mnt6/g2.rs
@@ -32,7 +32,7 @@ impl PairingCurve for G2Affine {
     }
 }
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct MNT6G2Parameters;
 
 impl ModelParameters for MNT6G2Parameters {
@@ -200,7 +200,7 @@ pub(super) struct G2ProjectiveExtended {
     pub(crate) t: Fq3,
 }
 
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct AteDoubleCoefficients {
     pub(crate) c_h:  Fq3,
     pub(crate) c_4c: Fq3,
@@ -208,7 +208,7 @@ pub struct AteDoubleCoefficients {
     pub(crate) c_l:  Fq3,
 }
 
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct AteAdditionCoefficients {
     pub(crate) c_l1: Fq3,
     pub(crate) c_rz: Fq3,

--- a/algebra/src/curves/sw6/g1.rs
+++ b/algebra/src/curves/sw6/g1.rs
@@ -28,7 +28,7 @@ impl PairingCurve for G1Affine {
     }
 }
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct SW6G1Parameters;
 
 impl ModelParameters for SW6G1Parameters {

--- a/algebra/src/curves/sw6/g2.rs
+++ b/algebra/src/curves/sw6/g2.rs
@@ -28,7 +28,7 @@ impl PairingCurve for G2Affine {
     }
 }
 
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
+#[derive( Clone, Default, PartialEq, Eq)]
 pub struct SW6G2Parameters;
 
 impl ModelParameters for SW6G2Parameters {


### PR DESCRIPTION
This should help us build more confidence in avoiding accidental
performance-impacting copies.