### PR TITLE
Performance improvements for serialization

### DIFF
--- a/algebra-core/src/biginteger/mod.rs
+++ b/algebra-core/src/biginteger/mod.rs
@@ -2,8 +2,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::BitIterator,
     io::{Read, Result as IoResult, Write},
-    serialize::{deserialize_num_limbs, serialize_num_limbs},
-    CanonicalDeserialize, CanonicalSerialize, EmptyFlags, SerializationError, UniformRand, Vec,
+    CanonicalDeserialize, CanonicalSerialize, SerializationError, UniformRand, Vec,
 };
 use core::fmt::{Debug, Display};
 use rand::{
@@ -24,7 +23,8 @@ bigint_impl!(BigInteger832, 13);
 
 impl<T: BigInteger> CanonicalSerialize for T {
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-        serialize_num_limbs(writer, self.as_ref(), Self::NUM_LIMBS * 8, EmptyFlags)
+        self.write(writer)?;
+        Ok(())
     }
 
     fn serialized_size(&self) -> usize {
@@ -34,8 +34,7 @@ impl<T: BigInteger> CanonicalSerialize for T {
 
 impl<T: BigInteger> CanonicalDeserialize for T {
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let mut value = T::default();
-        deserialize_num_limbs::<_, EmptyFlags>(reader, value.as_mut(), Self::NUM_LIMBS * 8, false)?;
+        let value = Self::read(reader)?;
         Ok(value)
     }
 }

--- a/algebra-core/src/serialize/flags.rs
+++ b/algebra-core/src/serialize/flags.rs
@@ -10,18 +10,22 @@ pub trait Flags: Default + Clone + Copy + Sized {
 pub struct EmptyFlags;
 
 impl Flags for EmptyFlags {
+    #[inline]
     fn u8_bitmask(&self) -> u8 {
         0
     }
 
+    #[inline]
     fn from_u8(_value: u8) -> Self {
         EmptyFlags
     }
 
+    #[inline]
     fn from_u8_remove_flags(_value: &mut u8) -> Self {
         EmptyFlags
     }
 
+    #[inline]
     fn len() -> usize {
         0
     }
@@ -37,10 +41,12 @@ pub enum SWFlags {
 }
 
 impl SWFlags {
+    #[inline]
     pub fn infinity() -> Self {
         SWFlags::Infinity
     }
 
+    #[inline]
     pub fn from_y_sign(is_positive: bool) -> Self {
         if is_positive {
             SWFlags::PositiveY
@@ -49,6 +55,7 @@ impl SWFlags {
         }
     }
 
+    #[inline]
     pub fn is_infinity(&self) -> bool {
         match self {
             SWFlags::Infinity => true,
@@ -56,6 +63,7 @@ impl SWFlags {
         }
     }
 
+    #[inline]
     pub fn is_positive(&self) -> Option<bool> {
         match self {
             SWFlags::Infinity => None,
@@ -66,6 +74,7 @@ impl SWFlags {
 }
 
 impl Default for SWFlags {
+    #[inline]
     fn default() -> Self {
         // NegativeY doesn't change the serialization
         SWFlags::NegativeY
@@ -73,6 +82,7 @@ impl Default for SWFlags {
 }
 
 impl Flags for SWFlags {
+    #[inline]
     fn u8_bitmask(&self) -> u8 {
         let mut mask = 0;
         match self {
@@ -83,6 +93,7 @@ impl Flags for SWFlags {
         mask
     }
 
+    #[inline]
     fn from_u8(value: u8) -> Self {
         let x_sign = (value >> 7) & 1 == 1;
         let is_infinity = (value >> 6) & 1 == 1;
@@ -93,6 +104,7 @@ impl Flags for SWFlags {
         }
     }
 
+    #[inline]
     fn from_u8_remove_flags(value: &mut u8) -> Self {
         let flags = Self::from_u8(*value);
         *value &= 0x3F;
@@ -100,6 +112,7 @@ impl Flags for SWFlags {
     }
 
     /// Number of bits required for these flags.
+    #[inline]
     fn len() -> usize {
         2
     }
@@ -114,6 +127,7 @@ pub enum EdwardsFlags {
 }
 
 impl EdwardsFlags {
+    #[inline]
     pub fn from_y_sign(is_positive: bool) -> Self {
         if is_positive {
             EdwardsFlags::PositiveY
@@ -122,6 +136,7 @@ impl EdwardsFlags {
         }
     }
 
+    #[inline]
     pub fn is_positive(&self) -> bool {
         match self {
             EdwardsFlags::PositiveY => true,
@@ -131,6 +146,7 @@ impl EdwardsFlags {
 }
 
 impl Default for EdwardsFlags {
+    #[inline]
     fn default() -> Self {
         // NegativeY doesn't change the serialization
         EdwardsFlags::NegativeY
@@ -138,6 +154,7 @@ impl Default for EdwardsFlags {
 }
 
 impl Flags for EdwardsFlags {
+    #[inline]
     fn u8_bitmask(&self) -> u8 {
         let mut mask = 0;
         match self {
@@ -147,6 +164,7 @@ impl Flags for EdwardsFlags {
         mask
     }
 
+    #[inline]
     fn from_u8(value: u8) -> Self {
         let x_sign = (value >> 7) & 1 == 1;
         if x_sign {
@@ -156,6 +174,7 @@ impl Flags for EdwardsFlags {
         }
     }
 
+    #[inline]
     fn from_u8_remove_flags(value: &mut u8) -> Self {
         let flags = Self::from_u8(*value);
         *value &= 0x7F;
@@ -163,6 +182,7 @@ impl Flags for EdwardsFlags {
     }
 
     /// Number of bits required for these flags.
+    #[inline]
     fn len() -> usize {
         1
     }


### PR DESCRIPTION
This branch adds several performance improvements to the (de-)serialization.
Also see #130.

It mainly inlines small functions and replaces the serialization of BigIntegers/Field points.
I'm not entirely sure why the previous way of serializing these was faster, but the benchmarks consistently show better results using the previous method.

Here's a benchmark between the old serialization from #73, the current one in master, and the one proposed here:
```
write_g1/#73            time:   [109.25 us 109.60 us 110.06 us]
write_g1/current        time:   [115.23 us 115.64 us 116.10 us]
write_g1/#131           time:   [98.144 us 98.384 us 98.714 us]

write_g1_uncompressed/#73
                        time:   [75.913 us 76.064 us 76.266 us]
write_g1_uncompressed/current
                        time:   [92.986 us 93.353 us 93.839 us]
write_g1_uncompressed/#131
                        time:   [74.795 us 75.238 us 75.804 us]

write_field/#73         time:   [38.366 us 38.665 us 39.018 us]
write_field/current     time:   [49.276 us 49.402 us 49.563 us]
write_field/#131        time:   [36.814 us 37.043 us 37.366 us]
```