### PR TITLE
Add support for tuples in (de-)serialization derive macro

### DIFF
--- a/algebra-core/Cargo.toml
+++ b/algebra-core/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
+algebra-core-derive = { path = "algebra-core-derive", optional = true }
 derivative = { version = "1", features = ["use_core"] }
 num-traits = { version = "0.2", default-features = false }
 rand = { version = "0.7", default-features = false }
@@ -31,6 +32,7 @@ rayon = { version = "1", optional = true }
 rand_xorshift = "0.2"
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = []
-parallel = ["std", "rayon"]
+parallel = [ "std", "rayon" ]
+derive = [ "algebra-core-derive" ]

--- a/algebra-core/algebra-core-derive/Cargo.toml
+++ b/algebra-core/algebra-core-derive/Cargo.toml
@@ -28,5 +28,3 @@ proc-macro = true
 proc-macro2 = "1.0"
 syn = "1.0"
 quote = "1.0"
-
-algebra-core = { path = "..", default-features = false }

--- a/algebra-core/src/lib.rs
+++ b/algebra-core/src/lib.rs
@@ -90,6 +90,15 @@ pub mod io;
 #[cfg(feature = "std")]
 pub use std::io;
 
+#[cfg(feature = "derive")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate algebra_core_derive;
+
+#[cfg(feature = "derive")]
+#[doc(hidden)]
+pub use algebra_core_derive::*;
+
 #[cfg(not(feature = "std"))]
 fn error(_msg: &'static str) -> io::Error {
     io::Error

--- a/algebra-core/src/lib.rs
+++ b/algebra-core/src/lib.rs
@@ -95,10 +95,6 @@ pub use std::io;
 #[macro_use]
 extern crate algebra_core_derive;
 
-#[cfg(feature = "derive")]
-#[doc(hidden)]
-pub use algebra_core_derive::*;
-
 #[cfg(not(feature = "std"))]
 fn error(_msg: &'static str) -> io::Error {
     io::Error

--- a/algebra-core/src/serialize/mod.rs
+++ b/algebra-core/src/serialize/mod.rs
@@ -1,14 +1,14 @@
 mod error;
 mod flags;
-use crate::io::{Read, Write};
+pub use crate::io::{Read, Write};
 pub use error::*;
 pub use flags::*;
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+#[cfg(feature = "derive")]
+#[doc(hidden)]
+pub use algebra_core_derive::*;
 
-#[cfg(feature = "std")]
-use std::vec::Vec;
+use crate::Vec;
 
 /// Serializer in little endian format allowing to encode flags.
 pub trait CanonicalSerializeWithFlags: CanonicalSerialize {
@@ -21,6 +21,24 @@ pub trait CanonicalSerializeWithFlags: CanonicalSerialize {
 }
 
 /// Serializer in little endian format.
+/// This trait can be derived if all fields of a struct implement
+/// `CanonicalSerialize` and the `derive` feature is enabled.
+///
+/// # Example
+/// ```
+/// // The `derive` feature must be set for the derivation to work.
+/// use algebra_core::serialize::*;
+///
+/// # #[cfg(feature = "derive")]
+/// #[derive(CanonicalSerialize)]
+/// struct TestStruct {
+///     a: u64,
+///     b: (u64, (u64, u64)),
+/// }
+/// ```
+///
+/// If your code depends on `algebra` instead, the example works analogously
+/// when importing `algebra::serialize::*`.
 pub trait CanonicalSerialize {
     /// Serializes `self` into `writer`.
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError>;
@@ -47,6 +65,24 @@ pub trait CanonicalDeserializeWithFlags: Sized {
 }
 
 /// Deserializer in little endian format.
+/// This trait can be derived if all fields of a struct implement
+/// `CanonicalDeserialize` and the `derive` feature is enabled.
+///
+/// # Example
+/// ```
+/// // The `derive` feature must be set for the derivation to work.
+/// use algebra_core::serialize::*;
+///
+/// # #[cfg(feature = "derive")]
+/// #[derive(CanonicalDeserialize)]
+/// struct TestStruct {
+///     a: u64,
+///     b: (u64, (u64, u64)),
+/// }
+/// ```
+///
+/// If your code depends on `algebra` instead, the example works analogously
+/// when importing `algebra::serialize::*`.
 pub trait CanonicalDeserialize: Sized {
     /// Reads `Self` from `reader`.
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError>;

--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -43,3 +43,4 @@ mnt6 = []
 
 std = [ "algebra-core/std" ]
 parallel = [ "std", "algebra-core/parallel" ]
+derive = [ "algebra-core/derive" ]

--- a/gm17/Cargo.toml
+++ b/gm17/Cargo.toml
@@ -22,8 +22,7 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra-core = { path = "../algebra-core", default-features = false }
-algebra-core-derive = { path = "../algebra-core/algebra-core-derive", default-features = false }
+algebra-core = { path = "../algebra-core", default-features = false, features = [ "derive" ] }
 bench-utils = { path = "../bench-utils" }
 ff-fft = { path = "../ff-fft", default-features = false }
 r1cs-core = { path = "../r1cs-core", default-features = false }

--- a/gm17/src/lib.rs
+++ b/gm17/src/lib.rs
@@ -13,9 +13,6 @@
 #[macro_use]
 extern crate bench_utils;
 
-#[macro_use]
-extern crate algebra_core_derive;
-
 #[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;

--- a/gm17/src/lib.rs
+++ b/gm17/src/lib.rs
@@ -25,8 +25,9 @@ use std::{string::String, vec::Vec};
 
 use algebra_core::{
     bytes::ToBytes,
-    io::{self, Read, Result as IoResult, Write},
-    CanonicalDeserialize, CanonicalSerialize, PairingEngine,
+    io::{self, Result as IoResult},
+    serialize::*,
+    PairingEngine,
 };
 use r1cs_core::SynthesisError;
 

--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -23,8 +23,7 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-algebra-core = { path = "../algebra-core", default-features = false }
-algebra-core-derive = { path = "../algebra-core/algebra-core-derive", default-features = false }
+algebra-core = { path = "../algebra-core", default-features = false, features = [ "derive" ] }
 bench-utils = { path = "../bench-utils" }
 ff-fft = { path = "../ff-fft", default-features = false }
 r1cs-core = { path = "../r1cs-core", default-features = false }

--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -13,9 +13,6 @@
 #[macro_use]
 extern crate bench_utils;
 
-#[macro_use]
-extern crate algebra_core_derive;
-
 #[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;

--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -25,8 +25,9 @@ use std::{string::String, vec::Vec};
 
 use algebra_core::{
     bytes::ToBytes,
-    io::{self, Read, Result as IoResult, Write},
-    CanonicalDeserialize, CanonicalSerialize, PairingEngine,
+    io::{self, Result as IoResult},
+    serialize::*,
+    PairingEngine,
 };
 use r1cs_core::SynthesisError;
 


### PR DESCRIPTION
Additionally allows re-export of (de-)serialization derive macro from algebra-core via feature flag.

This achieves what was requested in #125.
In particular, it allows to derive (de-)serialization for nested tuples as shown in the following example:
```rust
#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
struct TestCase<E: PairingEngine> {
    a: (E::G1Affine, (E::G1Affine, E::G2Affine)), // this works
    b: E::G1Affine,                               // this works
    c: Vec<E::G2Affine>,                          // this works
}
```

The derive functionality can now be used by depending on:
```
algebra_core = { ..., features = [ "derive" ] }
```

I also tried making it available via `algebra` only, but this results in several problems as described in #125 .