### PR TITLE
Serialize and Deserialize Uncompressed

### DIFF
--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -2,8 +2,8 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, PrimeField, SquareRootField},
     groups::Group,
-    UniformRand,
-    Vec,
+    UniformRand, Vec,
+    serialize::{GroupDeserialize, GroupSerialize, CanonicalDeserialize, CanonicalSerialize},
 };
 use core::{
     fmt::{Debug, Display},
@@ -203,6 +203,10 @@ pub trait AffineCurve:
     + Debug
     + Display
     + Zero
+    + CanonicalSerialize
+    + CanonicalDeserialize
+    + GroupSerialize
+    + GroupDeserialize
     + Neg<Output = Self>
     + 'static
 {

--- a/algebra/src/curves/mod.rs
+++ b/algebra/src/curves/mod.rs
@@ -2,8 +2,8 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, PrimeField, SquareRootField},
     groups::Group,
-    UniformRand, Vec,
     serialize::{GroupDeserialize, GroupSerialize, CanonicalDeserialize, CanonicalSerialize},
+    UniformRand, Vec,
 };
 use core::{
     fmt::{Debug, Display},

--- a/algebra/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra/src/curves/models/short_weierstrass_jacobian.rs
@@ -1,7 +1,7 @@
 use crate::{
     curves::models::SWModelParameters as Parameters,
     io::{Read, Result as IoResult, Write},
-    CanonicalDeserialize, CanonicalSerialize, UniformRand, Vec,
+    CanonicalDeserialize, CanonicalSerialize, GroupDeserialize, GroupSerialize, UniformRand, Vec,
 };
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},

--- a/algebra/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra/src/curves/models/short_weierstrass_projective.rs
@@ -1,7 +1,7 @@
 use crate::{
     curves::models::SWModelParameters as Parameters,
     io::{Read, Result as IoResult, Write},
-    CanonicalDeserialize, CanonicalSerialize, UniformRand, Vec,
+    CanonicalDeserialize, CanonicalSerialize, GroupDeserialize, GroupSerialize, UniformRand, Vec,
 };
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},

--- a/algebra/src/curves/models/twisted_edwards_extended/mod.rs
+++ b/algebra/src/curves/models/twisted_edwards_extended/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     io::{Read, Result as IoResult, Write},
-    CanonicalDeserialize, CanonicalSerialize, UniformRand, Vec,
+    CanonicalDeserialize, CanonicalSerialize, GroupSerialize, GroupDeserialize, UniformRand, Vec,
 };
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},

--- a/algebra/src/curves/models/twisted_edwards_extended/tests.rs
+++ b/algebra/src/curves/models/twisted_edwards_extended/tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     curves::models::twisted_edwards_extended::{GroupAffine, GroupProjective},
     fields::Field,
-    CanonicalDeserialize, CanonicalSerialize, MontgomeryModelParameters, ProjectiveCurve,
+    CanonicalDeserialize, CanonicalSerialize, GroupDeserialize, GroupSerialize, MontgomeryModelParameters, ProjectiveCurve,
     SerializationError, TEModelParameters, UniformRand,
 };
 use num_traits::{One, Zero};
@@ -31,6 +31,14 @@ pub fn edwards_curve_serialization_test<P: TEModelParameters>(buf_size: usize) {
     for _ in 0..ITERATIONS {
         let a = GroupProjective::<P>::rand(&mut rng);
         let a = a.into_affine();
+
+        {
+            let mut serialized = vec![0; 2 * buf_size];
+            a.serialize_uncompressed(&mut serialized).unwrap();
+            let b = GroupAffine::<P>::deserialize_uncompressed(&serialized).unwrap();
+            assert_eq!(a, b);
+        }
+
         {
             let mut serialized = vec![0; buf_size];
             a.serialize(&[], &mut serialized).unwrap();

--- a/algebra/src/curves/tests.rs
+++ b/algebra/src/curves/tests.rs
@@ -4,7 +4,7 @@ use crate::{
         AffineCurve, ProjectiveCurve,
     },
     fields::PrimeField,
-    CanonicalDeserialize, CanonicalSerialize, SWModelParameters, SerializationError, UniformRand,
+    CanonicalDeserialize, CanonicalSerialize, GroupDeserialize, GroupSerialize, SWModelParameters, SerializationError, UniformRand,
     Vec,
 };
 use num_traits::Zero;
@@ -292,6 +292,14 @@ pub fn sw_curve_serialization_test<P: SWModelParameters>(buf_size: usize) {
     for _ in 0..ITERATIONS {
         let a = GroupProjective::<P>::rand(&mut rng);
         let mut a = a.into_affine();
+
+        {
+            let mut serialized = vec![0; 2 * buf_size];
+            a.serialize_uncompressed(&mut serialized).unwrap();
+            let b = GroupAffine::<P>::deserialize_uncompressed(&serialized).unwrap();
+            assert_eq!(a, b);
+        }
+
         {
             let mut serialized = vec![0; buf_size];
             a.serialize(&[], &mut serialized).unwrap();

--- a/algebra/src/serialize/mod.rs
+++ b/algebra/src/serialize/mod.rs
@@ -161,7 +161,7 @@ macro_rules! impl_sw_curve_serializer {
                 &self,
                 output_buf: &mut [u8],
             ) -> Result<(), crate::serialize::SerializationError> {
-                let len = <Self as CanonicalSerialize>::buffer_size();
+                let len = <P as crate::curves::models::ModelParameters>::BaseField::buffer_size();
                 self.x.serialize(&[], &mut output_buf[..len])?;
                 self.y.serialize(&[], &mut output_buf[len..2 * len])?;
                 Ok(())


### PR DESCRIPTION
This PR defines a new serialization trait which directly serializes a group element in its uncompressed form. In addition, I found it reasonable to add the serialization trait bounds in the `AffineCurve` trait.