### PR TITLE
Optimize Groth16 memory and run-time performance

### DIFF
--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -29,7 +29,6 @@ ff-fft = { path = "../ff-fft", default-features = false }
 r1cs-core = { path = "../r1cs-core", default-features = false }
 rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
-smallvec = "1.2.0"
 
 [dev-dependencies]
 csv = { version = "1" }

--- a/groth16/examples/snark-scalability/constraints.rs
+++ b/groth16/examples/snark-scalability/constraints.rs
@@ -22,7 +22,6 @@ impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {
         let mut assignments = Vec::new();
-
         let mut a_val = F::one();
         let mut a_var = cs.alloc_input(|| "a", || Ok(a_val))?;
         assignments.push((a_val, a_var));

--- a/groth16/examples/snark-scalability/groth16.rs
+++ b/groth16/examples/snark-scalability/groth16.rs
@@ -128,7 +128,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         let start = Instant::now();
         // let proof = Proof::read(&proof_vec[..]).unwrap();
         // Check the proof
-        let _ = verify_proof(&pvk, &proof, &inputs).unwrap();
+        let r = verify_proof(&pvk, &proof, &inputs).unwrap();
+        assert!(r);
         total_verifying += start.elapsed();
     }
 

--- a/groth16/examples/snark-scalability/groth16.rs
+++ b/groth16/examples/snark-scalability/groth16.rs
@@ -145,15 +145,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         verifying_avg.subsec_nanos() as f64 / 1_000_000_000f64 + (verifying_avg.as_secs() as f64);
 
     println!(
-        "=== Benchmarking Groth16 with {} inputs and {} constraints: ====",
-        num_inputs, num_constraints
+        "=== Benchmarking Groth16 with {} constraints: ====",
+        num_constraints
     );
     println!("Average setup time: {:?} seconds", setup_avg);
     println!("Average proving time: {:?} seconds", proving_avg);
     println!("Average verifying time: {:?} seconds", verifying_avg);
 
     wtr.write_record(&[
-        format!("{}", num_inputs),
         format!("{}", num_constraints),
         format!("{}", setup_avg),
         format!("{}", proving_avg),

--- a/groth16/examples/snark-scalability/groth16.rs
+++ b/groth16/examples/snark-scalability/groth16.rs
@@ -52,14 +52,13 @@ use crate::constraints::Benchmark;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 4 || args[1] == "-h" || args[1] == "--help" {
+    if args.len() < 3 || args[1] == "-h" || args[1] == "--help" {
         println!(
-            "\nHelp: Invoke this as <program> <num_inputs> <num_constraints> <output_file_path>\n"
+            "\nHelp: Invoke this as <program> <num_constraints> <output_file_path>\n"
         );
     }
-    let num_inputs: usize = args[1].parse().unwrap();
-    let num_constraints: usize = args[2].parse().unwrap();
-    let output_file_path = PathBuf::from(args[3].clone());
+    let num_constraints: usize = args[1].parse().unwrap();
+    let output_file_path = PathBuf::from(args[2].clone());
     let mut wtr = if !output_file_path.exists() {
         println!("Creating output file");
         let f = OpenOptions::new()
@@ -68,7 +67,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             .open(output_file_path)?;
         let mut wtr = csv::Writer::from_writer(f);
         wtr.write_record(&[
-            "num_inputs",
             "num_constraints",
             "setup",
             "prover",

--- a/groth16/src/generator.rs
+++ b/groth16/src/generator.rs
@@ -11,7 +11,7 @@ use rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use crate::{r1cs_to_qap::R1CStoQAP, Parameters, String, Vec, VerifyingKey};
+use crate::{r1cs_to_qap::R1CStoQAP, Parameters, String, Vec, VerifyingKey, push_constraints};
 
 /// Generates a random common reference string for
 /// a circuit.
@@ -86,34 +86,22 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
         LB: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LC: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
     {
-        fn eval<E: PairingEngine>(
-            l: LinearCombination<E::Fr>,
-            constraints: &mut [Vec<(E::Fr, Index)>],
-            this_constraint: usize,
-        ) {
-            for (var, coeff) in l.as_ref() {
-                match var.get_unchecked() {
-                    Index::Input(i) => constraints[this_constraint].push((*coeff, Index::Input(i))),
-                    Index::Aux(i) => constraints[this_constraint].push((*coeff, Index::Aux(i))),
-                }
-            }
-        }
 
         self.at.push(vec![]);
         self.bt.push(vec![]);
         self.ct.push(vec![]);
 
-        eval::<E>(
+        push_constraints(
             a(LinearCombination::zero()),
             &mut self.at,
             self.num_constraints,
         );
-        eval::<E>(
+        push_constraints(
             b(LinearCombination::zero()),
             &mut self.bt,
             self.num_constraints,
         );
-        eval::<E>(
+        push_constraints(
             c(LinearCombination::zero()),
             &mut self.ct,
             self.num_constraints,

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -150,14 +150,17 @@ where
     let synthesis_time = start_timer!(|| "Constraint synthesis");
     circuit.generate_constraints(&mut prover)?;
     end_timer!(synthesis_time);
+    let full_input_assignment =
+        [&prover.input_assignment[..], &prover.aux_assignment[..]].concat();
 
     let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
-    let (full_input_assignment, h, _) = R1CStoQAP::witness_map::<E>(&prover)?;
+    let h = R1CStoQAP::witness_map::<E>(&prover)?;
     end_timer!(witness_map_time);
 
     let num_inputs = prover.input_assignment.len();
 
-    let input_assignment = cfg_into_iter!(full_input_assignment[1..num_inputs])
+    let input_assignment = full_input_assignment[1..num_inputs]
+        .into_iter()
         .map(|s| s.into_repr())
         .collect::<Vec<_>>();
 

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -169,8 +169,7 @@ where
 
     let num_inputs = prover.input_assignment.len();
 
-    let input_assignment = full_input_assignment[1..num_inputs]
-        .into_iter()
+    let input_assignment = cfg_into_iter!(full_input_assignment[1..num_inputs])
         .map(|s| s.into_repr())
         .collect::<Vec<_>>();
 
@@ -180,8 +179,7 @@ where
 
     drop(full_input_assignment);
 
-    let h_input_assignment = h[0..num_inputs]
-        .into_iter()
+    let h_input_assignment = cfg_into_iter!(h[0..num_inputs])
         .map(|s| s.into_repr())
         .collect::<Vec<_>>();
 
@@ -214,7 +212,7 @@ where
         let b_inputs_acc = VariableBaseMSM::multi_scalar_mul(b_inputs_source, &input_assignment);
         let b_aux_acc = VariableBaseMSM::multi_scalar_mul(b_aux_source, &aux_assignment);
 
-        let s_g1 = params.delta_g1.mul(s.clone());
+        let s_g1 = params.delta_g1.mul(s);
 
         let mut g1_b = s_g1;
         g1_b.add_assign_mixed(&params.get_b_g1_query_full()?[0]);
@@ -235,7 +233,7 @@ where
     let b_inputs_acc = VariableBaseMSM::multi_scalar_mul(b_inputs_source, &input_assignment);
     let b_aux_acc = VariableBaseMSM::multi_scalar_mul(b_aux_source, &aux_assignment);
 
-    let s_g2 = params.vk.delta_g2.mul(s.clone());
+    let s_g2 = params.vk.delta_g2.mul(s);
 
     let mut g2_b = s_g2;
     g2_b.add_assign_mixed(&params.get_b_g2_query_full()?[0]);
@@ -254,8 +252,8 @@ where
     let l_aux_source = params.get_l_query_full()?;
     let l_aux_acc = VariableBaseMSM::multi_scalar_mul(l_aux_source, &aux_assignment);
 
-    let s_g_a = g_a.clone().mul(s);
-    let r_g1_b = g1_b.clone().mul(r);
+    let s_g_a = g_a.mul(s);
+    let r_g1_b = g1_b.mul(r);
     let r_s_delta_g1 = params.delta_g1.into_projective().mul(r).mul(s);
 
     let mut g_c = s_g_a;

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -150,51 +150,30 @@ where
     let synthesis_time = start_timer!(|| "Constraint synthesis");
     circuit.generate_constraints(&mut prover)?;
     end_timer!(synthesis_time);
-    let full_input_assignment =
-        [&prover.input_assignment[..], &prover.aux_assignment[..]].concat();
 
     let witness_map_time = start_timer!(|| "R1CS to QAP witness map");
     let h = R1CStoQAP::witness_map::<E>(&prover)?;
     end_timer!(witness_map_time);
 
-    let num_inputs = prover.input_assignment.len();
-
-    let input_assignment = full_input_assignment[1..num_inputs]
+    let input_assignment = prover.input_assignment[1..]
         .into_iter()
         .map(|s| s.into_repr())
         .collect::<Vec<_>>();
 
-    let aux_assignment = cfg_into_iter!(full_input_assignment[num_inputs..])
+    let aux_assignment = cfg_into_iter!(prover.aux_assignment)
         .map(|s| s.into_repr())
         .collect::<Vec<_>>();
 
-    drop(full_input_assignment);
+    let assignment = [&input_assignment[..], &aux_assignment[..]].concat();
 
-    let h_input_assignment = cfg_into_iter!(h[0..num_inputs])
-        .map(|s| s.into_repr())
-        .collect::<Vec<_>>();
-
-    let h_aux_assignment = cfg_into_iter!(h[num_inputs..])
-        .map(|s| s.into_repr())
-        .collect::<Vec<_>>();
-
-    drop(h);
+    let h_assignment = cfg_into_iter!(h).map(|s| s.into_repr()).collect::<Vec<_>>();
 
     // Compute A
     let a_acc_time = start_timer!(|| "Compute A");
-    let (a_inputs_source, a_aux_source) = params.get_a_query(num_inputs)?;
-    let a_query = params.get_a_query_full()?[0];
+    let a_query = params.get_a_query_full()?;
     let r_g1 = params.delta_g1.mul(r);
 
-    let g_a = calculate_coeff(
-        r_g1,
-        a_inputs_source,
-        a_aux_source,
-        &input_assignment,
-        &aux_assignment,
-        a_query,
-        params.vk.alpha_g1,
-    );
+    let g_a = calculate_coeff(r_g1, a_query, params.vk.alpha_g1, &assignment);
 
     end_timer!(a_acc_time);
 
@@ -202,18 +181,9 @@ where
     let g1_b = if r != E::Fr::zero() {
         let b_g1_acc_time = start_timer!(|| "Compute B in G1");
         let s_g1 = params.delta_g1.mul(s);
-        let b_query = params.get_b_g1_query_full()?[0];
-        let (b_inputs_source, b_aux_source) = params.get_b_g1_query(num_inputs)?;
+        let b_query = params.get_b_g1_query_full()?;
 
-        let g1_b = calculate_coeff(
-            s_g1,
-            b_inputs_source,
-            b_aux_source,
-            &input_assignment,
-            &aux_assignment,
-            b_query,
-            params.beta_g1,
-        );
+        let g1_b = calculate_coeff(s_g1, b_query, params.beta_g1, &assignment);
 
         end_timer!(b_g1_acc_time);
 
@@ -224,27 +194,17 @@ where
 
     // Compute B in G2
     let b_g2_acc_time = start_timer!(|| "Compute B in G2");
-    let (b_inputs_source, b_aux_source) = params.get_b_g2_query(num_inputs)?;
-    let b_query = params.get_b_g2_query_full()?[0];
+    let b_query = params.get_b_g2_query_full()?;
     let s_g2 = params.vk.delta_g2.mul(s);
-    let g2_b = calculate_coeff(
-        s_g2,
-        b_inputs_source,
-        b_aux_source,
-        &input_assignment,
-        &aux_assignment,
-        b_query,
-        params.vk.beta_g2,
-    );
+    let g2_b = calculate_coeff(s_g2, b_query, params.vk.beta_g2, &assignment);
 
     end_timer!(b_g2_acc_time);
 
     // Compute C
     let c_acc_time = start_timer!(|| "Compute C");
 
-    let (h_inputs_source, h_aux_source) = params.get_h_query(num_inputs)?;
-    let h_inputs_acc = VariableBaseMSM::multi_scalar_mul(h_inputs_source, &h_input_assignment);
-    let h_aux_acc = VariableBaseMSM::multi_scalar_mul(h_aux_source, &h_aux_assignment);
+    let h_query = params.get_h_query_full()?;
+    let h_acc = VariableBaseMSM::multi_scalar_mul(&h_query, &h_assignment);
 
     let l_aux_source = params.get_l_query_full()?;
     let l_aux_acc = VariableBaseMSM::multi_scalar_mul(l_aux_source, &aux_assignment);
@@ -257,8 +217,7 @@ where
     g_c += &r_g1_b;
     g_c -= &r_s_delta_g1;
     g_c += &l_aux_acc;
-    g_c += &h_inputs_acc;
-    g_c += &h_aux_acc;
+    g_c += &h_acc;
     end_timer!(c_acc_time);
 
     end_timer!(prover_time);
@@ -272,21 +231,16 @@ where
 
 fn calculate_coeff<G: AffineCurve>(
     initial: G::Projective,
-    inputs_source: &[G],
-    aux_source: &[G],
-    input_assignment: &[<G::ScalarField as PrimeField>::BigInt],
-    aux_assignment: &[<G::ScalarField as PrimeField>::BigInt],
-    query: G,
+    query: &[G],
     vk_param: G,
+    assignment: &[<G::ScalarField as PrimeField>::BigInt],
 ) -> G::Projective {
+    let el = query[0];
+    let acc = VariableBaseMSM::multi_scalar_mul(&query[1..], assignment);
+
     let mut res = initial;
-
-    let inputs_acc = VariableBaseMSM::multi_scalar_mul(inputs_source, input_assignment);
-    let aux_acc = VariableBaseMSM::multi_scalar_mul(aux_source, aux_assignment);
-
-    res.add_assign_mixed(&query);
-    res += &inputs_acc;
-    res += &aux_acc;
+    res.add_assign_mixed(&el);
+    res += &acc;
     res.add_assign_mixed(&vk_param);
 
     res

--- a/groth16/src/r1cs_to_qap.rs
+++ b/groth16/src/r1cs_to_qap.rs
@@ -16,8 +16,8 @@ fn evaluate_constraint<'a, LHS, RHS, R>(
 ) -> R
 where
     LHS: One + Send + Sync + PartialEq,
-    RHS: Send + Sync + std::ops::Mul<&'a LHS, Output = RHS> + Copy,
-    R: std::iter::Sum + Zero + Send + AddAssign<RHS>,
+    RHS: Send + Sync + core::ops::Mul<&'a LHS, Output = RHS> + Copy,
+    R: core::iter::Sum + Zero + Send + AddAssign<RHS>,
 {
     cfg_into_iter!(terms)
         .fold(

--- a/groth16/src/r1cs_to_qap.rs
+++ b/groth16/src/r1cs_to_qap.rs
@@ -103,9 +103,8 @@ impl R1CStoQAP {
     #[inline]
     pub(crate) fn witness_map<E: PairingEngine>(
         prover: &ProvingAssignment<E>,
-    ) -> Result<(Vec<E::Fr>, Vec<E::Fr>, usize), SynthesisError> {
+    ) -> Result<Vec<E::Fr>, SynthesisError> {
         let zero = E::Fr::zero();
-        let one = E::Fr::one();
         let num_inputs = prover.input_assignment.len();
         let num_constraints = prover.num_constraints();
 
@@ -129,7 +128,7 @@ impl R1CStoQAP {
             });
 
         for i in 0..num_inputs {
-            a[num_constraints + i] = if i > 0 { full_input_assignment[i] } else { one };
+            a[num_constraints + i] = full_input_assignment[i];
         }
 
         domain.ifft_in_place(&mut a);
@@ -159,11 +158,6 @@ impl R1CStoQAP {
         domain.divide_by_vanishing_poly_on_coset_in_place(&mut ab);
         domain.coset_ifft_in_place(&mut ab);
 
-        let mut h: Vec<E::Fr> = vec![zero; domain_size - 1];
-        cfg_iter_mut!(h)
-            .enumerate()
-            .for_each(|(i, e)| e.add_assign(&ab[i]));
-
-        Ok((full_input_assignment, h, domain_size))
+        Ok(ab)
     }
 }

--- a/groth16/src/r1cs_to_qap.rs
+++ b/groth16/src/r1cs_to_qap.rs
@@ -101,7 +101,6 @@ impl R1CStoQAP {
         let full_input_assignment =
             [&prover.input_assignment[..], &prover.aux_assignment[..]].concat();
 
-        // dbg!(prover.num_constraints, prover.num_inputs);
         let domain = EvaluationDomain::<E::Fr>::new(num_constraints + num_inputs)
             .ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
         let domain_size = domain.size();

--- a/groth16/src/verifier.rs
+++ b/groth16/src/verifier.rs
@@ -9,7 +9,7 @@ use core::ops::{AddAssign, Neg};
 pub fn prepare_verifying_key<E: PairingEngine>(vk: &VerifyingKey<E>) -> PreparedVerifyingKey<E> {
     PreparedVerifyingKey {
         vk:               vk.clone(),
-        alpha_g1_beta_g2: E::pairing(vk.alpha_g1.clone(), vk.beta_g2.clone()),
+        alpha_g1_beta_g2: E::pairing(vk.alpha_g1, vk.beta_g2),
         gamma_g2_neg_pc:  vk.gamma_g2.neg().into(),
         delta_g2_neg_pc:  vk.delta_g2.neg().into(),
         gamma_abc_g1:     vk.gamma_abc_g1.clone(),


### PR DESCRIPTION
Turns out we were making redundant evaluations? The evaluation of the polynomial was already being done in R1CS-to-QAP -- cc @kobigurk 