### PR TITLE
Replace many impls of `(Add|Mul|AddAssign|MulAssign)<Self>` with derive macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
-members = [ "algebra", "ff-fft", "r1cs-core", "r1cs-std", "groth16", "gm17", "crypto-primitives", "dpc", "bench-utils" ]
+members = [ "algebra-derive", "algebra", "ff-fft", "r1cs-core", "r1cs-std", "groth16", "gm17", "crypto-primitives", "dpc", "bench-utils" ]
 
 [profile.release]
 opt-level = 3

--- a/algebra-derive/Cargo.toml
+++ b/algebra-derive/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "algebra-derive"
+version = "0.1.0"
+description = "A library for finite fields and elliptic curves"
+homepage = "https://libzexe.org"
+repository = "https://github.com/scipr/zexe"
+documentation = "https://docs.rs/algebra/"
+keywords = ["cryptography", "finite fields", "elliptic curves", "pairing"]
+categories = ["cryptography"]
+include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+license = "MIT/Apache-2.0"
+edition = "2018"
+
+################################# Dependencies ################################
+[lib]
+proc_macro = true
+
+[dependencies]
+syn = { version = "1.0.1", features = ["derive"] }
+quote = "1.0.0"
+proc-macro2 = "1.0.1"
+
+[dev-dependencies]
+anyhow = "1.0"

--- a/algebra-derive/LICENSE-APACHE
+++ b/algebra-derive/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/algebra-derive/LICENSE-MIT
+++ b/algebra-derive/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/algebra-derive/src/lib.rs
+++ b/algebra-derive/src/lib.rs
@@ -47,6 +47,49 @@ pub fn derive_addassign_from_ref(input: TokenStream) -> TokenStream {
     .into()
 }
 
+// This assumes you already have `Sub` defined on `&'a Self` operand
+#[proc_macro_derive(SubFromRef)]
+pub fn derive_sub_from_ref(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        impl #impl_generics ::std::ops::Sub<Self> for #name #ty_generics
+        #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn sub(self, other: Self) -> Self {
+                <Self as Sub<&Self>>::sub(self, &other)
+            }
+        }
+    )
+    .into()
+}
+
+// This assumes you already have `SubAssign` defined on a `&'a Self` operand
+#[proc_macro_derive(SubAssignFromRef)]
+pub fn derive_subassign_from_ref(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        impl #impl_generics ::std::ops::SubAssign<Self> for #name #ty_generics
+        #where_clause
+        {
+            fn sub_assign(&mut self, other: Self) {
+                <Self as ::std::ops::SubAssign<&Self>>::sub_assign(self, &other)
+            }
+        }
+    )
+    .into()
+}
+
 // This assumes you already have `Mul` defined on `&'a Self` operand
 #[proc_macro_derive(MulFromRef)]
 pub fn derive_mul_from_ref(input: TokenStream) -> TokenStream {
@@ -84,6 +127,49 @@ pub fn derive_mulassign_from_ref(input: TokenStream) -> TokenStream {
         {
             fn mul_assign(&mut self, other: Self) {
                 <Self as ::std::ops::MulAssign<&Self>>::mul_assign(self, &other)
+            }
+        }
+    )
+    .into()
+}
+
+// This assumes you already have `Div` defined on `&'a Self` operand
+#[proc_macro_derive(DivFromRef)]
+pub fn derive_div_from_ref(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        impl #impl_generics ::std::ops::Div<Self> for #name #ty_generics
+        #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn div(self, other: Self) -> Self {
+                <Self as Div<&Self>>::div(self, &other)
+            }
+        }
+    )
+    .into()
+}
+
+// This assumes you already have `DivAssign` defined on a `&'a Self` operand
+#[proc_macro_derive(DivAssignFromRef)]
+pub fn derive_divassign_from_ref(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        impl #impl_generics ::std::ops::DivAssign<Self> for #name #ty_generics
+        #where_clause
+        {
+            fn div_assign(&mut self, other: Self) {
+                <Self as ::std::ops::DivAssign<&Self>>::div_assign(self, &other)
             }
         }
     )

