### PR TITLE
Fall back to generic mul implementation if needed

### DIFF
--- a/algebra-core/src/fields/macros.rs
+++ b/algebra-core/src/fields/macros.rs
@@ -440,7 +440,7 @@ macro_rules! impl_Fp {
 /// zero bit in the rest of the modulus.
 macro_rules! impl_field_mul_assign {
     ($limbs:expr) => {
-        #[inline(never)]
+        #[inline]
         #[unroll_for_loops]
         fn mul_assign(&mut self, other: &Self) {
             // Checking the modulus at compile time
@@ -451,7 +451,7 @@ macro_rules! impl_field_mul_assign {
             }
             let no_carry:bool = !(first_bit_set || all_bits_set);
 
-            // No carry optimisation applied to CIOS
+            // No-carry optimisation applied to CIOS
             if no_carry {
                 let mut r = [0u64; $limbs];
                 let mut carry1 = 0u64;

--- a/algebra-core/src/fields/macros.rs
+++ b/algebra-core/src/fields/macros.rs
@@ -431,27 +431,72 @@ macro_rules! impl_Fp {
     }
 }
 
+
+// The no carry optimisation requires last bit to be zero
+// and all remaining bits not set
+// https://hackmd.io/@zkteam/modular_multiplication
+// It is slightly faster
 macro_rules! impl_field_mul_assign {
     ($limbs:expr) => {
         #[inline]
         #[unroll_for_loops]
         fn mul_assign(&mut self, other: &Self) {
-            let mut r = [0u64; $limbs];
-            let mut carry1 = 0u64;
-            let mut carry2 = 0u64;
-
-            for i in 0..$limbs {
-                r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[i], &mut carry1);
-                let k = r[0].wrapping_mul(P::INV);
-                fa::mac_discard(r[0], k, P::MODULUS.0[0], &mut carry2);
-                for j in 1..$limbs {
-                    r[j] = fa::mac_with_carry(r[j], (self.0).0[j], (other.0).0[i], &mut carry1);
-                    r[j-1] = fa::mac_with_carry(r[j], k, P::MODULUS.0[j], &mut carry2);
+            let mut no_carry = true;
+            if P::MODULUS.0[$limbs-1] >> 63 != 0 {
+                no_carry = false;
+            } else if ((P::MODULUS.0[$limbs-1] << 1) + 1) & !(0u64) == 0 {
+                let mut all_bits_set = true;
+                for i in 1..$limbs {
+                    if P::MODULUS.0[$limbs-1-i] & !(0u64) == 0 {
+                        all_bits_set &= true;
+                    } else { all_bits_set = false; }
                 }
-                r[$limbs-1] = carry1 + carry2;
+                no_carry = !all_bits_set;
             }
-            (self.0).0 = r;
-            self.reduce();
+            // No carry optimisation applied to CIOS
+            if no_carry {
+                let mut r = [0u64; $limbs];
+                let mut carry1 = 0u64;
+                let mut carry2 = 0u64;
+
+                for i in 0..$limbs {
+                    r[0] = fa::mac(r[0], (self.0).0[0], (other.0).0[i], &mut carry1);
+                    let k = r[0].wrapping_mul(P::INV);
+                    fa::mac_discard(r[0], k, P::MODULUS.0[0], &mut carry2);
+                    for j in 1..$limbs {
+                        r[j] = fa::mac_with_carry(r[j], (self.0).0[j], (other.0).0[i], &mut carry1);
+                        r[j-1] = fa::mac_with_carry(r[j], k, P::MODULUS.0[j], &mut carry2);
+                    }
+                    r[$limbs-1] = carry1 + carry2;
+                }
+                (self.0).0 = r;
+                self.reduce();
+            // Alternative implementation
+            } else {
+                let mut r = [0u64; $limbs*2];
+
+                for i in 0..$limbs {
+                    let mut carry = 0;
+                    for j in 0..$limbs {
+                        r[j+i] = fa::mac_with_carry(r[j+i], (self.0).0[i], (other.0).0[j], &mut carry);
+                    }
+                    r[$limbs+i] = carry;
+                }
+                // Montgomery reduction
+                let mut _carry2 = 0;
+                for i in 0..$limbs {
+                    let k = r[i].wrapping_mul(P::INV);
+                    let mut carry = 0;
+                    fa::mac_with_carry(r[i], k, P::MODULUS.0[0], &mut carry);
+                    for j in 1..$limbs {
+                        r[j+i] = fa::mac_with_carry(r[j+i], k, P::MODULUS.0[j], &mut carry);
+                    }
+                    r[$limbs+i] = fa::adc(r[$limbs+i], _carry2, &mut carry);
+                    _carry2 = carry;
+                }
+                (self.0).0.copy_from_slice(&r[$limbs..]);
+                self.reduce();
+            }
         }
     }
 }


### PR DESCRIPTION
Minor changes that should have been added to previous PR #163. 

By using my favourite tool of time `#[unroll_for_loops]`, I am able to get compile time checks that traverse the entire modulus, resulting in zero-overhead implementation switching. 

Alternate implementation to no carry is about 6% slower.