### PR TITLE
Add `X`, `XAssign` ops for `X in {Add, Sub, Mul, Div}` when taking arguments by value.

### DIFF
--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     fields::{Field, PrimeField, SquareRootField},
     groups::Group,
     UniformRand,
+    Vec,
 };
 use core::{
     fmt::{Debug, Display},
@@ -118,11 +119,16 @@ pub trait ProjectiveCurve:
     + Zero
     + 'static
     + Neg<Output = Self>
-    + for<'a> Add<&'a Self, Output = Self>
     + Add<Self, Output = Self>
+    + Sub<Self, Output = Self>
+    + AddAssign<Self>
+    + SubAssign<Self>
+    + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>
+    + core::iter::Sum<Self>
+    + for<'a> core::iter::Sum<&'a Self>
 {
     type ScalarField: PrimeField + SquareRootField + Into<<Self::ScalarField as PrimeField>::BigInt>;
     type BaseField: Field;
@@ -135,6 +141,14 @@ pub trait ProjectiveCurve:
     /// Normalizes a slice of projective elements so that
     /// conversion to affine is cheap.
     fn batch_normalization(v: &mut [Self]);
+
+    /// Normalizes a slice of projective elements and outputs a vector
+    /// containing the affine equivalents.
+    fn batch_normalization_into_affine(v: &[Self]) -> Vec<Self::Affine> {
+        let mut v = v.to_vec();
+        Self::batch_normalization(&mut v);
+        v.into_iter().map(|v| v.into_affine()).collect()
+    }
 
     /// Checks if the point is already "normalized" so that
     /// cheap affine conversion is possible.

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -547,7 +547,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
             }
 
             if i {
-                res.add_assign(self);
+                res += &*self;
             }
         }
 
@@ -583,16 +583,7 @@ impl<P: Parameters> Neg for GroupProjective<P> {
     }
 }
 
-impl<P: Parameters> Add<Self> for GroupProjective<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut copy = self;
-        copy += &other;
-        copy
-    }
-}
+crate::impl_additive_ops_from_ref!(GroupProjective, Parameters);
 
 impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
     type Output = Self;

--- a/algebra/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra/src/curves/models/short_weierstrass_projective.rs
@@ -461,7 +461,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
             }
 
             if i {
-                res.add_assign(self);
+                res += &*self;
             }
         }
 
@@ -492,14 +492,7 @@ impl<P: Parameters> Neg for GroupProjective<P> {
     }
 }
 
-impl<P: Parameters> Add<Self> for GroupProjective<P> {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        let mut copy = self;
-        copy += &other;
-        copy
-    }
-}
+crate::impl_additive_ops_from_ref!(GroupProjective, Parameters);
 
 impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
     type Output = Self;

--- a/algebra/src/curves/models/twisted_edwards_extended/mod.rs
+++ b/algebra/src/curves/models/twisted_edwards_extended/mod.rs
@@ -160,14 +160,7 @@ impl<P: Parameters> Neg for GroupAffine<P> {
     }
 }
 
-impl<P: Parameters> Add<Self> for GroupAffine<P> {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        let mut copy = self;
-        copy += &other;
-        copy
-    }
-}
+crate::impl_additive_ops_from_ref!(GroupAffine, Parameters);
 
 impl<'a, P: Parameters> Add<&'a Self> for GroupAffine<P> {
     type Output = Self;
@@ -281,7 +274,7 @@ mod group_impl {
         #[inline]
         fn double_in_place(&mut self) -> &mut Self {
             let mut tmp = *self;
-            tmp += self;
+            tmp += &*self;
             *self = tmp;
             self
         }
@@ -499,7 +492,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
             }
 
             if i {
-                res.add_assign(self);
+                res += &*self;
             }
         }
 
@@ -528,14 +521,7 @@ impl<P: Parameters> Neg for GroupProjective<P> {
     }
 }
 
-impl<P: Parameters> Add<Self> for GroupProjective<P> {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        let mut copy = self;
-        copy += &other;
-        copy
-    }
-}
+crate::impl_additive_ops_from_ref!(GroupProjective, Parameters);
 
 impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
     type Output = Self;

--- a/algebra/src/fields/macros.rs
+++ b/algebra/src/fields/macros.rs
@@ -118,22 +118,115 @@ macro_rules! sqrt_impl {
 }
 
 // Implements AddAssign on Self by deferring to an implementation on &Self