--- a/algebra-derive/src/lib.rs
+++ b/algebra-derive/src/lib.rs
@@ -4,16 +4,76 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
+fn get_type_from_attrs(attrs: &[syn::Attribute], attr_name: &str) -> syn::Result<syn::LitStr> {
+    attrs
+        .iter()
+        .find(|attr| attr.path.is_ident(attr_name))
+        .map_or_else(
+            || {
+                Err(syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    format!("Could not find attribute {}", attr_name),
+                ))
+            },
+            |attr| match attr.parse_meta()? {
+                syn::Meta::NameValue(meta) => {
+                    if let syn::Lit::Str(lit) = &meta.lit {
+                        Ok(lit.clone())
+                    } else {
+                        Err(syn::Error::new_spanned(
+                            meta,
+                            &format!("Could not parse {} attribute", attr_name)[..],
+                        ))
+                    }
+                },
+                bad => Err(syn::Error::new_spanned(
+                    bad,
+                    &format!("Could not parse {} attribute", attr_name)[..],
+                )),
+            },
+        )
+}
+
+fn get_param_from_generics(
+    item: &DeriveInput,
+) -> Result<Vec<proc_macro2::TokenStream>, syn::Error> {
+    item.generics
+        .params
+        .iter()
+        .map(|generic_param| match generic_param {
+            syn::GenericParam::Type(type_param) => {
+                let ident = type_param.ident.clone();
+                Ok(quote!(#ident))
+            },
+            bad => Err(syn::Error::new_spanned(
+                bad,
+                &format!("Could not parse generics of {}", item.ident)[..],
+            )),
+        })
+        .collect()
+}
+
 // This assumes you already have `Add` defined on `&'a Self` operand
-#[proc_macro_derive(AddFromRef)]
+#[proc_macro_derive(AddFromRef, attributes(ArithmeticBound))]
 pub fn derive_add_from_ref(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
+    let bounded_generics: Result<Vec<_>, _> = get_param_from_generics(&item);
+    let first_param = {
+        let vec = bounded_generics.expect("Could not find generic parameter");
+
+        vec.get(0)
+            .expect("Struct should have a generic parameter")
+            .clone()
+    };
+
+    let arithmetic_bound = get_type_from_attrs(&item.attrs, "ArithmeticBound").unwrap();
+    let bound: syn::Type = arithmetic_bound.parse().unwrap();
 
     quote!(
-        impl #impl_generics ::std::ops::Add<Self> for #name #ty_generics
+        impl <#first_param: #bound> ::std::ops::Add<Self> for #name #ty_generics
         #where_clause
         {
             type Output = Self;
@@ -28,15 +88,26 @@ pub fn derive_add_from_ref(input: TokenStream) -> TokenStream {
 }
 
 // This assumes you already have `AddAssign` defined on a `&'a Self` operand
-#[proc_macro_derive(AddAssignFromRef)]
+#[proc_macro_derive(AddAssignFromRef, attributes(ArithmeticBound))]
 pub fn derive_addassign_from_ref(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
+    let bounded_generics: Result<Vec<_>, _> = get_param_from_generics(&item);
+    let first_param = {
+        let vec = bounded_generics.expect("Could not find generic parameter");
+
+        vec.get(0)
+            .expect("Struct should have a generic parameter")
+            .clone()
+    };
+
+    let arithmetic_bound = get_type_from_attrs(&item.attrs, "ArithmeticBound").unwrap();
+    let bound: syn::Type = arithmetic_bound.parse().unwrap();
 
     quote!(
-        impl #impl_generics ::std::ops::AddAssign<Self> for #name #ty_generics
+        impl <#first_param: #bound> ::std::ops::AddAssign<Self> for #name #ty_generics
         #where_clause
         {
             fn add_assign(&mut self, other: Self) {
@@ -48,15 +119,26 @@ pub fn derive_addassign_from_ref(input: TokenStream) -> TokenStream {
 }
 
 // This assumes you already have `Sub` defined on `&'a Self` operand
-#[proc_macro_derive(SubFromRef)]
+#[proc_macro_derive(SubFromRef, attributes(ArithmeticBound))]
 pub fn derive_sub_from_ref(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
+    let bounded_generics: Result<Vec<_>, _> = get_param_from_generics(&item);
+    let first_param = {
+        let vec = bounded_generics.expect("Could not find generic parameter");
+
+        vec.get(0)
+            .expect("Struct should have a generic parameter")
+            .clone()
+    };
+
+    let arithmetic_bound = get_type_from_attrs(&item.attrs, "ArithmeticBound").unwrap();
+    let bound: syn::Type = arithmetic_bound.parse().unwrap();
 
     quote!(
-        impl #impl_generics ::std::ops::Sub<Self> for #name #ty_generics
+        impl <#first_param: #bound> ::std::ops::Sub<Self> for #name #ty_generics
         #where_clause
         {
             type Output = Self;
@@ -71,15 +153,26 @@ pub fn derive_sub_from_ref(input: TokenStream) -> TokenStream {
 }
 
 // This assumes you already have `SubAssign` defined on a `&'a Self` operand
-#[proc_macro_derive(SubAssignFromRef)]
+#[proc_macro_derive(SubAssignFromRef, attributes(ArithmeticBound))]
 pub fn derive_subassign_from_ref(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
+    let bounded_generics: Result<Vec<_>, _> = get_param_from_generics(&item);
+    let first_param = {
+        let vec = bounded_generics.expect("Could not find generic parameter");
+
+        vec.get(0)
+            .expect("Struct should have a generic parameter")
+            .clone()
+    };
+
+    let arithmetic_bound = get_type_from_attrs(&item.attrs, "ArithmeticBound").unwrap();
+    let bound: syn::Type = arithmetic_bound.parse().unwrap();
 
     quote!(
-        impl #impl_generics ::std::ops::SubAssign<Self> for #name #ty_generics
+        impl <#first_param: #bound> ::std::ops::SubAssign<Self> for #name #ty_generics
         #where_clause
         {
             fn sub_assign(&mut self, other: Self) {
@@ -91,15 +184,26 @@ pub fn derive_subassign_from_ref(input: TokenStream) -> TokenStream {
 }
 
 // This assumes you already have `Mul` defined on `&'a Self` operand
-#[proc_macro_derive(MulFromRef)]
+#[proc_macro_derive(MulFromRef, attributes(ArithmeticBound))]
 pub fn derive_mul_from_ref(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
+    let bounded_generics: Result<Vec<_>, _> = get_param_from_generics(&item);
+    let first_param = {
+        let vec = bounded_generics.expect("Could not find generic parameter");
+
+        vec.get(0)
+            .expect("Struct should have a generic parameter")
+            .clone()
+    };
+
+    let arithmetic_bound = get_type_from_attrs(&item.attrs, "ArithmeticBound").unwrap();
+    let bound: syn::Type = arithmetic_bound.parse().unwrap();
 
     quote!(
-        impl #impl_generics ::std::ops::Mul<Self> for #name #ty_generics
+        impl <#first_param: #bound> ::std::ops::Mul<Self> for #name #ty_generics
         #where_clause
         {
             type Output = Self;
@@ -114,15 +218,26 @@ pub fn derive_mul_from_ref(input: TokenStream) -> TokenStream {
 }
 
 // This assumes you already have `MulAssign` defined on a `&'a Self` operand
-#[proc_macro_derive(MulAssignFromRef)]
+#[proc_macro_derive(MulAssignFromRef, attributes(ArithmeticBound))]
 pub fn derive_mulassign_from_ref(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
+    let bounded_generics: Result<Vec<_>, _> = get_param_from_generics(&item);
+    let first_param = {
+        let vec = bounded_generics.expect("Could not find generic parameter");
+
+        vec.get(0)
+            .expect("Struct should have a generic parameter")
+            .clone()
+    };
+
+    let arithmetic_bound = get_type_from_attrs(&item.attrs, "ArithmeticBound").unwrap();
+    let bound: syn::Type = arithmetic_bound.parse().unwrap();
 
     quote!(
-        impl #impl_generics ::std::ops::MulAssign<Self> for #name #ty_generics
+        impl <#first_param: #bound> ::std::ops::MulAssign<Self> for #name #ty_generics
         #where_clause
         {
             fn mul_assign(&mut self, other: Self) {
@@ -134,15 +249,26 @@ pub fn derive_mulassign_from_ref(input: TokenStream) -> TokenStream {
 }
 
 // This assumes you already have `Div` defined on `&'a Self` operand
-#[proc_macro_derive(DivFromRef)]
+#[proc_macro_derive(DivFromRef, attributes(ArithmeticBound))]
 pub fn derive_div_from_ref(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
+    let bounded_generics: Result<Vec<_>, _> = get_param_from_generics(&item);
+    let first_param = {
+        let vec = bounded_generics.expect("Could not find generic parameter");
+
+        vec.get(0)
+            .expect("Struct should have a generic parameter")
+            .clone()
+    };
+
+    let arithmetic_bound = get_type_from_attrs(&item.attrs, "ArithmeticBound").unwrap();
+    let bound: syn::Type = arithmetic_bound.parse().unwrap();
 
     quote!(
-        impl #impl_generics ::std::ops::Div<Self> for #name #ty_generics
+        impl <#first_param: #bound> ::std::ops::Div<Self> for #name #ty_generics
         #where_clause
         {
             type Output = Self;
@@ -157,15 +283,26 @@ pub fn derive_div_from_ref(input: TokenStream) -> TokenStream {
 }
 
 // This assumes you already have `DivAssign` defined on a `&'a Self` operand
-#[proc_macro_derive(DivAssignFromRef)]
+#[proc_macro_derive(DivAssignFromRef, attributes(ArithmeticBound))]
 pub fn derive_divassign_from_ref(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
-
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    let (_, ty_generics, where_clause) = item.generics.split_for_impl();
+    let bounded_generics: Result<Vec<_>, _> = get_param_from_generics(&item);
+    let first_param = {
+        let vec = bounded_generics.expect("Could not find generic parameter");
+
+        vec.get(0)
+            .expect("Struct should have a generic parameter")
+            .clone()
+    };
+
+    let arithmetic_bound = get_type_from_attrs(&item.attrs, "ArithmeticBound").unwrap();
+    let bound: syn::Type = arithmetic_bound.parse().unwrap();
 
     quote!(
-        impl #impl_generics ::std::ops::DivAssign<Self> for #name #ty_generics
+        impl <#first_param: #bound> ::std::ops::DivAssign<Self> for #name #ty_generics
         #where_clause
         {
             fn div_assign(&mut self, other: Self) {

--- a/algebra-derive/src/lib.rs
+++ b/algebra-derive/src/lib.rs
@@ -1,0 +1,91 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+// This assumes you already have `Add` defined on `&'a Self` operand
+#[proc_macro_derive(AddFromRef)]
+pub fn derive_add_from_ref(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        impl #impl_generics ::std::ops::Add<Self> for #name #ty_generics
+        #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn add(self, other: Self) -> Self {
+                <Self as Add<&Self>>::add(self, &other)
+            }
+        }
+    )
+    .into()
+}
+
+// This assumes you already have `AddAssign` defined on a `&'a Self` operand
+#[proc_macro_derive(AddAssignFromRef)]
+pub fn derive_addassign_from_ref(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        impl #impl_generics ::std::ops::AddAssign<Self> for #name #ty_generics
+        #where_clause
+        {
+            fn add_assign(&mut self, other: Self) {
+                <Self as ::std::ops::AddAssign<&Self>>::add_assign(self, &other)
+            }
+        }
+    )
+    .into()
+}
+
+// This assumes you already have `Mul` defined on `&'a Self` operand
+#[proc_macro_derive(MulFromRef)]
+pub fn derive_mul_from_ref(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        impl #impl_generics ::std::ops::Mul<Self> for #name #ty_generics
+        #where_clause
+        {
+            type Output = Self;
+
+            #[inline]
+            fn mul(self, other: Self) -> Self {
+                <Self as Mul<&Self>>::mul(self, &other)
+            }
+        }
+    )
+    .into()
+}
+
+// This assumes you already have `MulAssign` defined on a `&'a Self` operand
+#[proc_macro_derive(MulAssignFromRef)]
+pub fn derive_mulassign_from_ref(input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as DeriveInput);
+
+    let name = &item.ident;
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
+    quote!(
+        impl #impl_generics ::std::ops::MulAssign<Self> for #name #ty_generics
+        #where_clause
+        {
+            fn mul_assign(&mut self, other: Self) {
+                <Self as ::std::ops::MulAssign<&Self>>::mul_assign(self, &other)
+            }
+        }
+    )
+    .into()
+}

--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
+algebra-derive = { path = "../algebra-derive" }
 byteorder = { version = "1" }
 rand = { version = "0.7" }
 derivative = { version = "1" }

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -22,6 +22,7 @@ use algebra_derive::{AddAssignFromRef, AddFromRef, SubAssignFromRef, SubFromRef}
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 #[derive(AddAssignFromRef, Derivative)]
+#[ArithmeticBound = "Parameters"]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
@@ -212,6 +213,7 @@ impl<P: Parameters> Default for GroupAffine<P> {
 }
 
 #[derive(AddFromRef, AddAssignFromRef, SubFromRef, SubAssignFromRef, Derivative)]
+#[ArithmeticBound = "Parameters"]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -18,6 +18,7 @@ use crate::{
     curves::{AffineCurve, ProjectiveCurve},
     fields::{BitIterator, Field, PrimeField, SquareRootField},
 };
+use algebra_derive::AddFromRef;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 #[derive(Derivative)]
@@ -210,7 +211,7 @@ impl<P: Parameters> Default for GroupAffine<P> {
     }
 }
 
-#[derive(Derivative)]
+#[derive(AddFromRef, Derivative)]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
@@ -580,17 +581,6 @@ impl<P: Parameters> Neg for GroupProjective<P> {
         } else {
             self
         }
-    }
-}
-
-impl<P: Parameters> Add<Self> for GroupProjective<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut copy = self;
-        copy += &other;
-        copy
     }
 }
 

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -18,10 +18,10 @@ use crate::{
     curves::{AffineCurve, ProjectiveCurve},
     fields::{BitIterator, Field, PrimeField, SquareRootField},
 };
-use algebra_derive::AddFromRef;
+use algebra_derive::{AddAssignFromRef, AddFromRef, SubAssignFromRef, SubFromRef};
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-#[derive(Derivative)]
+#[derive(AddAssignFromRef, Derivative)]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
@@ -211,7 +211,7 @@ impl<P: Parameters> Default for GroupAffine<P> {
     }
 }
 
-#[derive(AddFromRef, Derivative)]
+#[derive(AddFromRef, AddAssignFromRef, SubFromRef, SubAssignFromRef, Derivative)]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
@@ -548,7 +548,8 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
             }
 
             if i {
-                res.add_assign(self);
+                let im_self = &*self;
+                res.add_assign(im_self);
             }
         }
 

--- a/algebra/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra/src/curves/models/short_weierstrass_projective.rs
@@ -18,6 +18,7 @@ use crate::{
     curves::{AffineCurve, ProjectiveCurve},
     fields::{BitIterator, Field, PrimeField, SquareRootField},
 };
+use algebra_derive::AddFromRef;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 #[derive(Derivative)]
@@ -209,7 +210,7 @@ impl<P: Parameters> Default for GroupAffine<P> {
     }
 }
 
-#[derive(Derivative)]
+#[derive(AddFromRef, Derivative)]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
@@ -489,15 +490,6 @@ impl<P: Parameters> Neg for GroupProjective<P> {
         } else {
             self
         }
-    }
-}
-
-impl<P: Parameters> Add<Self> for GroupProjective<P> {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        let mut copy = self;
-        copy += &other;
-        copy
     }
 }
 

--- a/algebra/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra/src/curves/models/short_weierstrass_projective.rs
@@ -211,6 +211,7 @@ impl<P: Parameters> Default for GroupAffine<P> {
 }
 
 #[derive(AddFromRef, Derivative)]
+#[ArithmeticBound = "Parameters"]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),

--- a/algebra/src/curves/models/twisted_edwards_extended/mod.rs
+++ b/algebra/src/curves/models/twisted_edwards_extended/mod.rs
@@ -27,6 +27,7 @@ use algebra_derive::AddFromRef;
 pub mod tests;
 
 #[derive(AddFromRef, Derivative)]
+#[ArithmeticBound = "Parameters"]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
@@ -281,6 +282,7 @@ mod group_impl {
 //////////////////////////////////////////////////////////////////////////////
 
 #[derive(AddFromRef, Derivative)]
+#[ArithmeticBound = "Parameters"]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),

--- a/algebra/src/curves/models/twisted_edwards_extended/mod.rs
+++ b/algebra/src/curves/models/twisted_edwards_extended/mod.rs
@@ -21,11 +21,12 @@ use crate::{
     },
     fields::{BitIterator, Field, PrimeField, SquareRootField},
 };
+use algebra_derive::AddFromRef;
 
 #[cfg(test)]
 pub mod tests;
 
-#[derive(Derivative)]
+#[derive(AddFromRef, Derivative)]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
@@ -158,15 +159,6 @@ impl<P: Parameters> Neg for GroupAffine<P> {
     }
 }
 
-impl<P: Parameters> Add<Self> for GroupAffine<P> {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        let mut copy = self;
-        copy += &other;
-        copy
-    }
-}
-
 impl<'a, P: Parameters> Add<&'a Self> for GroupAffine<P> {
     type Output = Self;
     fn add(self, other: &'a Self) -> Self {
@@ -288,7 +280,7 @@ mod group_impl {
 
 //////////////////////////////////////////////////////////////////////////////
 
-#[derive(Derivative)]
+#[derive(AddFromRef, Derivative)]
 #[derivative(
     Copy(bound = "P: Parameters"),
     Clone(bound = "P: Parameters"),
@@ -523,15 +515,6 @@ impl<P: Parameters> Neg for GroupProjective<P> {
         self.x = -self.x;
         self.t = -self.t;
         self
-    }
-}
-
-impl<P: Parameters> Add<Self> for GroupProjective<P> {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        let mut copy = self;
-        copy += &other;
-        copy
     }
 }
 

--- a/algebra/src/fields/macros.rs
+++ b/algebra/src/fields/macros.rs
@@ -116,25 +116,3 @@ macro_rules! sqrt_impl {
         }
     }};
 }
-
-// Implements AddAssign on Self by deferring to an implementation on &Self
-macro_rules! impl_addassign_from_ref {
-    ($field: ident, $params: ident) => {
-        impl<P: $params> AddAssign<Self> for $field<P> {
-            fn add_assign(&mut self, other: Self) {
-                self.add_assign(&other)
-            }
-        }
-    };
-}
-
-// Implements MulAssign on Self by deferring to an implementation on &Self
-macro_rules! impl_mulassign_from_ref {
-    ($field: ident, $params: ident) => {
-        impl<P: $params> MulAssign<Self> for $field<P> {
-            fn mul_assign(&mut self, other: Self) {
-                self.mul_assign(&other)
-            }
-        }
-    };
-}

--- a/algebra/src/fields/models/fp12_2over3over2.rs
+++ b/algebra/src/fields/models/fp12_2over3over2.rs
@@ -16,7 +16,10 @@ use crate::{
     fields::{fp6_3over2::*, Field, Fp2, Fp2Parameters},
     BitIterator,
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp12Parameters: 'static + Send + Sync + Copy {
     type Fp6Params: Fp6Parameters;
@@ -26,7 +29,17 @@ pub trait Fp12Parameters: 'static + Send + Sync + Copy {
 }
 
 /// An element of Fp12, represented by c0 + c1 * v
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = "P: Fp12Parameters"),
     Hash(bound = "P: Fp12Parameters"),
@@ -355,7 +368,7 @@ impl<'a, P: Fp12Parameters> Sub<&'a Self> for Fp12<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
+        result.sub_assign(other);
         result
     }
 }

--- a/algebra/src/fields/models/fp12_2over3over2.rs
+++ b/algebra/src/fields/models/fp12_2over3over2.rs
@@ -16,6 +16,7 @@ use crate::{
     fields::{fp6_3over2::*, Field, Fp2, Fp2Parameters},
     BitIterator,
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp12Parameters: 'static + Send + Sync + Copy {
     type Fp6Params: Fp6Parameters;
@@ -25,7 +26,7 @@ pub trait Fp12Parameters: 'static + Send + Sync + Copy {
 }
 
 /// An element of Fp12, represented by c0 + c1 * v
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = "P: Fp12Parameters"),
     Hash(bound = "P: Fp12Parameters"),
@@ -337,17 +338,6 @@ impl<P: Fp12Parameters> Neg for Fp12<P> {
     }
 }
 
-impl<P: Fp12Parameters> Add<Self> for Fp12<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp12Parameters> Add<&'a Self> for Fp12<P> {
     type Output = Self;
 
@@ -366,17 +356,6 @@ impl<'a, P: Fp12Parameters> Sub<&'a Self> for Fp12<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
         result.sub_assign(&other);
-        result
-    }
-}
-
-impl<P: Fp12Parameters> Mul<Self> for Fp12<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(other);
         result
     }
 }
