### PR TITLE
Add constant serialized size trait

### DIFF
--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, PrimeField, SquareRootField},
     groups::Group,
-    CanonicalDeserialize, CanonicalSerialize, UniformRand, Vec,
+    CanonicalDeserialize, CanonicalSerialize, ConstantSerializedSize, UniformRand, Vec,
 };
 use core::{
     fmt::{Debug, Display},
@@ -208,6 +208,7 @@ pub trait AffineCurve:
     + ToBytes
     + FromBytes
     + CanonicalSerialize
+    + ConstantSerializedSize
     + CanonicalDeserialize
     + Copy
     + Clone

--- a/algebra-core/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra-core/src/curves/models/short_weierstrass_jacobian.rs
@@ -2,7 +2,7 @@ use crate::{
     curves::models::SWModelParameters as Parameters,
     io::{Read, Result as IoResult, Write},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, UniformRand, Vec,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, UniformRand, Vec,
 };
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},

--- a/algebra-core/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra-core/src/curves/models/short_weierstrass_projective.rs
@@ -2,7 +2,7 @@ use crate::{
     curves::models::SWModelParameters as Parameters,
     io::{Read, Result as IoResult, Write},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, UniformRand, Vec,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, UniformRand, Vec,
 };
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},

--- a/algebra-core/src/curves/models/twisted_edwards_extended.rs
+++ b/algebra-core/src/curves/models/twisted_edwards_extended.rs
@@ -1,7 +1,7 @@
 use crate::{
     io::{Read, Result as IoResult, Write},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, UniformRand, Vec,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, UniformRand, Vec,
 };
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},