-macro_rules! impl_addassign_from_ref {
+macro_rules! impl_additive_ops_from_ref {
     ($field: ident, $params: ident) => {
-        impl<P: $params> AddAssign<Self> for $field<P> {
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::Add<Self> for $field<P> {
+            type Output = Self;
+
+            #[inline]
+            fn add(self, other: Self) -> Self {
+                let mut result = self;
+                result.add_assign(&other);
+                result
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::Sub<Self> for $field<P> {
+            type Output = Self;
+
+            #[inline]
+            fn sub(self, other: Self) -> Self {
+                let mut result = self;
+                result.sub_assign(&other);
+                result
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::iter::Sum<Self> for $field<P> {
+            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::zero(), core::ops::Add::add)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<'a, P: $params> core::iter::Sum<&'a Self> for $field<P> {
+            fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+                iter.fold(Self::zero(), core::ops::Add::add)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::AddAssign<Self> for $field<P> {
             fn add_assign(&mut self, other: Self) {
                 self.add_assign(&other)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::SubAssign<Self> for $field<P> {
+            fn sub_assign(&mut self, other: Self) {
+                self.sub_assign(&other)
             }
         }
     };
 }
 
-// Implements MulAssign on Self by deferring to an implementation on &Self
-macro_rules! impl_mulassign_from_ref {
+// Implements AddAssign on Self by deferring to an implementation on &Self
+macro_rules! impl_multiplicative_ops_from_ref {
     ($field: ident, $params: ident) => {
-        impl<P: $params> MulAssign<Self> for $field<P> {
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::Mul<Self> for $field<P> {
+            type Output = Self;
+
+            #[inline]
+            fn mul(self, other: Self) -> Self {
+                let mut result = self;
+                result.mul_assign(&other);
+                result
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::Div<Self> for $field<P> {
+            type Output = Self;
+
+            #[inline]
+            fn div(self, other: Self) -> Self {
+                let mut result = self;
+                result.div_assign(&other);
+                result
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::iter::Product<Self> for $field<P> {
+            fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::one(), core::ops::Mul::mul)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<'a, P: $params> core::iter::Product<&'a Self> for $field<P> {
+            fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+                iter.fold(Self::one(), Mul::mul)
+            }
+        }
+
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::MulAssign<Self> for $field<P> {
             fn mul_assign(&mut self, other: Self) {
                 self.mul_assign(&other)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::DivAssign<Self> for $field<P> {
+            fn div_assign(&mut self, other: Self) {
+                self.div_assign(&other)
             }
         }
     };

--- a/algebra/src/fields/macros.rs
+++ b/algebra/src/fields/macros.rs
@@ -118,10 +118,11 @@ macro_rules! sqrt_impl {
 }
 
 // Implements AddAssign on Self by deferring to an implementation on &Self
+#[macro_export]
 macro_rules! impl_additive_ops_from_ref {
-    ($field: ident, $params: ident) => {
+    ($type: ident, $params: ident) => {
         #[allow(unused_qualifications)]
-        impl<P: $params> core::ops::Add<Self> for $field<P> {
+        impl<P: $params> core::ops::Add<Self> for $type<P> {
             type Output = Self;
 
             #[inline]
@@ -133,7 +134,19 @@ macro_rules! impl_additive_ops_from_ref {
         }
 
         #[allow(unused_qualifications)]
-        impl<P: $params> core::ops::Sub<Self> for $field<P> {
+        impl<'a, P: $params> core::ops::Add<&'a mut Self> for $type<P> {
+            type Output = Self;
+
+            #[inline]
+            fn add(self, other: &'a mut Self) -> Self {
+                let mut result = self;
+                result.add_assign(&*other);
+                result
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::Sub<Self> for $type<P> {
             type Output = Self;
 
             #[inline]
@@ -145,40 +158,67 @@ macro_rules! impl_additive_ops_from_ref {
         }
 
         #[allow(unused_qualifications)]
-        impl<P: $params> core::iter::Sum<Self> for $field<P> {
+        impl<'a, P: $params> core::ops::Sub<&'a mut Self> for $type<P> {
+            type Output = Self;
+
+            #[inline]
+            fn sub(self, other: &'a mut Self) -> Self {
+                let mut result = self;
+                result.sub_assign(&*other);
+                result
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::iter::Sum<Self> for $type<P> {
             fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
                 iter.fold(Self::zero(), core::ops::Add::add)
             }
         }
 
         #[allow(unused_qualifications)]
-        impl<'a, P: $params> core::iter::Sum<&'a Self> for $field<P> {
+        impl<'a, P: $params> core::iter::Sum<&'a Self> for $type<P> {
             fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
                 iter.fold(Self::zero(), core::ops::Add::add)
             }
         }
 
         #[allow(unused_qualifications)]
-        impl<P: $params> core::ops::AddAssign<Self> for $field<P> {
+        impl<P: $params> core::ops::AddAssign<Self> for $type<P> {
             fn add_assign(&mut self, other: Self) {
                 self.add_assign(&other)
             }
         }
 
         #[allow(unused_qualifications)]
-        impl<P: $params> core::ops::SubAssign<Self> for $field<P> {
+        impl<P: $params> core::ops::SubAssign<Self> for $type<P> {
             fn sub_assign(&mut self, other: Self) {
                 self.sub_assign(&other)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<'a, P: $params> core::ops::AddAssign<&'a mut Self> for $type<P> {
+            fn add_assign(&mut self, other: &'a mut Self) {
+                self.add_assign(&*other)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<'a, P: $params> core::ops::SubAssign<&'a mut Self> for $type<P> {
+            fn sub_assign(&mut self, other: &'a mut Self) {
+                self.sub_assign(&*other)
             }
         }
     };
 }
 
 // Implements AddAssign on Self by deferring to an implementation on &Self
+#[macro_export]
 macro_rules! impl_multiplicative_ops_from_ref {
-    ($field: ident, $params: ident) => {
+    ($type: ident, $params: ident) => {
         #[allow(unused_qualifications)]
-        impl<P: $params> core::ops::Mul<Self> for $field<P> {
+        impl<P: $params> core::ops::Mul<Self> for $type<P> {
             type Output = Self;
 
             #[inline]
@@ -190,7 +230,7 @@ macro_rules! impl_multiplicative_ops_from_ref {
         }
 
         #[allow(unused_qualifications)]
-        impl<P: $params> core::ops::Div<Self> for $field<P> {
+        impl<P: $params> core::ops::Div<Self> for $type<P> {
             type Output = Self;
 
             #[inline]
@@ -202,29 +242,66 @@ macro_rules! impl_multiplicative_ops_from_ref {
         }
 
         #[allow(unused_qualifications)]
-        impl<P: $params> core::iter::Product<Self> for $field<P> {
+        impl<'a, P: $params> core::ops::Mul<&'a mut Self> for $type<P> {
+            type Output = Self;
+
+            #[inline]
+            fn mul(self, other: &'a mut Self) -> Self {
+                let mut result = self;
+                result.mul_assign(&*other);
+                result
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<'a, P: $params> core::ops::Div<&'a mut Self> for $type<P> {
+            type Output = Self;
+
+            #[inline]
+            fn div(self, other: &'a mut Self) -> Self {
+                let mut result = self;
+                result.div_assign(&*other);
+                result
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::iter::Product<Self> for $type<P> {
             fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
                 iter.fold(Self::one(), core::ops::Mul::mul)
             }
         }
 
         #[allow(unused_qualifications)]
-        impl<'a, P: $params> core::iter::Product<&'a Self> for $field<P> {
+        impl<'a, P: $params> core::iter::Product<&'a Self> for $type<P> {
             fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
                 iter.fold(Self::one(), Mul::mul)
             }
         }
 
-
         #[allow(unused_qualifications)]
-        impl<P: $params> core::ops::MulAssign<Self> for $field<P> {
+        impl<P: $params> core::ops::MulAssign<Self> for $type<P> {
             fn mul_assign(&mut self, other: Self) {
                 self.mul_assign(&other)
             }
         }
 
         #[allow(unused_qualifications)]
-        impl<P: $params> core::ops::DivAssign<Self> for $field<P> {
+        impl<'a, P: $params> core::ops::DivAssign<&'a mut Self> for $type<P> {
+            fn div_assign(&mut self, other: &'a mut Self) {
+                self.div_assign(&*other)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<'a, P: $params> core::ops::MulAssign<&'a mut Self> for $type<P> {
+            fn mul_assign(&mut self, other: &'a mut Self) {
+                self.mul_assign(&*other)
+            }
+        }
+
+        #[allow(unused_qualifications)]
+        impl<P: $params> core::ops::DivAssign<Self> for $type<P> {
             fn div_assign(&mut self, other: Self) {
                 self.div_assign(&other)
             }

--- a/algebra/src/fields/mod.rs
+++ b/algebra/src/fields/mod.rs
@@ -12,7 +12,7 @@ use core::{
 use num_traits::{One, Zero};
 
 #[macro_use]
-mod macros;
+pub mod macros;
 
 pub mod bls12_377;
 pub mod bls12_381;

--- a/algebra/src/fields/mod.rs
+++ b/algebra/src/fields/mod.rs
@@ -75,15 +75,25 @@ pub trait Field:
     + CanonicalSerialize
     + CanonicalDeserialize
     + Add<Self, Output = Self>
+    + Sub<Self, Output = Self>
+    + Mul<Self, Output = Self>
+    + Div<Self, Output = Self>
+    + AddAssign<Self>
+    + SubAssign<Self>
+    + MulAssign<Self>
+    + DivAssign<Self>
     + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
-    + Mul<Self, Output = Self>
     + for<'a> Mul<&'a Self, Output = Self>
     + for<'a> Div<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>
     + for<'a> MulAssign<&'a Self>
     + for<'a> DivAssign<&'a Self>
+    + core::iter::Sum<Self>
+    + for<'a> core::iter::Sum<&'a Self>
+    + core::iter::Product<Self>
+    + for<'a> core::iter::Product<&'a Self>
 {
     /// Returns the characteristic of the field.
     fn characteristic<'a>() -> &'a [u64];
@@ -336,7 +346,7 @@ pub fn batch_inversion<F: Field>(v: &mut [F]) {
     let mut prod = Vec::with_capacity(v.len());
     let mut tmp = F::one();
     for f in v.iter().filter(|f| !f.is_zero()) {
-        tmp.mul_assign(&f);
+        tmp.mul_assign(f);
         prod.push(tmp);
     }
 

--- a/algebra/src/fields/models/fp12_2over3over2.rs
+++ b/algebra/src/fields/models/fp12_2over3over2.rs
@@ -384,7 +384,6 @@ impl<'a, P: Fp12Parameters> Div<&'a Self> for Fp12<P> {
     }
 }
 
-
 impl_additive_ops_from_ref!(Fp12, Fp12Parameters);
 impl_multiplicative_ops_from_ref!(Fp12, Fp12Parameters);
 

--- a/algebra/src/fields/models/fp12_2over3over2.rs
+++ b/algebra/src/fields/models/fp12_2over3over2.rs
@@ -340,17 +340,6 @@ impl<P: Fp12Parameters> Neg for Fp12<P> {
     }
 }
 
-impl<P: Fp12Parameters> Add<Self> for Fp12<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp12Parameters> Add<&'a Self> for Fp12<P> {
     type Output = Self;
 
@@ -368,18 +357,7 @@ impl<'a, P: Fp12Parameters> Sub<&'a Self> for Fp12<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
-        result
-    }
-}
-
-impl<P: Fp12Parameters> Mul<Self> for Fp12<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(other);
+        result.sub_assign(other);
         result
     }
 }
@@ -406,7 +384,10 @@ impl<'a, P: Fp12Parameters> Div<&'a Self> for Fp12<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp12, Fp12Parameters);
+
+impl_additive_ops_from_ref!(Fp12, Fp12Parameters);
+impl_multiplicative_ops_from_ref!(Fp12, Fp12Parameters);
+
 impl<'a, P: Fp12Parameters> AddAssign<&'a Self> for Fp12<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -423,7 +404,6 @@ impl<'a, P: Fp12Parameters> SubAssign<&'a Self> for Fp12<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp12, Fp12Parameters);
 impl<'a, P: Fp12Parameters> MulAssign<&'a Self> for Fp12<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp2.rs
+++ b/algebra/src/fields/models/fp2.rs
@@ -303,17 +303,6 @@ impl<P: Fp2Parameters> Distribution<Fp2<P>> for Standard {
     }
 }
 
-impl<P: Fp2Parameters> Add<Fp2<P>> for Fp2<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp2Parameters> Add<&'a Fp2<P>> for Fp2<P> {
     type Output = Self;
 
@@ -331,18 +320,7 @@ impl<'a, P: Fp2Parameters> Sub<&'a Fp2<P>> for Fp2<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
-        result
-    }
-}
-
-impl<P: Fp2Parameters> Mul<Fp2<P>> for Fp2<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(&other);
+        result.sub_assign(other);
         result
     }
 }
@@ -369,7 +347,6 @@ impl<'a, P: Fp2Parameters> Div<&'a Fp2<P>> for Fp2<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp2, Fp2Parameters);
 impl<'a, P: Fp2Parameters> AddAssign<&'a Self> for Fp2<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -386,7 +363,9 @@ impl<'a, P: Fp2Parameters> SubAssign<&'a Self> for Fp2<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp2, Fp2Parameters);
+impl_additive_ops_from_ref!(Fp2, Fp2Parameters);
+impl_multiplicative_ops_from_ref!(Fp2, Fp2Parameters);
+
 impl<'a, P: Fp2Parameters> MulAssign<&'a Self> for Fp2<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp3.rs
+++ b/algebra/src/fields/models/fp3.rs
@@ -356,17 +356,6 @@ impl<P: Fp3Parameters> Distribution<Fp3<P>> for Standard {
     }
 }
 
-impl<P: Fp3Parameters> Add<Fp3<P>> for Fp3<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp3Parameters> Add<&'a Fp3<P>> for Fp3<P> {
     type Output = Self;
 
@@ -384,18 +373,7 @@ impl<'a, P: Fp3Parameters> Sub<&'a Fp3<P>> for Fp3<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
-        result
-    }
-}
-
-impl<'a, P: Fp3Parameters> Mul<Fp3<P>> for Fp3<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(&other);
+        result.sub_assign(other);
         result
     }
 }
@@ -422,7 +400,8 @@ impl<'a, P: Fp3Parameters> Div<&'a Fp3<P>> for Fp3<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp3, Fp3Parameters);
+impl_additive_ops_from_ref!(Fp3, Fp3Parameters);
+impl_multiplicative_ops_from_ref!(Fp3, Fp3Parameters);
 impl<'a, P: Fp3Parameters> AddAssign<&'a Self> for Fp3<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -441,7 +420,6 @@ impl<'a, P: Fp3Parameters> SubAssign<&'a Self> for Fp3<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp3, Fp3Parameters);
 impl<'a, P: Fp3Parameters> MulAssign<&'a Self> for Fp3<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp6_2over3.rs
+++ b/algebra/src/fields/models/fp6_2over3.rs
@@ -294,17 +294,6 @@ impl<P: Fp6Parameters> Distribution<Fp6<P>> for Standard {
     }
 }
 
-impl<P: Fp6Parameters> Add<Fp6<P>> for Fp6<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp6Parameters> Add<&'a Fp6<P>> for Fp6<P> {
     type Output = Self;
 
@@ -322,18 +311,7 @@ impl<'a, P: Fp6Parameters> Sub<&'a Fp6<P>> for Fp6<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
-        result
-    }
-}
-
-impl<P: Fp6Parameters> Mul<Fp6<P>> for Fp6<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(other);
+        result.sub_assign(other);
         result
     }
 }
@@ -360,7 +338,9 @@ impl<'a, P: Fp6Parameters> Div<&'a Fp6<P>> for Fp6<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp6, Fp6Parameters);
+impl_additive_ops_from_ref!(Fp6, Fp6Parameters);
+impl_multiplicative_ops_from_ref!(Fp6, Fp6Parameters);
+
 impl<'a, P: Fp6Parameters> AddAssign<&'a Self> for Fp6<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -377,7 +357,6 @@ impl<'a, P: Fp6Parameters> SubAssign<&'a Self> for Fp6<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp6, Fp6Parameters);
 impl<'a, P: Fp6Parameters> MulAssign<&'a Self> for Fp6<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp6_3over2.rs
+++ b/algebra/src/fields/models/fp6_3over2.rs
@@ -303,17 +303,6 @@ impl<P: Fp6Parameters> Neg for Fp6<P> {
     }
 }
 
-impl<P: Fp6Parameters> Add<Self> for Fp6<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp6Parameters> Add<&'a Self> for Fp6<P> {
     type Output = Self;
 
@@ -331,18 +320,7 @@ impl<'a, P: Fp6Parameters> Sub<&'a Self> for Fp6<P> {
     #[inline]
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
-        result.sub_assign(&other);
-        result
-    }
-}
-
-impl<P: Fp6Parameters> Mul<Self> for Fp6<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(other);
+        result.sub_assign(other);
         result
     }
 }
@@ -369,7 +347,9 @@ impl<'a, P: Fp6Parameters> Div<&'a Self> for Fp6<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp6, Fp6Parameters);
+impl_additive_ops_from_ref!(Fp6, Fp6Parameters);
+impl_multiplicative_ops_from_ref!(Fp6, Fp6Parameters);
+
 impl<'a, P: Fp6Parameters> AddAssign<&'a Self> for Fp6<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -388,7 +368,6 @@ impl<'a, P: Fp6Parameters> SubAssign<&'a Self> for Fp6<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp6, Fp6Parameters);
 impl<'a, P: Fp6Parameters> MulAssign<&'a Self> for Fp6<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_256.rs
+++ b/algebra/src/fields/models/fp_256.rs
@@ -467,17 +467,6 @@ impl<P: Fp256Parameters> Neg for Fp256<P> {
     }
 }
 
-impl<P: Fp256Parameters> Add<Fp256<P>> for Fp256<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self;
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp256Parameters> Add<&'a Fp256<P>> for Fp256<P> {
     type Output = Self;
 
@@ -496,17 +485,6 @@ impl<'a, P: Fp256Parameters> Sub<&'a Fp256<P>> for Fp256<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self;
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp256Parameters> Mul<Fp256<P>> for Fp256<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self;
-        result.mul_assign(&other);
         result
     }
 }
@@ -533,7 +511,9 @@ impl<'a, P: Fp256Parameters> Div<&'a Fp256<P>> for Fp256<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp256, Fp256Parameters);
+impl_additive_ops_from_ref!(Fp256, Fp256Parameters);
+impl_multiplicative_ops_from_ref!(Fp256, Fp256Parameters);
+
 impl<'a, P: Fp256Parameters> AddAssign<&'a Self> for Fp256<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -557,7 +537,6 @@ impl<'a, P: Fp256Parameters> SubAssign<&'a Self> for Fp256<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp256, Fp256Parameters);
 impl<'a, P: Fp256Parameters> MulAssign<&'a Self> for Fp256<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_320.rs
+++ b/algebra/src/fields/models/fp_320.rs
@@ -493,17 +493,6 @@ impl<P: Fp320Parameters> Neg for Fp320<P> {
     }
 }
 
-impl<P: Fp320Parameters> Add<Fp320<P>> for Fp320<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp320Parameters> Add<&'a Fp320<P>> for Fp320<P> {
     type Output = Self;
 
@@ -522,17 +511,6 @@ impl<'a, P: Fp320Parameters> Sub<&'a Fp320<P>> for Fp320<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self.clone();
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp320Parameters> Mul<Fp320<P>> for Fp320<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.mul_assign(&other);
         result
     }
 }
@@ -559,7 +537,9 @@ impl<'a, P: Fp320Parameters> Div<&'a Fp320<P>> for Fp320<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp320, Fp320Parameters);
+impl_additive_ops_from_ref!(Fp320, Fp320Parameters);
+impl_multiplicative_ops_from_ref!(Fp320, Fp320Parameters);
+
 impl<'a, P: Fp320Parameters> AddAssign<&'a Self> for Fp320<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -582,7 +562,6 @@ impl<'a, P: Fp320Parameters> SubAssign<&'a Self> for Fp320<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp320, Fp320Parameters);
 impl<'a, P: Fp320Parameters> MulAssign<&'a Self> for Fp320<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_384.rs
+++ b/algebra/src/fields/models/fp_384.rs
@@ -525,17 +525,6 @@ impl<P: Fp384Parameters> Neg for Fp384<P> {
     }
 }
 
-impl<P: Fp384Parameters> Add<Fp384<P>> for Fp384<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp384Parameters> Add<&'a Fp384<P>> for Fp384<P> {
     type Output = Self;
 
@@ -554,17 +543,6 @@ impl<'a, P: Fp384Parameters> Sub<&'a Fp384<P>> for Fp384<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self.clone();
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp384Parameters> Mul<Fp384<P>> for Fp384<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.mul_assign(&other);
         result
     }
 }
@@ -591,7 +569,9 @@ impl<'a, P: Fp384Parameters> Div<&'a Fp384<P>> for Fp384<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp384, Fp384Parameters);
+impl_additive_ops_from_ref!(Fp384, Fp384Parameters);
+impl_multiplicative_ops_from_ref!(Fp384, Fp384Parameters);
+
 impl<'a, P: Fp384Parameters> AddAssign<&'a Self> for Fp384<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -614,7 +594,6 @@ impl<'a, P: Fp384Parameters> SubAssign<&'a Self> for Fp384<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp384, Fp384Parameters);
 impl<'a, P: Fp384Parameters> MulAssign<&'a Self> for Fp384<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_768.rs
+++ b/algebra/src/fields/models/fp_768.rs
@@ -855,17 +855,6 @@ impl<P: Fp768Parameters> Neg for Fp768<P> {
     }
 }
 