@@ -403,7 +382,6 @@ impl<'a, P: Fp12Parameters> Div<&'a Self> for Fp12<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp12, Fp12Parameters);
 impl<'a, P: Fp12Parameters> AddAssign<&'a Self> for Fp12<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -420,7 +398,6 @@ impl<'a, P: Fp12Parameters> SubAssign<&'a Self> for Fp12<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp12, Fp12Parameters);
 impl<'a, P: Fp12Parameters> MulAssign<&'a Self> for Fp12<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp12_2over3over2.rs
+++ b/algebra/src/fields/models/fp12_2over3over2.rs
@@ -40,6 +40,7 @@ pub trait Fp12Parameters: 'static + Send + Sync + Copy {
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp12Parameters"]
 #[derivative(
     Default(bound = "P: Fp12Parameters"),
     Hash(bound = "P: Fp12Parameters"),

--- a/algebra/src/fields/models/fp2.rs
+++ b/algebra/src/fields/models/fp2.rs
@@ -15,6 +15,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, LegendreSymbol, PrimeField, SquareRootField},
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp2Parameters: 'static + Send + Sync {
     type Fp: PrimeField;
@@ -32,7 +33,7 @@ pub trait Fp2Parameters: 'static + Send + Sync {
     }
 }
 
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = "P: Fp2Parameters"),
     Hash(bound = "P: Fp2Parameters"),
