### PR TITLE
Parallelize groth16

### DIFF
--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -35,6 +35,7 @@ crossbeam = "0.7.3"
 [dev-dependencies]
 csv = { version = "1" }
 algebra = { path = "../algebra", default-features = false, features = [ "bls12_377", "bls12_381", "sw6" ] }
+rand_xorshift = "0.2.0"
 
 [features]
 default = ["parallel"]

--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -30,6 +30,7 @@ r1cs-core = { path = "../r1cs-core", default-features = false }
 rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
 smallvec = "1.2.0"
+crossbeam = "0.7.3"
 
 [dev-dependencies]
 csv = { version = "1" }

--- a/groth16/examples/snark-scalability/groth16.rs
+++ b/groth16/examples/snark-scalability/groth16.rs
@@ -28,7 +28,10 @@
 use csv;
 
 // For randomness (during paramgen and proof generation)
-use algebra_core::{test_rng, One};
+use algebra_core::One;
+use rand_xorshift::XorShiftRng;
+use rand::SeedableRng;
+
 
 // For benchmarking
 use std::{
@@ -82,18 +85,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("Path to output file does not point to a file.");
         process::exit(1);
     };
-    // This may not be cryptographically safe, use
-    // `OsRng` (for example) in production software.
-    let rng = &mut test_rng();
+
+    // This is not cryptographically secure!
+    let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
 
     // Let's benchmark stuff!
-    let samples = if num_constraints > 10000 {
-        1
-    } else if num_constraints > 4096 {
-        2
-    } else {
-        4
-    };
+    let samples = 4;
     let mut total_setup = Duration::new(0, 0);
     let mut total_proving = Duration::new(0, 0);
     let mut total_verifying = Duration::new(0, 0);

--- a/r1cs-core/src/error.rs
+++ b/r1cs-core/src/error.rs
@@ -21,6 +21,15 @@ pub enum SynthesisError {
     MalformedVerifyingKey,
     /// During CRS generation, we observed an unconstrained auxiliary variable
     UnconstrainedVariable,
+    /// Any error which occured while multithreading
+    CrossBeamError,
+}
+
+#[cfg(feature = "std")]
+impl From<Box<dyn std::any::Any + Send>> for SynthesisError {
+    fn from(_: Box<dyn std::any::Any + Send>) -> SynthesisError {
+        SynthesisError::CrossBeamError
+    }
 }
 
 impl From<io::Error> for SynthesisError {
@@ -52,6 +61,9 @@ impl fmt::Display for SynthesisError {
             SynthesisError::MalformedVerifyingKey => write!(f, "malformed verifying key"),
             SynthesisError::UnconstrainedVariable => {
                 write!(f, "auxiliary variable was unconstrained")
+            },
+            SynthesisError::CrossBeamError => {
+                write!(f, "Crossbeam parallelization error")
             },
         }
     }


### PR DESCRIPTION
fixes: https://github.com/scipr-lab/zexe/issues/157

As title, using Crossbeam, we spawn a thread and get its value via its `JoinHandle`.  I also added a new Error variant for Crossbeam Errors (that's where the `Box<dyn Any + Send>` comes in, not sure if there's a cleaner way to do this, have tried doing this before and couldn't find one)

<s>After changing the Groth16 example to use deterministic RNG, with 500k constraints and 25k inputs I get  ~15% improvements on the prover and the setup generator.</s>

EDIT: After running it multiple times, it seems that prover times actually are around 40sec for both versions. It _might_ be the case that all my CPU threads are occupied in Rayon's operations, not giving any room for this change to provide any benefit.

EDIT2: I've run the same benchmark with a larger circuit (5mil constraints, BLS12-377), and I get ~same performance as master. It probably is the case that FFTs are dominating the computation.