-impl<P: Fp768Parameters> Add<Fp768<P>> for Fp768<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp768Parameters> Add<&'a Fp768<P>> for Fp768<P> {
     type Output = Self;
 
@@ -884,17 +873,6 @@ impl<'a, P: Fp768Parameters> Sub<&'a Fp768<P>> for Fp768<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self.clone();
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp768Parameters> Mul<Fp768<P>> for Fp768<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.mul_assign(&other);
         result
     }
 }
@@ -921,7 +899,9 @@ impl<'a, P: Fp768Parameters> Div<&'a Fp768<P>> for Fp768<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp768, Fp768Parameters);
+impl_additive_ops_from_ref!(Fp768, Fp768Parameters);
+impl_multiplicative_ops_from_ref!(Fp768, Fp768Parameters);
+
 impl<'a, P: Fp768Parameters> AddAssign<&'a Self> for Fp768<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -944,7 +924,6 @@ impl<'a, P: Fp768Parameters> SubAssign<&'a Self> for Fp768<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp768, Fp768Parameters);
 impl<'a, P: Fp768Parameters> MulAssign<&'a Self> for Fp768<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/fields/models/fp_832.rs
+++ b/algebra/src/fields/models/fp_832.rs
@@ -823,17 +823,6 @@ impl<P: Fp832Parameters> Neg for Fp832<P> {
     }
 }
 