@@ -300,17 +301,6 @@ impl<P: Fp2Parameters> Distribution<Fp2<P>> for Standard {
     }
 }
 
-impl<P: Fp2Parameters> Add<Fp2<P>> for Fp2<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp2Parameters> Add<&'a Fp2<P>> for Fp2<P> {
     type Output = Self;
 
@@ -329,17 +319,6 @@ impl<'a, P: Fp2Parameters> Sub<&'a Fp2<P>> for Fp2<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
         result.sub_assign(&other);
-        result
-    }
-}
-
-impl<P: Fp2Parameters> Mul<Fp2<P>> for Fp2<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(&other);
         result
     }
 }
@@ -366,7 +345,6 @@ impl<'a, P: Fp2Parameters> Div<&'a Fp2<P>> for Fp2<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp2, Fp2Parameters);
 impl<'a, P: Fp2Parameters> AddAssign<&'a Self> for Fp2<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -383,7 +361,6 @@ impl<'a, P: Fp2Parameters> SubAssign<&'a Self> for Fp2<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp2, Fp2Parameters);
 impl<'a, P: Fp2Parameters> MulAssign<&'a Self> for Fp2<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp2.rs
+++ b/algebra/src/fields/models/fp2.rs
@@ -15,7 +15,10 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, LegendreSymbol, PrimeField, SquareRootField},
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp2Parameters: 'static + Send + Sync {
     type Fp: PrimeField;
