### PR TITLE
r1cs-std: makes extension field to_bits create namespaces for the ind…

### DIFF
--- a/r1cs-std/src/fields/fp12.rs
+++ b/r1cs-std/src/fields/fp12.rs
@@ -725,8 +725,8 @@ where
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
-        let mut c0 = self.c0.to_bits(&mut cs)?;
-        let mut c1 = self.c1.to_bits(cs)?;
+        let mut c0 = self.c0.to_bits(cs.ns(|| "c0"))?;
+        let mut c1 = self.c1.to_bits(cs.ns(|| "c1"))?;
         c0.append(&mut c1);
         Ok(c0)
     }
@@ -735,8 +735,8 @@ where
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
-        let mut c0 = self.c0.to_bits_strict(&mut cs)?;
-        let mut c1 = self.c1.to_bits_strict(cs)?;
+        let mut c0 = self.c0.to_bits_strict(cs.ns(|| "c0"))?;
+        let mut c1 = self.c1.to_bits_strict(cs.ns(|| "c1"))?;
         c0.append(&mut c1);
         Ok(c0)
     }

--- a/r1cs-std/src/fields/fp2.rs
+++ b/r1cs-std/src/fields/fp2.rs
@@ -524,8 +524,8 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> ToBitsGadget<C
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
-        let mut c0 = self.c0.to_bits(&mut cs)?;
-        let mut c1 = self.c1.to_bits(cs)?;
+        let mut c0 = self.c0.to_bits(cs.ns(|| "c0"))?;
+        let mut c1 = self.c1.to_bits(cs.ns(|| "c1"))?;
         c0.append(&mut c1);
         Ok(c0)
     }
@@ -534,8 +534,8 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> ToBitsGadget<C
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
-        let mut c0 = self.c0.to_bits_strict(&mut cs)?;
-        let mut c1 = self.c1.to_bits_strict(cs)?;
+        let mut c0 = self.c0.to_bits_strict(cs.ns(|| "c0"))?;
+        let mut c1 = self.c1.to_bits_strict(cs.ns(|| "c1"))?;
         c0.append(&mut c1);
         Ok(c0)
     }

--- a/r1cs-std/src/fields/fp6_3over2.rs
+++ b/r1cs-std/src/fields/fp6_3over2.rs
@@ -790,9 +790,9 @@ where
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
-        let mut c0 = self.c0.to_bits(&mut cs)?;
-        let mut c1 = self.c1.to_bits(&mut cs)?;
-        let mut c2 = self.c2.to_bits(cs)?;
+        let mut c0 = self.c0.to_bits(cs.ns(|| "c0"))?;
+        let mut c1 = self.c1.to_bits(cs.ns(|| "c1"))?;
+        let mut c2 = self.c2.to_bits(cs.ns(|| "c2"))?;
 
         c0.append(&mut c1);
         c0.append(&mut c2);
@@ -804,9 +804,9 @@ where
         &self,
         mut cs: CS,
     ) -> Result<Vec<Boolean>, SynthesisError> {
-        let mut c0 = self.c0.to_bits_strict(&mut cs)?;
-        let mut c1 = self.c1.to_bits_strict(&mut cs)?;
-        let mut c2 = self.c2.to_bits_strict(cs)?;
+        let mut c0 = self.c0.to_bits_strict(cs.ns(|| "c0"))?;
+        let mut c1 = self.c1.to_bits_strict(cs.ns(|| "c1"))?;
+        let mut c2 = self.c2.to_bits_strict(cs.ns(|| "c2"))?;
 
         c0.append(&mut c1);
         c0.append(&mut c2);


### PR DESCRIPTION
…ividual elements

Otherwise, when using `to_bits`, there are conflicts with the variable names.