--- a/algebra-core/src/fields/mod.rs
+++ b/algebra-core/src/fields/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     biginteger::BigInteger,
     bytes::{FromBytes, ToBytes},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, UniformRand, Vec,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, UniformRand, Vec,
 };
 use core::{
     fmt::{Debug, Display},
@@ -64,6 +64,7 @@ pub trait Field:
     + Sized
     + Hash
     + CanonicalSerialize
+    + ConstantSerializedSize
     + CanonicalSerializeWithFlags
     + CanonicalDeserialize
     + CanonicalDeserializeWithFlags

--- a/algebra-core/src/fields/models/fp12_2over3over2.rs
+++ b/algebra-core/src/fields/models/fp12_2over3over2.rs
@@ -1,7 +1,8 @@
 use crate::{
     io::{Read, Result as IoResult, Write},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, EmptyFlags, Flags, SerializationError, UniformRand,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
+    UniformRand,
 };
 use core::{
     cmp::Ordering,
@@ -488,6 +489,7 @@ impl<P: Fp12Parameters> FromBytes for Fp12<P> {
 }
 
 impl<P: Fp12Parameters> CanonicalSerializeWithFlags for Fp12<P> {
+    #[inline]
     fn serialize_with_flags<W: Write, F: Flags>(
         &self,
         writer: &mut W,
@@ -500,16 +502,25 @@ impl<P: Fp12Parameters> CanonicalSerializeWithFlags for Fp12<P> {
 }
 
 impl<P: Fp12Parameters> CanonicalSerialize for Fp12<P> {
+    #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
         self.serialize_with_flags(writer, EmptyFlags)
     }
 
+    #[inline]
     fn serialized_size(&self) -> usize {
-        self.c0.serialized_size() + self.c1.serialized_size()
+        Self::SERIALIZED_SIZE
     }
 }
 
+impl<P: Fp12Parameters> ConstantSerializedSize for Fp12<P> {
+    const SERIALIZED_SIZE: usize =
+        2 * <Fp6<P::Fp6Params> as ConstantSerializedSize>::SERIALIZED_SIZE;
+    const UNCOMPRESSED_SIZE: usize = Self::SERIALIZED_SIZE;
+}
+
 impl<P: Fp12Parameters> CanonicalDeserializeWithFlags for Fp12<P> {
+    #[inline]
     fn deserialize_with_flags<R: Read, F: Flags>(
         reader: &mut R,
     ) -> Result<(Self, F), SerializationError> {
@@ -520,6 +531,7 @@ impl<P: Fp12Parameters> CanonicalDeserializeWithFlags for Fp12<P> {
 }
 
 impl<P: Fp12Parameters> CanonicalDeserialize for Fp12<P> {
+    #[inline]
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
         let c0 = Fp6::deserialize(reader)?;
         let c1 = Fp6::deserialize(reader)?;

--- a/algebra-core/src/fields/models/fp2.rs
+++ b/algebra-core/src/fields/models/fp2.rs
@@ -1,7 +1,8 @@
 use crate::{
     io::{Read, Result as IoResult, Write},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, EmptyFlags, Flags, SerializationError, UniformRand,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
+    UniformRand,
 };
 use core::{
     cmp::{Ord, Ordering, PartialOrd},
@@ -397,6 +398,7 @@ impl<P: Fp2Parameters> fmt::Display for Fp2<P> {
 }
 
 impl<P: Fp2Parameters> CanonicalSerializeWithFlags for Fp2<P> {
+    #[inline]
     fn serialize_with_flags<W: Write, F: Flags>(
         &self,
         writer: &mut W,
@@ -409,16 +411,24 @@ impl<P: Fp2Parameters> CanonicalSerializeWithFlags for Fp2<P> {
 }
 
 impl<P: Fp2Parameters> CanonicalSerialize for Fp2<P> {
+    #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
         self.serialize_with_flags(writer, EmptyFlags)
     }
 
+    #[inline]
     fn serialized_size(&self) -> usize {
-        self.c0.serialized_size() + self.c1.serialized_size()
+        Self::SERIALIZED_SIZE
     }
 }
 
+impl<P: Fp2Parameters> ConstantSerializedSize for Fp2<P> {
+    const SERIALIZED_SIZE: usize = 2 * <P::Fp as ConstantSerializedSize>::SERIALIZED_SIZE;
+    const UNCOMPRESSED_SIZE: usize = Self::SERIALIZED_SIZE;
+}
+
 impl<P: Fp2Parameters> CanonicalDeserializeWithFlags for Fp2<P> {
+    #[inline]
     fn deserialize_with_flags<R: Read, F: Flags>(
         reader: &mut R,
     ) -> Result<(Self, F), SerializationError> {
@@ -430,6 +440,7 @@ impl<P: Fp2Parameters> CanonicalDeserializeWithFlags for Fp2<P> {
 }
 
 impl<P: Fp2Parameters> CanonicalDeserialize for Fp2<P> {
+    #[inline]
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
         let c0: P::Fp = CanonicalDeserialize::deserialize(reader)?;
         let c1: P::Fp = CanonicalDeserialize::deserialize(reader)?;

--- a/algebra-core/src/fields/models/fp3.rs
+++ b/algebra-core/src/fields/models/fp3.rs
@@ -1,6 +1,7 @@
 use crate::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, EmptyFlags, Flags, SerializationError, UniformRand, Vec,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
+    UniformRand, Vec,
 };
 use core::{
     cmp::{Ord, Ordering, PartialOrd},
@@ -495,6 +496,7 @@ impl<P: Fp3Parameters> fmt::Display for Fp3<P> {
 }
 
 impl<P: Fp3Parameters> CanonicalSerializeWithFlags for Fp3<P> {
+    #[inline]
     fn serialize_with_flags<W: Write, F: Flags>(
         &self,
         writer: &mut W,
@@ -508,16 +510,24 @@ impl<P: Fp3Parameters> CanonicalSerializeWithFlags for Fp3<P> {
 }
 
 impl<P: Fp3Parameters> CanonicalSerialize for Fp3<P> {
+    #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
         self.serialize_with_flags(writer, EmptyFlags)
     }
 
+    #[inline]
     fn serialized_size(&self) -> usize {
-        self.c0.serialized_size() + self.c1.serialized_size() + self.c2.serialized_size()
+        Self::SERIALIZED_SIZE
     }
 }
 
+impl<P: Fp3Parameters> ConstantSerializedSize for Fp3<P> {
+    const SERIALIZED_SIZE: usize = 3 * <P::Fp as ConstantSerializedSize>::SERIALIZED_SIZE;
+    const UNCOMPRESSED_SIZE: usize = Self::SERIALIZED_SIZE;
+}
+
 impl<P: Fp3Parameters> CanonicalDeserializeWithFlags for Fp3<P> {
+    #[inline]
     fn deserialize_with_flags<R: Read, F: Flags>(
         reader: &mut R,
     ) -> Result<(Self, F), SerializationError> {
@@ -530,6 +540,7 @@ impl<P: Fp3Parameters> CanonicalDeserializeWithFlags for Fp3<P> {
 }
 
 impl<P: Fp3Parameters> CanonicalDeserialize for Fp3<P> {
+    #[inline]
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
         let c0: P::Fp = CanonicalDeserialize::deserialize(reader)?;
         let c1: P::Fp = CanonicalDeserialize::deserialize(reader)?;

--- a/algebra-core/src/fields/models/fp6_2over3.rs
+++ b/algebra-core/src/fields/models/fp6_2over3.rs
@@ -1,6 +1,7 @@
 use crate::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, EmptyFlags, Flags, SerializationError, UniformRand,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
+    UniformRand,
 };
 use core::{
     cmp::Ordering,
@@ -403,6 +404,7 @@ impl<P: Fp6Parameters> fmt::Display for Fp6<P> {
 }
 
 impl<P: Fp6Parameters> CanonicalSerializeWithFlags for Fp6<P> {
+    #[inline]
     fn serialize_with_flags<W: Write, F: Flags>(
         &self,
         writer: &mut W,
@@ -415,16 +417,25 @@ impl<P: Fp6Parameters> CanonicalSerializeWithFlags for Fp6<P> {
 }
 
 impl<P: Fp6Parameters> CanonicalSerialize for Fp6<P> {
+    #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
         self.serialize_with_flags(writer, EmptyFlags)
     }
 
+    #[inline]
     fn serialized_size(&self) -> usize {
-        self.c0.serialized_size() + self.c1.serialized_size()
+        Self::SERIALIZED_SIZE
     }
 }
 
+impl<P: Fp6Parameters> ConstantSerializedSize for Fp6<P> {
+    const SERIALIZED_SIZE: usize =
+        2 * <Fp3<P::Fp3Params> as ConstantSerializedSize>::SERIALIZED_SIZE;
+    const UNCOMPRESSED_SIZE: usize = Self::SERIALIZED_SIZE;
+}
+
 impl<P: Fp6Parameters> CanonicalDeserializeWithFlags for Fp6<P> {
+    #[inline]
     fn deserialize_with_flags<R: Read, F: Flags>(
         reader: &mut R,
     ) -> Result<(Self, F), SerializationError> {
@@ -435,6 +446,7 @@ impl<P: Fp6Parameters> CanonicalDeserializeWithFlags for Fp6<P> {
 }
 
 impl<P: Fp6Parameters> CanonicalDeserialize for Fp6<P> {
+    #[inline]
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
         let c0 = Fp3::deserialize(reader)?;
         let c1 = Fp3::deserialize(reader)?;

--- a/algebra-core/src/fields/models/fp6_3over2.rs
+++ b/algebra-core/src/fields/models/fp6_3over2.rs
@@ -1,7 +1,8 @@
 use crate::{
     io::{Read, Result as IoResult, Write},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, EmptyFlags, Flags, SerializationError, UniformRand,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
+    UniformRand,
 };
 use core::{
     cmp::Ordering,
@@ -478,6 +479,7 @@ impl<P: Fp6Parameters> FromBytes for Fp6<P> {
 }
 
 impl<P: Fp6Parameters> CanonicalSerializeWithFlags for Fp6<P> {
+    #[inline]
     fn serialize_with_flags<W: Write, F: Flags>(
         &self,
         writer: &mut W,
@@ -491,16 +493,25 @@ impl<P: Fp6Parameters> CanonicalSerializeWithFlags for Fp6<P> {
 }
 
 impl<P: Fp6Parameters> CanonicalSerialize for Fp6<P> {
+    #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
         self.serialize_with_flags(writer, EmptyFlags)
     }
 
+    #[inline]
     fn serialized_size(&self) -> usize {
-        self.c0.serialized_size() + self.c1.serialized_size() + self.c2.serialized_size()
+        Self::SERIALIZED_SIZE
     }
 }
 
+impl<P: Fp6Parameters> ConstantSerializedSize for Fp6<P> {
+    const SERIALIZED_SIZE: usize =
+        3 * <Fp2<P::Fp2Params> as ConstantSerializedSize>::SERIALIZED_SIZE;
+    const UNCOMPRESSED_SIZE: usize = Self::SERIALIZED_SIZE;
+}
+
 impl<P: Fp6Parameters> CanonicalDeserializeWithFlags for Fp6<P> {
+    #[inline]
     fn deserialize_with_flags<R: Read, F: Flags>(
         reader: &mut R,
     ) -> Result<(Self, F), SerializationError> {
@@ -512,6 +523,7 @@ impl<P: Fp6Parameters> CanonicalDeserializeWithFlags for Fp6<P> {
 }
 
 impl<P: Fp6Parameters> CanonicalDeserialize for Fp6<P> {
+    #[inline]
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
         let c0 = Fp2::deserialize(reader)?;
         let c1 = Fp2::deserialize(reader)?;


### PR DESCRIPTION
As per wish of @gakonst, here is a convenience trait that allows to get the serialized size for constant sized elements without requiring an instance of the element.

This also includes a commit that adds proper derivation of the uncompressed variant.
So far, derived serialization always used the compressed variant.