@@ -33,7 +36,17 @@ pub trait Fp2Parameters: 'static + Send + Sync {
     }
 }
 
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+    Derivative,
+)]
 #[derivative(
     Default(bound = "P: Fp2Parameters"),
     Hash(bound = "P: Fp2Parameters"),
@@ -318,7 +331,7 @@ impl<'a, P: Fp2Parameters> Sub<&'a Fp2<P>> for Fp2<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
+        result.sub_assign(other);
         result
     }
 }

--- a/algebra/src/fields/models/fp2.rs
+++ b/algebra/src/fields/models/fp2.rs
@@ -47,6 +47,7 @@ pub trait Fp2Parameters: 'static + Send + Sync {
     DivAssignFromRef,
     Derivative,
 )]
+#[ArithmeticBound = "Fp2Parameters"]
 #[derivative(
     Default(bound = "P: Fp2Parameters"),
     Hash(bound = "P: Fp2Parameters"),

--- a/algebra/src/fields/models/fp3.rs
+++ b/algebra/src/fields/models/fp3.rs
@@ -50,6 +50,7 @@ pub trait Fp3Parameters: 'static + Send + Sync {
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp3Parameters"]
 #[derivative(
     Default(bound = "P: Fp3Parameters"),
     Hash(bound = "P: Fp3Parameters"),

--- a/algebra/src/fields/models/fp3.rs
+++ b/algebra/src/fields/models/fp3.rs
@@ -16,6 +16,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, LegendreSymbol, PrimeField, SquareRootField},
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp3Parameters: 'static + Send + Sync {
     type Fp: PrimeField + SquareRootField;
@@ -35,7 +36,7 @@ pub trait Fp3Parameters: 'static + Send + Sync {
     }
 }
 
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = "P: Fp3Parameters"),
     Hash(bound = "P: Fp3Parameters"),
@@ -355,17 +356,6 @@ impl<P: Fp3Parameters> Distribution<Fp3<P>> for Standard {
     }
 }
 
-impl<P: Fp3Parameters> Add<Fp3<P>> for Fp3<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp3Parameters> Add<&'a Fp3<P>> for Fp3<P> {
     type Output = Self;
 
@@ -384,17 +374,6 @@ impl<'a, P: Fp3Parameters> Sub<&'a Fp3<P>> for Fp3<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
         result.sub_assign(&other);
-        result
-    }
-}
-
-impl<'a, P: Fp3Parameters> Mul<Fp3<P>> for Fp3<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(&other);
         result
     }
 }
@@ -421,7 +400,6 @@ impl<'a, P: Fp3Parameters> Div<&'a Fp3<P>> for Fp3<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp3, Fp3Parameters);
 impl<'a, P: Fp3Parameters> AddAssign<&'a Self> for Fp3<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -440,7 +418,6 @@ impl<'a, P: Fp3Parameters> SubAssign<&'a Self> for Fp3<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp3, Fp3Parameters);
 impl<'a, P: Fp3Parameters> MulAssign<&'a Self> for Fp3<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp3.rs
+++ b/algebra/src/fields/models/fp3.rs
@@ -16,7 +16,10 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, LegendreSymbol, PrimeField, SquareRootField},
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp3Parameters: 'static + Send + Sync {
     type Fp: PrimeField + SquareRootField;
@@ -36,7 +39,17 @@ pub trait Fp3Parameters: 'static + Send + Sync {
     }
 }
 
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = "P: Fp3Parameters"),
     Hash(bound = "P: Fp3Parameters"),
@@ -373,7 +386,7 @@ impl<'a, P: Fp3Parameters> Sub<&'a Fp3<P>> for Fp3<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
+        result.sub_assign(other);
         result
     }
 }

--- a/algebra/src/fields/models/fp6_2over3.rs
+++ b/algebra/src/fields/models/fp6_2over3.rs
@@ -46,6 +46,7 @@ pub trait Fp6Parameters: 'static + Send + Sync {
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp6Parameters"]
 #[derivative(
     Default(bound = "P: Fp6Parameters"),
     Hash(bound = "P: Fp6Parameters"),

--- a/algebra/src/fields/models/fp6_2over3.rs
+++ b/algebra/src/fields/models/fp6_2over3.rs
@@ -16,6 +16,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, Fp3, Fp3Parameters},
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp6Parameters: 'static + Send + Sync {
     type Fp3Params: Fp3Parameters;
@@ -31,7 +32,7 @@ pub trait Fp6Parameters: 'static + Send + Sync {
     }
 }
 
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = "P: Fp6Parameters"),
     Hash(bound = "P: Fp6Parameters"),
