### PR TITLE
Rename arguments to CondSelectGadget for code clarity

### DIFF
--- a/r1cs-std/src/bits/boolean.rs
+++ b/r1cs-std/src/bits/boolean.rs
@@ -804,7 +804,9 @@ impl<ConstraintF: PrimeField> CondSelectGadget<ConstraintF> for Boolean {
         match cond {
             Boolean::Constant(true) => Ok(true_value.clone()),
             Boolean::Constant(false) => Ok(false_value.clone()),
-            cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), false_value, true_value),
+            cond @ Boolean::Not(_) => {
+                Self::conditionally_select(cs, &cond.not(), false_value, true_value)
+            },
             cond @ Boolean::Is(_) => match (true_value, false_value) {
                 (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x).into(),
                 (&Boolean::Constant(false), x) => Boolean::and(cs.ns(|| "and"), &cond.not(), x),

--- a/r1cs-std/src/bits/boolean.rs
+++ b/r1cs-std/src/bits/boolean.rs
@@ -312,14 +312,14 @@ impl<ConstraintF: PrimeField> CondSelectGadget<ConstraintF> for AllocatedBit {
     fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError> {
         cond_select_helper(
             cs,
             cond,
-            (first.value, first.variable),
-            (second.value, second.variable),
+            (true_value.value, true_value.variable),
+            (false_value.value, false_value.variable),
         )
     }
 
@@ -795,17 +795,17 @@ impl<ConstraintF: PrimeField> CondSelectGadget<ConstraintF> for Boolean {
     fn conditionally_select<CS>(
         mut cs: CS,
         cond: &Self,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError>
     where
         CS: ConstraintSystem<ConstraintF>,
     {
         match cond {
-            Boolean::Constant(true) => Ok(first.clone()),
-            Boolean::Constant(false) => Ok(second.clone()),
-            cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), second, first),
-            cond @ Boolean::Is(_) => match (first, second) {
+            Boolean::Constant(true) => Ok(true_value.clone()),
+            Boolean::Constant(false) => Ok(false_value.clone()),
+            cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), false_value, true_value),
+            cond @ Boolean::Is(_) => match (true_value, false_value) {
                 (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x).into(),
                 (&Boolean::Constant(false), x) => Boolean::and(cs.ns(|| "and"), &cond.not(), x),
                 (&Boolean::Constant(true), x) => Boolean::or(cs.ns(|| "or"), cond, x).into(),

--- a/r1cs-std/src/fields/fp.rs
+++ b/r1cs-std/src/fields/fp.rs
@@ -449,19 +449,19 @@ impl<F: PrimeField> CondSelectGadget<F> for FpGadget<F> {
     fn conditionally_select<CS: ConstraintSystem<F>>(
         mut cs: CS,
         cond: &Boolean,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError> {
         if let Boolean::Constant(cond) = *cond {
             if cond {
-                Ok(first.clone())
+                Ok(true_value.clone())
             } else {
-                Ok(second.clone())
+                Ok(false_value.clone())
             }
         } else {
             let result = Self::alloc(cs.ns(|| ""), || {
                 cond.get_value()
-                    .and_then(|cond| if cond { first } else { second }.get_value())
+                    .and_then(|cond| if cond { true_value } else { false_value }.get_value())
                     .get()
             })?;
             // a = self; b = other; c = cond;
@@ -473,8 +473,8 @@ impl<F: PrimeField> CondSelectGadget<F> for FpGadget<F> {
             cs.enforce(
                 || "conditionally_select",
                 |_| cond.lc(one, F::one()),
-                |lc| (&first.variable - &second.variable) + lc,
-                |lc| (&result.variable - &second.variable) + lc,
+                |lc| (&true_value.variable - &false_value.variable) + lc,
+                |lc| (&result.variable - &false_value.variable) + lc,
             );
 
             Ok(result)

--- a/r1cs-std/src/fields/fp12.rs
+++ b/r1cs-std/src/fields/fp12.rs
@@ -787,20 +787,20 @@ where
     fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError> {
         let c0 = Fp6Gadget::<P, ConstraintF>::conditionally_select(
             &mut cs.ns(|| "c0"),
             cond,
-            &first.c0,
-            &second.c0,
+            &true_value.c0,
+            &false_value.c0,
         )?;
         let c1 = Fp6Gadget::<P, ConstraintF>::conditionally_select(
             &mut cs.ns(|| "c1"),
             cond,
-            &first.c1,
-            &second.c1,
+            &true_value.c1,
+            &false_value.c1,
         )?;
 
         Ok(Self::new(c0, c1))

--- a/r1cs-std/src/fields/fp2.rs
+++ b/r1cs-std/src/fields/fp2.rs
@@ -581,20 +581,20 @@ impl<P: Fp2Parameters<Fp = ConstraintF>, ConstraintF: PrimeField> CondSelectGadg
     fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError> {
         let c0 = FpGadget::<ConstraintF>::conditionally_select(
             &mut cs.ns(|| "c0"),
             cond,
-            &first.c0,
-            &second.c0,
+            &true_value.c0,
+            &false_value.c0,
         )?;
         let c1 = FpGadget::<ConstraintF>::conditionally_select(
             &mut cs.ns(|| "c1"),
             cond,
-            &first.c1,
-            &second.c1,
+            &true_value.c1,
+            &false_value.c1,
         )?;
 
         Ok(Self::new(c0, c1))

--- a/r1cs-std/src/fields/fp6_3over2.rs
+++ b/r1cs-std/src/fields/fp6_3over2.rs
@@ -861,26 +861,26 @@ where
     fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError> {
         let c0 = Fp2Gadget::<P, ConstraintF>::conditionally_select(
             &mut cs.ns(|| "c0"),
             cond,
-            &first.c0,
-            &second.c0,
+            &true_value.c0,
+            &false_value.c0,
         )?;
         let c1 = Fp2Gadget::<P, ConstraintF>::conditionally_select(
             &mut cs.ns(|| "c1"),
             cond,
-            &first.c1,
-            &second.c1,
+            &true_value.c1,
+            &false_value.c1,
         )?;
         let c2 = Fp2Gadget::<P, ConstraintF>::conditionally_select(
             &mut cs.ns(|| "c2"),
             cond,
-            &first.c2,
-            &second.c2,
+            &true_value.c2,
+            &false_value.c2,
         )?;
 
         Ok(Self::new(c0, c1, c2))

--- a/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
@@ -339,16 +339,16 @@ where
     fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError> {
-        let x = F::conditionally_select(&mut cs.ns(|| "x"), cond, &first.x, &second.x)?;
-        let y = F::conditionally_select(&mut cs.ns(|| "y"), cond, &first.y, &second.y)?;
+        let x = F::conditionally_select(&mut cs.ns(|| "x"), cond, &true_value.x, &false_value.x)?;
+        let y = F::conditionally_select(&mut cs.ns(|| "y"), cond, &true_value.y, &false_value.y)?;
         let infinity = Boolean::conditionally_select(
             &mut cs.ns(|| "infinity"),
             cond,
-            &first.infinity,
-            &second.infinity,
+            &true_value.infinity,
+            &false_value.infinity,
         )?;
 
         Ok(Self::new(x, y, infinity))

--- a/r1cs-std/src/groups/curves/twisted_edwards/mod.rs
+++ b/r1cs-std/src/groups/curves/twisted_edwards/mod.rs
@@ -1266,11 +1266,11 @@ where
     fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         mut cs: CS,
         cond: &Boolean,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError> {
-        let x = F::conditionally_select(&mut cs.ns(|| "x"), cond, &first.x, &second.x)?;
-        let y = F::conditionally_select(&mut cs.ns(|| "y"), cond, &first.y, &second.y)?;
+        let x = F::conditionally_select(&mut cs.ns(|| "x"), cond, &true_value.x, &false_value.x)?;
+        let y = F::conditionally_select(&mut cs.ns(|| "y"), cond, &true_value.y, &false_value.y)?;
 
         Ok(Self::new(x, y))
     }

--- a/r1cs-std/src/select.rs
+++ b/r1cs-std/src/select.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use algebra::Field;
 use r1cs_core::{ConstraintSystem, SynthesisError};
 
-/// If condition is `true`, return `first`; else, select `second`.
+/// If condition is `true`, return `true_value`; else, select `false_value`.
 pub trait CondSelectGadget<ConstraintF: Field>
 where
     Self: Sized,
@@ -10,8 +10,8 @@ where
     fn conditionally_select<CS: ConstraintSystem<ConstraintF>>(
         cs: CS,
         cond: &Boolean,
-        first: &Self,
-        second: &Self,
+        true_value: &Self,
+        false_value: &Self,
     ) -> Result<Self, SynthesisError>;
 
     fn cost() -> usize;


### PR DESCRIPTION
I think this rename makes it obvious what the order of arguments should be, without resorting to looking at the comment. (I initially expected the arguments to be reversed)