### PR TITLE
Make Groth16 efficient when ZK isn't needed

### DIFF
--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -194,6 +194,17 @@ where
     create_proof::<E, C>(circuit, params, r, s)
 }
 
+pub fn create_proof_no_zk<E, C>(
+    circuit: C,
+    params: &Parameters<E>,
+) -> Result<Proof<E>, SynthesisError>
+where
+    E: PairingEngine,
+    C: ConstraintSynthesizer<E::Fr>,
+{
+    create_proof::<E, C>(circuit, params, E::Fr::zero(), E::Fr::zero())
+}
+
 pub fn create_proof<E, C>(
     circuit: C,
     params: &Parameters<E>,
@@ -228,7 +239,8 @@ where
     end_timer!(synthesis_time);
 
     let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
-    let (full_input_assignment, h, _) = R1CStoQAP::witness_map::<E>(&prover, &E::Fr::zero(), &E::Fr::zero(), &E::Fr::zero())?;
+    let (full_input_assignment, h, _) =
+        R1CStoQAP::witness_map::<E>(&prover, &E::Fr::zero(), &E::Fr::zero(), &E::Fr::zero())?;
     end_timer!(witness_map_time);
 
     let input_assignment = full_input_assignment[1..prover.num_inputs]

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -239,8 +239,7 @@ where
     end_timer!(synthesis_time);
 
     let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
-    let (full_input_assignment, h, _) =
-        R1CStoQAP::witness_map::<E>(&prover)?;
+    let (full_input_assignment, h, _) = R1CStoQAP::witness_map::<E>(&prover)?;
     end_timer!(witness_map_time);
 
     let input_assignment = full_input_assignment[1..prover.num_inputs]

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -240,7 +240,7 @@ where
 
     let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
     let (full_input_assignment, h, _) =
-        R1CStoQAP::witness_map::<E>(&prover, &E::Fr::zero(), &E::Fr::zero(), &E::Fr::zero())?;
+        R1CStoQAP::witness_map::<E>(&prover)?;
     end_timer!(witness_map_time);
 
     let input_assignment = full_input_assignment[1..prover.num_inputs]

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -188,21 +188,15 @@ where
     C: ConstraintSynthesizer<E::Fr>,
     R: Rng,
 {
-    let d1 = E::Fr::zero();
-    let d2 = E::Fr::zero();
-    let d3 = E::Fr::zero();
     let r = E::Fr::rand(rng);
     let s = E::Fr::rand(rng);
 
-    create_proof::<E, C>(circuit, params, d1, d2, d3, r, s)
+    create_proof::<E, C>(circuit, params, r, s)
 }
 
 pub fn create_proof<E, C>(
     circuit: C,
     params: &Parameters<E>,
-    d1: E::Fr,
-    d2: E::Fr,
-    d3: E::Fr,
     r: E::Fr,
     s: E::Fr,
 ) -> Result<Proof<E>, SynthesisError>
@@ -234,7 +228,7 @@ where
     end_timer!(synthesis_time);
 
     let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
-    let (full_input_assignment, h, _) = R1CStoQAP::witness_map::<E>(&prover, &d1, &d2, &d3)?;
+    let (full_input_assignment, h, _) = R1CStoQAP::witness_map::<E>(&prover, &E::Fr::zero(), &E::Fr::zero(), &E::Fr::zero())?;
     end_timer!(witness_map_time);
 
     let input_assignment = full_input_assignment[1..prover.num_inputs]
@@ -274,21 +268,27 @@ where
     g_a.add_assign_mixed(&params.vk.alpha_g1);
     end_timer!(a_acc_time);
 
-    // Compute B in G1
-    let b_g1_acc_time = start_timer!(|| "Compute B in G1");
+    // Compute B in G1 if needed
+    let g1_b = if r != E::Fr::zero() {
+        let b_g1_acc_time = start_timer!(|| "Compute B in G1");
 
-    let (b_inputs_source, b_aux_source) = params.get_b_g1_query(prover.num_inputs)?;
-    let b_inputs_acc = VariableBaseMSM::multi_scalar_mul(b_inputs_source, &input_assignment);
-    let b_aux_acc = VariableBaseMSM::multi_scalar_mul(b_aux_source, &aux_assignment);
+        let (b_inputs_source, b_aux_source) = params.get_b_g1_query(prover.num_inputs)?;
+        let b_inputs_acc = VariableBaseMSM::multi_scalar_mul(b_inputs_source, &input_assignment);
+        let b_aux_acc = VariableBaseMSM::multi_scalar_mul(b_aux_source, &aux_assignment);
 
-    let s_g1 = params.delta_g1.mul(s.clone());
+        let s_g1 = params.delta_g1.mul(s.clone());
 
-    let mut g1_b = s_g1;
-    g1_b.add_assign_mixed(&params.get_b_g1_query_full()?[0]);
-    g1_b += &b_inputs_acc;
-    g1_b += &b_aux_acc;
-    g1_b.add_assign_mixed(&params.beta_g1);
-    end_timer!(b_g1_acc_time);
+        let mut g1_b = s_g1;
+        g1_b.add_assign_mixed(&params.get_b_g1_query_full()?[0]);
+        g1_b += &b_inputs_acc;
+        g1_b += &b_aux_acc;
+        g1_b.add_assign_mixed(&params.beta_g1);
+        end_timer!(b_g1_acc_time);
+
+        g1_b
+    } else {
+        E::G1Projective::zero()
+    };
 
     // Compute B in G2
     let b_g2_acc_time = start_timer!(|| "Compute B in G2");

--- a/groth16/src/r1cs_to_qap.rs
+++ b/groth16/src/r1cs_to_qap.rs
@@ -119,7 +119,6 @@ impl R1CStoQAP {
         domain.ifft_in_place(&mut a);
         domain.ifft_in_place(&mut b);
 
-
         domain.coset_fft_in_place(&mut a);
         domain.coset_fft_in_place(&mut b);
 

--- a/groth16/src/r1cs_to_qap.rs
+++ b/groth16/src/r1cs_to_qap.rs
@@ -2,7 +2,7 @@ use algebra_core::{One, PairingEngine, Zero};
 use ff_fft::{cfg_iter, cfg_iter_mut, EvaluationDomain};
 
 use crate::{generator::KeypairAssembly, prover::ProvingAssignment, Vec};
-use core::ops::{AddAssign, SubAssign};
+use core::ops::AddAssign;
 use r1cs_core::{Index, SynthesisError};
 
 #[cfg(feature = "parallel")]
@@ -71,9 +71,6 @@ impl R1CStoQAP {
     #[inline]
     pub(crate) fn witness_map<E: PairingEngine>(
         prover: &ProvingAssignment<E>,
-        d1: &E::Fr,
-        d2: &E::Fr,
-        d3: &E::Fr,
     ) -> Result<(Vec<E::Fr>, Vec<E::Fr>, usize), SynthesisError> {
         #[inline]
         fn evaluate_constraint<E: PairingEngine>(
@@ -122,16 +119,6 @@ impl R1CStoQAP {
         domain.ifft_in_place(&mut a);
         domain.ifft_in_place(&mut b);
 
-        let mut h: Vec<E::Fr> = vec![zero; domain_size];
-        cfg_iter_mut!(h)
-            .zip(&a)
-            .zip(&b)
-            .for_each(|((h_i, a_i), b_i)| *h_i *= &(*d2 * a_i + &(*d1 * b_i)));
-
-        h[0].sub_assign(&d3);
-        let d1d2 = *d1 * d2;
-        h[0].sub_assign(&d1d2);
-        h.push(d1d2);
 
         domain.coset_fft_in_place(&mut a);
         domain.coset_fft_in_place(&mut b);
@@ -161,7 +148,8 @@ impl R1CStoQAP {
         domain.divide_by_vanishing_poly_on_coset_in_place(&mut ab);
         domain.coset_ifft_in_place(&mut ab);
 
-        cfg_iter_mut!(h[..domain_size - 1])
+        let mut h: Vec<E::Fr> = vec![zero; domain_size - 1];
+        cfg_iter_mut!(h)
             .enumerate()
             .for_each(|(i, e)| e.add_assign(&ab[i]));
 


### PR DESCRIPTION
* Don't compute g_b1 if r is zero
* Set d1,d2,d3 to always be zero - they're not needed for Groth16

Adds a helper function `create_proof_no_zk`.

Closes #120.