@@ -293,17 +294,6 @@ impl<P: Fp6Parameters> Distribution<Fp6<P>> for Standard {
     }
 }
 
-impl<P: Fp6Parameters> Add<Fp6<P>> for Fp6<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp6Parameters> Add<&'a Fp6<P>> for Fp6<P> {
     type Output = Self;
 
@@ -322,17 +312,6 @@ impl<'a, P: Fp6Parameters> Sub<&'a Fp6<P>> for Fp6<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
         result.sub_assign(&other);
-        result
-    }
-}
-
-impl<P: Fp6Parameters> Mul<Fp6<P>> for Fp6<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(other);
         result
     }
 }
@@ -359,7 +338,6 @@ impl<'a, P: Fp6Parameters> Div<&'a Fp6<P>> for Fp6<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp6, Fp6Parameters);
 impl<'a, P: Fp6Parameters> AddAssign<&'a Self> for Fp6<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -376,7 +354,6 @@ impl<'a, P: Fp6Parameters> SubAssign<&'a Self> for Fp6<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp6, Fp6Parameters);
 impl<'a, P: Fp6Parameters> MulAssign<&'a Self> for Fp6<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp6_2over3.rs
+++ b/algebra/src/fields/models/fp6_2over3.rs
@@ -16,7 +16,10 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, Fp3, Fp3Parameters},
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp6Parameters: 'static + Send + Sync {
     type Fp3Params: Fp3Parameters;
@@ -32,7 +35,17 @@ pub trait Fp6Parameters: 'static + Send + Sync {
     }
 }
 
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = "P: Fp6Parameters"),
     Hash(bound = "P: Fp6Parameters"),
@@ -311,7 +324,7 @@ impl<'a, P: Fp6Parameters> Sub<&'a Fp6<P>> for Fp6<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
+        result.sub_assign(other);
         result
     }
 }

--- a/algebra/src/fields/models/fp6_3over2.rs
+++ b/algebra/src/fields/models/fp6_3over2.rs
@@ -15,7 +15,10 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, Fp2, Fp2Parameters},
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp6Parameters: 'static + Send + Sync + Copy {
     type Fp2Params: Fp2Parameters;
@@ -33,7 +36,17 @@ pub trait Fp6Parameters: 'static + Send + Sync + Copy {
 }
 
 /// An element of Fp6, represented by c0 + c1 * v + c2 * v^(2).
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = "P: Fp6Parameters"),
     Hash(bound = "P: Fp6Parameters"),
@@ -318,7 +331,7 @@ impl<'a, P: Fp6Parameters> Sub<&'a Self> for Fp6<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
+        result.sub_assign(other);
         result
     }
 }

--- a/algebra/src/fields/models/fp6_3over2.rs
+++ b/algebra/src/fields/models/fp6_3over2.rs
@@ -15,6 +15,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, Fp2, Fp2Parameters},
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp6Parameters: 'static + Send + Sync + Copy {
     type Fp2Params: Fp2Parameters;
@@ -32,7 +33,7 @@ pub trait Fp6Parameters: 'static + Send + Sync + Copy {
 }
 
 /// An element of Fp6, represented by c0 + c1 * v + c2 * v^(2).
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = "P: Fp6Parameters"),
     Hash(bound = "P: Fp6Parameters"),
@@ -300,17 +301,6 @@ impl<P: Fp6Parameters> Neg for Fp6<P> {
     }
 }
 
-impl<P: Fp6Parameters> Add<Self> for Fp6<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp6Parameters> Add<&'a Self> for Fp6<P> {
     type Output = Self;
 
@@ -329,17 +319,6 @@ impl<'a, P: Fp6Parameters> Sub<&'a Self> for Fp6<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
         result.sub_assign(&other);
-        result
-    }
-}
-
-impl<P: Fp6Parameters> Mul<Self> for Fp6<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(other);
         result
     }
 }
@@ -366,7 +345,6 @@ impl<'a, P: Fp6Parameters> Div<&'a Self> for Fp6<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp6, Fp6Parameters);
 impl<'a, P: Fp6Parameters> AddAssign<&'a Self> for Fp6<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -385,7 +363,6 @@ impl<'a, P: Fp6Parameters> SubAssign<&'a Self> for Fp6<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp6, Fp6Parameters);
 impl<'a, P: Fp6Parameters> MulAssign<&'a Self> for Fp6<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp6_3over2.rs
+++ b/algebra/src/fields/models/fp6_3over2.rs
@@ -47,6 +47,7 @@ pub trait Fp6Parameters: 'static + Send + Sync + Copy {
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp6Parameters"]
 #[derivative(
     Default(bound = "P: Fp6Parameters"),
     Hash(bound = "P: Fp6Parameters"),

--- a/algebra/src/fields/models/fp_256.rs
+++ b/algebra/src/fields/models/fp_256.rs
@@ -13,10 +13,11 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp256Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -26,7 +27,7 @@ pub trait Fp256Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp256<P>(
+pub struct Fp256<P: Fp256Parameters>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]
@@ -467,17 +468,6 @@ impl<P: Fp256Parameters> Neg for Fp256<P> {
     }
 }
 
-impl<P: Fp256Parameters> Add<Fp256<P>> for Fp256<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp256Parameters> Add<&'a Fp256<P>> for Fp256<P> {
     type Output = Self;
 
@@ -496,17 +486,6 @@ impl<'a, P: Fp256Parameters> Sub<&'a Fp256<P>> for Fp256<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp256Parameters> Mul<Fp256<P>> for Fp256<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(&other);
         result
     }
 }
@@ -533,7 +512,6 @@ impl<'a, P: Fp256Parameters> Div<&'a Fp256<P>> for Fp256<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp256, Fp256Parameters);
 impl<'a, P: Fp256Parameters> AddAssign<&'a Self> for Fp256<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -557,7 +535,6 @@ impl<'a, P: Fp256Parameters> SubAssign<&'a Self> for Fp256<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp256, Fp256Parameters);
 impl<'a, P: Fp256Parameters> MulAssign<&'a Self> for Fp256<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_256.rs
+++ b/algebra/src/fields/models/fp_256.rs
@@ -31,6 +31,7 @@ pub trait Fp256Parameters: FpParameters<BigInt = BigInteger> {}
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp256Parameters"]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),

--- a/algebra/src/fields/models/fp_256.rs
+++ b/algebra/src/fields/models/fp_256.rs
@@ -13,11 +13,24 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp256Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -34,14 +47,12 @@ pub struct Fp256<P: Fp256Parameters>(
     pub PhantomData<P>,
 );
 