-impl<P: Fp832Parameters> Add<Fp832<P>> for Fp832<P> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.add_assign(&other);
-        result
-    }
-}
-
 impl<'a, P: Fp832Parameters> Add<&'a Fp832<P>> for Fp832<P> {
     type Output = Self;
 
@@ -852,17 +841,6 @@ impl<'a, P: Fp832Parameters> Sub<&'a Fp832<P>> for Fp832<P> {
     fn sub(self, other: &Self) -> Self {
         let mut result = self.clone();
         result.sub_assign(other);
-        result
-    }
-}
-
-impl<P: Fp832Parameters> Mul<Fp832<P>> for Fp832<P> {
-    type Output = Self;
-
-    #[inline]
-    fn mul(self, other: Self) -> Self {
-        let mut result = self.clone();
-        result.mul_assign(&other);
         result
     }
 }
@@ -889,7 +867,9 @@ impl<'a, P: Fp832Parameters> Div<&'a Fp832<P>> for Fp832<P> {
     }
 }
 
-impl_addassign_from_ref!(Fp832, Fp832Parameters);
+impl_additive_ops_from_ref!(Fp832, Fp832Parameters);
+impl_multiplicative_ops_from_ref!(Fp832, Fp832Parameters);
+
 impl<'a, P: Fp832Parameters> AddAssign<&'a Self> for Fp832<P> {
     #[inline]
     fn add_assign(&mut self, other: &Self) {
@@ -912,7 +892,6 @@ impl<'a, P: Fp832Parameters> SubAssign<&'a Self> for Fp832<P> {
     }
 }
 
-impl_mulassign_from_ref!(Fp832, Fp832Parameters);
 impl<'a, P: Fp832Parameters> MulAssign<&'a Self> for Fp832<P> {
     #[inline]
     fn mul_assign(&mut self, other: &Self) {

--- a/algebra/src/groups/mod.rs
+++ b/algebra/src/groups/mod.rs
@@ -31,10 +31,15 @@ pub trait Group:
     + UniformRand
     + Zero
     + Add<Self, Output = Self>
+    + Sub<Self, Output = Self>
+    + AddAssign<Self>
+    + SubAssign<Self>
     + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + for<'a> SubAssign<&'a Self>
+    + core::iter::Sum<Self>
+    + for<'a> core::iter::Sum<&'a Self>
 {
     type ScalarField: PrimeField + Into<<Self::ScalarField as PrimeField>::BigInt>;
 
@@ -57,7 +62,7 @@ pub trait Group:
         for i in BitIterator::new(other.into_repr()) {
             res.double_in_place();
             if i {
-                res += self
+                res += &*self
             }
         }
         *self = res

--- a/algebra/src/lib.rs
+++ b/algebra/src/lib.rs
@@ -68,15 +68,15 @@ pub use self::bytes::*;
 pub mod serialize;
 pub use self::serialize::*;
 
+#[macro_use]
+pub mod fields;
+pub use self::fields::*;
+
 pub mod biginteger;
 pub use self::biginteger::*;
 
 pub mod curves;
 pub use self::curves::*;
-
-#[macro_use]
-pub mod fields;
-pub use self::fields::*;
 
 pub mod groups;
 pub use self::groups::*;

--- a/algebra/src/msm/variable_base.rs
+++ b/algebra/src/msm/variable_base.rs
@@ -91,7 +91,7 @@ impl VariableBaseMSM {
                 }
                 total
             })
-            + *lowest
+            + lowest
     }
 
     pub fn multi_scalar_mul<G: AffineCurve>(

--- a/ff-fft/src/polynomial/dense.rs
+++ b/ff-fft/src/polynomial/dense.rs
@@ -109,8 +109,6 @@ impl<F: Field> DensePolynomial<F> {
             .zip(&self.coeffs)
             .map(|(power, coeff)| power * coeff)
             .sum()
-
-        
     }
 
     /// Perform a naive n^2 multiplication of `self` by `other`.

--- a/ff-fft/src/polynomial/dense.rs
+++ b/ff-fft/src/polynomial/dense.rs
@@ -105,25 +105,12 @@ impl<F: Field> DensePolynomial<F> {
             cur *= &point;
         }
         assert_eq!(powers_of_point.len(), self.coeffs.len());
-        let zero = F::zero();
+        cfg_into_iter!(powers_of_point)
+            .zip(&self.coeffs)
+            .map(|(power, coeff)| power * coeff)
+            .sum()
 
-        #[cfg(feature = "parallel")]
-        {
-            powers_of_point
-                .into_par_iter()
-                .zip(&self.coeffs)
-                .map(|(power, coeff)| power * coeff)
-                .reduce(|| zero, |a, b| a + &b)
-        }
-
-        #[cfg(not(feature = "parallel"))]
-        {
-            powers_of_point
-                .into_iter()
-                .zip(&self.coeffs)
-                .map(|(power, coeff)| power * coeff)
-                .fold(zero, |a, b| a + &b)
-        }
+        
     }
 
     /// Perform a naive n^2 multiplication of `self` by `other`.

--- a/gm17/src/prover.rs
+++ b/gm17/src/prover.rs
@@ -302,7 +302,7 @@ where
     let c2_inputs_acc = VariableBaseMSM::multi_scalar_mul(c2_inputs_source, &input_assignment);
     let c2_aux_acc = VariableBaseMSM::multi_scalar_mul(c2_aux_source, &aux_assignment);
 
-    let c2_acc = c2_inputs_acc + c2_aux_acc;
+    let c2_acc = c2_inputs_acc + &c2_aux_acc;
     end_timer!(c2_acc_time);
 
     // Compute G
@@ -312,7 +312,7 @@ where
     let g_inputs_acc = VariableBaseMSM::multi_scalar_mul(g_inputs_source, &h_input);
     let g_aux_acc = VariableBaseMSM::multi_scalar_mul(g_aux_source, &h_aux);
 
-    let g_acc = g_inputs_acc + g_aux_acc;
+    let g_acc = g_inputs_acc + &g_aux_acc;
     end_timer!(g_acc_time);
 
     let r2_g_gamma2_z2 = params.get_g_gamma2_z2()?.mul(r2);

--- a/r1cs-std/src/test_constraint_system.rs
+++ b/r1cs-std/src/test_constraint_system.rs
@@ -37,8 +37,8 @@ impl<ConstraintF: Field> TestConstraintSystem<ConstraintF> {
                 Index::Aux(index) => aux[index].0,
             };
 
-            tmp.mul_assign(&coeff);
-            acc.add_assign(&tmp);
+            tmp *= coeff;
+            acc += tmp;
         }
 
         acc


### PR DESCRIPTION
Supersedes #62.