### PR TITLE
Add UInt64 used for representing Merkle tree node locations

### DIFF
--- a/r1cs-std/src/bits/mod.rs
+++ b/r1cs-std/src/bits/mod.rs
@@ -6,8 +6,8 @@ use algebra::Field;
 use r1cs_core::{ConstraintSystem, SynthesisError};
 
 pub mod boolean;
-pub mod uint64;
 pub mod uint32;
+pub mod uint64;
 pub mod uint8;
 
 pub trait ToBitsGadget<ConstraintF: Field> {

--- a/r1cs-std/src/bits/mod.rs
+++ b/r1cs-std/src/bits/mod.rs
@@ -6,6 +6,7 @@ use algebra::Field;
 use r1cs_core::{ConstraintSystem, SynthesisError};
 
 pub mod boolean;
+pub mod uint64;
 pub mod uint32;
 pub mod uint8;
 


### PR DESCRIPTION
Added UInt64, which resembles UInt32. It is planned to use UInt64 later to represent Merkle tree node locations, which will be used in a later PR.

As discussed in https://github.com/scipr-lab/zexe/pull/128, it is useful when `operands.len() == 1`, `addmany` simply returns that operand. (no test has been written for this case)