-impl<P> Fp256<P> {
+impl<P: Fp256Parameters> Fp256<P> {
     #[inline]
-    pub const fn new(element: BigInteger) -> Self {
+    pub fn new(element: BigInteger) -> Self {
         Self(element, PhantomData)
     }
-}
 
-impl<P: Fp256Parameters> Fp256<P> {
     #[inline]
     fn is_valid(&self) -> bool {
         self.0 < P::MODULUS

--- a/algebra/src/fields/models/fp_256.rs
+++ b/algebra/src/fields/models/fp_256.rs
@@ -41,19 +41,21 @@ pub trait Fp256Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp256<P: Fp256Parameters>(
+pub struct Fp256<P>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]
     pub PhantomData<P>,
 );
 
-impl<P: Fp256Parameters> Fp256<P> {
+impl<P> Fp256<P> {
     #[inline]
-    pub fn new(element: BigInteger) -> Self {
+    pub const fn new(element: BigInteger) -> Self {
         Self(element, PhantomData)
     }
+}
 
+impl<P: Fp256Parameters> Fp256<P> {
     #[inline]
     fn is_valid(&self) -> bool {
         self.0 < P::MODULUS

--- a/algebra/src/fields/models/fp_320.rs
+++ b/algebra/src/fields/models/fp_320.rs
@@ -13,10 +13,11 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp320Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -495,17 +496,6 @@ impl<P: Fp320Parameters> Neg for Fp320<P> {
     }
 }
 
-impl<P: Fp320Parameters> Add<Fp320<P>> for Fp320<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp320Parameters> Add<&'a Fp320<P>> for Fp320<P> {
     type Output = Self;
 
@@ -524,17 +514,6 @@ impl<'a, P: Fp320Parameters> Sub<&'a Fp320<P>> for Fp320<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self.clone();
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp320Parameters> Mul<Fp320<P>> for Fp320<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.mul_assign(&other);
         result
     }
 }
@@ -561,7 +540,6 @@ impl<'a, P: Fp320Parameters> Div<&'a Fp320<P>> for Fp320<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp320, Fp320Parameters);
 impl<'a, P: Fp320Parameters> AddAssign<&'a Self> for Fp320<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -584,7 +562,6 @@ impl<'a, P: Fp320Parameters> SubAssign<&'a Self> for Fp320<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp320, Fp320Parameters);
 impl<'a, P: Fp320Parameters> MulAssign<&'a Self> for Fp320<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_320.rs
+++ b/algebra/src/fields/models/fp_320.rs
@@ -41,7 +41,7 @@ pub trait Fp320Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp320<P: Fp320Parameters>(
+pub struct Fp320<P>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]

--- a/algebra/src/fields/models/fp_320.rs
+++ b/algebra/src/fields/models/fp_320.rs
@@ -13,11 +13,24 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp320Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -27,7 +40,7 @@ pub trait Fp320Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp320<P>(
+pub struct Fp320<P: Fp320Parameters>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]

--- a/algebra/src/fields/models/fp_320.rs
+++ b/algebra/src/fields/models/fp_320.rs
@@ -31,6 +31,7 @@ pub trait Fp320Parameters: FpParameters<BigInt = BigInteger> {}
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp320Parameters"]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),

--- a/algebra/src/fields/models/fp_384.rs
+++ b/algebra/src/fields/models/fp_384.rs
@@ -13,11 +13,24 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp384Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -27,21 +40,19 @@ pub trait Fp384Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp384<P>(
+pub struct Fp384<P: Fp384Parameters>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]
     pub PhantomData<P>,
 );
 
-impl<P> Fp384<P> {
+impl<P: Fp384Parameters> Fp384<P> {
     #[inline]
-    pub const fn new(element: BigInteger) -> Self {
+    pub fn new(element: BigInteger) -> Self {
         Self(element, PhantomData)
     }
-}
 
-impl<P: Fp384Parameters> Fp384<P> {
     #[inline]
     pub(crate) fn is_valid(&self) -> bool {
         self.0 < P::MODULUS

--- a/algebra/src/fields/models/fp_384.rs
+++ b/algebra/src/fields/models/fp_384.rs
@@ -41,19 +41,21 @@ pub trait Fp384Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp384<P: Fp384Parameters>(
+pub struct Fp384<P>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]
     pub PhantomData<P>,
 );
 
-impl<P: Fp384Parameters> Fp384<P> {
+impl<P> Fp384<P> {
     #[inline]
-    pub fn new(element: BigInteger) -> Self {
+    pub const fn new(element: BigInteger) -> Self {
         Self(element, PhantomData)
     }
+}
 
+impl<P: Fp384Parameters> Fp384<P> {
     #[inline]
     pub(crate) fn is_valid(&self) -> bool {
         self.0 < P::MODULUS

--- a/algebra/src/fields/models/fp_384.rs
+++ b/algebra/src/fields/models/fp_384.rs
@@ -31,6 +31,7 @@ pub trait Fp384Parameters: FpParameters<BigInt = BigInteger> {}
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp384Parameters"]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),

--- a/algebra/src/fields/models/fp_384.rs
+++ b/algebra/src/fields/models/fp_384.rs
@@ -13,10 +13,11 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp384Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -527,17 +528,6 @@ impl<P: Fp384Parameters> Neg for Fp384<P> {
     }
 }
 
-impl<P: Fp384Parameters> Add<Fp384<P>> for Fp384<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp384Parameters> Add<&'a Fp384<P>> for Fp384<P> {
     type Output = Self;
 
@@ -556,17 +546,6 @@ impl<'a, P: Fp384Parameters> Sub<&'a Fp384<P>> for Fp384<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self.clone();
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp384Parameters> Mul<Fp384<P>> for Fp384<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.mul_assign(&other);
         result
     }
 }
@@ -593,7 +572,6 @@ impl<'a, P: Fp384Parameters> Div<&'a Fp384<P>> for Fp384<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp384, Fp384Parameters);
 impl<'a, P: Fp384Parameters> AddAssign<&'a Self> for Fp384<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -616,7 +594,6 @@ impl<'a, P: Fp384Parameters> SubAssign<&'a Self> for Fp384<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp384, Fp384Parameters);
 impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_768.rs
+++ b/algebra/src/fields/models/fp_768.rs
@@ -13,11 +13,24 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 
 pub trait Fp768Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -27,7 +40,7 @@ pub trait Fp768Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp768<P>(
+pub struct Fp768<P: Fp768Parameters>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]

--- a/algebra/src/fields/models/fp_768.rs
+++ b/algebra/src/fields/models/fp_768.rs
@@ -41,7 +41,7 @@ pub trait Fp768Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp768<P: Fp768Parameters>(
+pub struct Fp768<P>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]

--- a/algebra/src/fields/models/fp_768.rs
+++ b/algebra/src/fields/models/fp_768.rs
@@ -13,10 +13,11 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 
 pub trait Fp768Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -857,17 +858,6 @@ impl<P: Fp768Parameters> Neg for Fp768<P> {
     }
 }
 
-impl<P: Fp768Parameters> Add<Fp768<P>> for Fp768<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp768Parameters> Add<&'a Fp768<P>> for Fp768<P> {
     type Output = Self;
 
@@ -886,17 +876,6 @@ impl<'a, P: Fp768Parameters> Sub<&'a Fp768<P>> for Fp768<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self.clone();
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp768Parameters> Mul<Fp768<P>> for Fp768<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.mul_assign(&other);
         result
     }
 }
