### PR TITLE
fix(affine-curve): ensure ProjectiveCurve can mul with Affine scalars

### DIFF
--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -23,7 +23,7 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     type G1Projective: ProjectiveCurve<BaseField = Self::Fq, ScalarField = Self::Fr, Affine = Self::G1Affine>
         + From<Self::G1Affine>
         + Into<Self::G1Affine>
-        + MulAssign<Self::Fr>;
+        + MulAssign<Self::Fr>; // needed due to https://github.com/rust-lang/rust/issues/69640
 
     /// The affine representation of an element in G1.
     type G1Affine: AffineCurve<BaseField = Self::Fq, ScalarField = Self::Fr, Projective = Self::G1Projective>
@@ -38,7 +38,7 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     type G2Projective: ProjectiveCurve<BaseField = Self::Fqe, ScalarField = Self::Fr, Affine = Self::G2Affine>
         + From<Self::G2Affine>
         + Into<Self::G2Affine>
-        + MulAssign<Self::Fr>;
+        + MulAssign<Self::Fr>; // needed due to https://github.com/rust-lang/rust/issues/69640
 
     /// The affine representation of an element in G2.
     type G2Affine: AffineCurve<BaseField = Self::Fqe, ScalarField = Self::Fr, Projective = Self::G2Projective>
@@ -224,7 +224,7 @@ pub trait AffineCurve:
     type Projective: ProjectiveCurve<Affine = Self, ScalarField = Self::ScalarField, BaseField = Self::BaseField>
         + From<Self>
         + Into<Self>
-        + MulAssign<Self::ScalarField>;
+        + MulAssign<Self::ScalarField>; // needed due to https://github.com/rust-lang/rust/issues/69640
 
     /// Returns a fixed generator of unknown exponent.
     #[must_use]

--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 use core::{
     fmt::{Debug, Display},
     hash::Hash,
-    ops::{Add, AddAssign, Neg, Sub, SubAssign},
+    ops::{Add, AddAssign, Neg, Sub, SubAssign, MulAssign},
 };
 use num_traits::Zero;
 
@@ -23,7 +23,7 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     type G1Projective: ProjectiveCurve<BaseField = Self::Fq, ScalarField = Self::Fr, Affine = Self::G1Affine>
         + From<Self::G1Affine>
         + Into<Self::G1Affine>
-        + core::ops::MulAssign<Self::Fr>;
+        + MulAssign<Self::Fr>;
 
     /// The affine representation of an element in G1.
     type G1Affine: AffineCurve<BaseField = Self::Fq, ScalarField = Self::Fr, Projective = Self::G1Projective>
@@ -38,7 +38,7 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     type G2Projective: ProjectiveCurve<BaseField = Self::Fqe, ScalarField = Self::Fr, Affine = Self::G2Affine>
         + From<Self::G2Affine>
         + Into<Self::G2Affine>
-        + core::ops::MulAssign<Self::Fr>;
+        + MulAssign<Self::Fr>;
 
     /// The affine representation of an element in G2.
     type G2Affine: AffineCurve<BaseField = Self::Fqe, ScalarField = Self::Fr, Projective = Self::G2Projective>
@@ -113,7 +113,7 @@ pub trait ProjectiveCurve:
     + Sub<Self, Output = Self>
     + AddAssign<Self>
     + SubAssign<Self>
-    + core::ops::MulAssign<<Self as ProjectiveCurve>::ScalarField>
+    + MulAssign<<Self as ProjectiveCurve>::ScalarField>
     + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
@@ -223,7 +223,8 @@ pub trait AffineCurve:
     type BaseField: Field;
     type Projective: ProjectiveCurve<Affine = Self, ScalarField = Self::ScalarField, BaseField = Self::BaseField>
         + From<Self>
-        + Into<Self>;
+        + Into<Self>
+        + MulAssign<Self::ScalarField>;
 
     /// Returns a fixed generator of unknown exponent.
     #[must_use]

--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 use core::{
     fmt::{Debug, Display},
     hash::Hash,
-    ops::{Add, AddAssign, Neg, Sub, SubAssign, MulAssign},
+    ops::{Add, AddAssign, MulAssign, Neg, Sub, SubAssign},
 };
 use num_traits::Zero;
 


### PR DESCRIPTION
As title. This was introduced in https://github.com/scipr-lab/zexe/commit/bfe7c3cb7231178a122e499d9de7469816638a06. 

Compiler downstream was [suggesting](https://github.com/celo-org/snark-setup/blob/master/snark-utils/src/helpers.rs#L479):
```
479 |             next_region = next_region.double();
    |                                       ^^^^^^ no implementation for <G as algebra_core::curves::AffineCurve>::Projective *= <G as algebra_core::curves::AffineCurve>::ScalarField
```