@@ -923,7 +902,6 @@ impl<'a, P: Fp768Parameters> Div<&'a Fp768<P>> for Fp768<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp768, Fp768Parameters);
 impl<'a, P: Fp768Parameters> AddAssign<&'a Self> for Fp768<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -946,7 +924,6 @@ impl<'a, P: Fp768Parameters> SubAssign<&'a Self> for Fp768<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp768, Fp768Parameters);
 impl<'a, P: Fp768Parameters> MulAssign<&'a Self> for Fp768<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_768.rs
+++ b/algebra/src/fields/models/fp_768.rs
@@ -31,6 +31,7 @@ pub trait Fp768Parameters: FpParameters<BigInt = BigInteger> {}
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp768Parameters"]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),

--- a/algebra/src/fields/models/fp_832.rs
+++ b/algebra/src/fields/models/fp_832.rs
@@ -41,19 +41,21 @@ pub trait Fp832Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp832<P: Fp832Parameters>(
+pub struct Fp832<P>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]
     pub PhantomData<P>,
 );
 
-impl<P: Fp832Parameters> Fp832<P> {
+impl<P> Fp832<P> {
     #[inline]
-    pub fn new(element: BigInteger) -> Self {
+    pub const fn new(element: BigInteger) -> Self {
         Self(element, PhantomData)
     }
+}
 
+impl<P: Fp832Parameters> Fp832<P> {
     #[inline]
     pub(crate) fn is_valid(&self) -> bool {
         self.0 < P::MODULUS

--- a/algebra/src/fields/models/fp_832.rs
+++ b/algebra/src/fields/models/fp_832.rs
@@ -5,7 +5,10 @@ use crate::{
 };
 use num_traits::{One, Zero};
 
-use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
+use algebra_derive::{
+    AddAssignFromRef, AddFromRef, DivAssignFromRef, DivFromRef, MulAssignFromRef, MulFromRef,
+    SubAssignFromRef, SubFromRef,
+};
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Display, Formatter, Result as FmtResult},
@@ -17,7 +20,17 @@ use std::{
 
 pub trait Fp832Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
+#[derive(
+    AddFromRef,
+    MulFromRef,
+    AddAssignFromRef,
+    MulAssignFromRef,
+    Derivative,
+    SubFromRef,
+    SubAssignFromRef,
+    DivFromRef,
+    DivAssignFromRef,
+)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -27,21 +40,19 @@ pub trait Fp832Parameters: FpParameters<BigInt = BigInteger> {}
     PartialEq(bound = ""),
     Eq(bound = "")
 )]
-pub struct Fp832<P>(
+pub struct Fp832<P: Fp832Parameters>(
     pub BigInteger,
     #[derivative(Debug = "ignore")]
     #[doc(hidden)]
     pub PhantomData<P>,
 );
 
-impl<P> Fp832<P> {
+impl<P: Fp832Parameters> Fp832<P> {
     #[inline]
-    pub const fn new(element: BigInteger) -> Self {
+    pub fn new(element: BigInteger) -> Self {
         Self(element, PhantomData)
     }
-}
 
-impl<P: Fp832Parameters> Fp832<P> {
     #[inline]
     pub(crate) fn is_valid(&self) -> bool {
         self.0 < P::MODULUS

--- a/algebra/src/fields/models/fp_832.rs
+++ b/algebra/src/fields/models/fp_832.rs
@@ -4,6 +4,8 @@ use crate::{
     fields::{Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
 };
 use num_traits::{One, Zero};
+
+use algebra_derive::{AddAssignFromRef, AddFromRef, MulAssignFromRef, MulFromRef};
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt::{Display, Formatter, Result as FmtResult},
@@ -15,7 +17,7 @@ use std::{
 
 pub trait Fp832Parameters: FpParameters<BigInt = BigInteger> {}
 
-#[derive(Derivative)]
+#[derive(AddFromRef, MulFromRef, AddAssignFromRef, MulAssignFromRef, Derivative)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -825,17 +827,6 @@ impl<P: Fp832Parameters> Neg for Fp832<P> {
     }
 }
 
-impl<P: Fp832Parameters> Add<Fp832<P>> for Fp832<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp832Parameters> Add<&'a Fp832<P>> for Fp832<P> {
     type Output = Self;
 
@@ -854,17 +845,6 @@ impl<'a, P: Fp832Parameters> Sub<&'a Fp832<P>> for Fp832<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self.clone();
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp832Parameters> Mul<Fp832<P>> for Fp832<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.mul_assign(&other);
         result
     }
 }
@@ -891,7 +871,6 @@ impl<'a, P: Fp832Parameters> Div<&'a Fp832<P>> for Fp832<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp832, Fp832Parameters);
 impl<'a, P: Fp832Parameters> AddAssign<&'a Self> for Fp832<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -914,7 +893,6 @@ impl<'a, P: Fp832Parameters> SubAssign<&'a Self> for Fp832<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp832, Fp832Parameters);
 impl<'a, P: Fp832Parameters> MulAssign<&'a Self> for Fp832<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_832.rs
+++ b/algebra/src/fields/models/fp_832.rs
@@ -31,6 +31,7 @@ pub trait Fp832Parameters: FpParameters<BigInt = BigInteger> {}
     DivFromRef,
     DivAssignFromRef,
 )]
+#[ArithmeticBound = "Fp832Parameters"]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),


### PR DESCRIPTION
The derive macros defer to the versions implemented on `Self`-type references.
This eliminates a lot of the impl boilerplate (& might go away when Rust figures out how to to autoref/deref on operators).

Hopefully this also serves as inspiration for extension of the approach to Sub, Neg ...