### PR TITLE
Implement `conditional_check_verify` for `NIZK`s

### DIFF
--- a/crypto-primitives/src/nizk/constraints.rs
+++ b/crypto-primitives/src/nizk/constraints.rs
@@ -20,4 +20,16 @@ pub trait NIZKVerifierGadget<N: NIZK, ConstraintF: Field> {
         CS: ConstraintSystem<ConstraintF>,
         I: Iterator<Item = &'a T>,
         T: 'a + ToBitsGadget<ConstraintF> + ?Sized;
+
+    fn conditional_check_verify<'a, CS, I, T>(
+        cs: CS,
+        verification_key: &Self::VerificationKeyGadget,
+        input: I,
+        proof: &Self::ProofGadget,
+        condition: &Boolean,
+    ) -> Result<(), SynthesisError>
+        where
+            CS: ConstraintSystem<ConstraintF>,
+            I: Iterator<Item = &'a T>,
+            T: 'a + ToBitsGadget<ConstraintF> + ?Sized;
 }

--- a/crypto-primitives/src/nizk/constraints.rs
+++ b/crypto-primitives/src/nizk/constraints.rs
@@ -28,8 +28,8 @@ pub trait NIZKVerifierGadget<N: NIZK, ConstraintF: Field> {
         proof: &Self::ProofGadget,
         condition: &Boolean,
     ) -> Result<(), SynthesisError>
-        where
-            CS: ConstraintSystem<ConstraintF>,
-            I: Iterator<Item = &'a T>,
-            T: 'a + ToBitsGadget<ConstraintF> + ?Sized;
+    where
+        CS: ConstraintSystem<ConstraintF>,
+        I: Iterator<Item = &'a T>,
+        T: 'a + ToBitsGadget<ConstraintF> + ?Sized;
 }

--- a/crypto-primitives/src/nizk/gm17/constraints.rs
+++ b/crypto-primitives/src/nizk/gm17/constraints.rs
@@ -119,13 +119,27 @@ where
         I: Iterator<Item = &'a T>,
         T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
     {
-        <Self as NIZKVerifierGadget<Gm17<PairingE, C, V>, ConstraintF>>::conditional_check_verify(cs, vk, public_inputs, proof, &Boolean::constant(true))
+        <Self as NIZKVerifierGadget<Gm17<PairingE, C, V>, ConstraintF>>::conditional_check_verify(
+            cs,
+            vk,
+            public_inputs,
+            proof,
+            &Boolean::constant(true),
+        )
     }
 
-    fn conditional_check_verify<'a, CS, I, T>(mut cs: CS, vk: &Self::VerificationKeyGadget, mut public_inputs: I, proof: &Self::ProofGadget, condition: &Boolean) -> Result<(), SynthesisError> where
+    fn conditional_check_verify<'a, CS, I, T>(
+        mut cs: CS,
+        vk: &Self::VerificationKeyGadget,
+        mut public_inputs: I,
+        proof: &Self::ProofGadget,
+        condition: &Boolean,
+    ) -> Result<(), SynthesisError>
+    where
         CS: ConstraintSystem<ConstraintF>,
-        I: Iterator<Item=&'a T>,
-        T: 'a + ToBitsGadget<ConstraintF> + ?Sized {
+        I: Iterator<Item = &'a T>,
+        T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
+    {
         let pvk = vk.prepare(&mut cs.ns(|| "Prepare vk"))?;
         // e(A*G^{alpha}, B*H^{beta}) = e(G^{alpha}, H^{beta}) * e(G^{psi}, H^{gamma}) *
         // e(C, H) where psi = \sum_{i=0}^l input_i pvk.query[i]

--- a/crypto-primitives/src/nizk/gm17/constraints.rs
+++ b/crypto-primitives/src/nizk/gm17/constraints.rs
@@ -109,9 +109,9 @@ where
     type ProofGadget = ProofGadget<PairingE, ConstraintF, P>;
 
     fn check_verify<'a, CS, I, T>(
-        mut cs: CS,
+        cs: CS,
         vk: &Self::VerificationKeyGadget,
-        mut public_inputs: I,
+        public_inputs: I,
         proof: &Self::ProofGadget,
     ) -> Result<(), SynthesisError>
     where
@@ -119,6 +119,13 @@ where
         I: Iterator<Item = &'a T>,
         T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
     {
+        <Self as NIZKVerifierGadget<Gm17<PairingE, C, V>, ConstraintF>>::conditional_check_verify(cs, vk, public_inputs, proof, &Boolean::constant(true))
+    }
+
+    fn conditional_check_verify<'a, CS, I, T>(mut cs: CS, vk: &Self::VerificationKeyGadget, mut public_inputs: I, proof: &Self::ProofGadget, condition: &Boolean) -> Result<(), SynthesisError> where
+        CS: ConstraintSystem<ConstraintF>,
+        I: Iterator<Item=&'a T>,
+        T: 'a + ToBitsGadget<ConstraintF> + ?Sized {
         let pvk = vk.prepare(&mut cs.ns(|| "Prepare vk"))?;
         // e(A*G^{alpha}, B*H^{beta}) = e(G^{alpha}, H^{beta}) * e(G^{psi}, H^{gamma}) *
         // e(C, H) where psi = \sum_{i=0}^l input_i pvk.query[i]
@@ -189,8 +196,8 @@ where
         let test2 = P::final_exponentiation(cs.ns(|| "Final Exp 2"), &test2_exp)?;
 
         let one = P::GTGadget::one(cs.ns(|| "GT One"))?;
-        test1.enforce_equal(cs.ns(|| "Test 1"), &one)?;
-        test2.enforce_equal(cs.ns(|| "Test 2"), &one)?;
+        test1.conditional_enforce_equal(cs.ns(|| "Test 1"), &one, condition)?;
+        test2.conditional_enforce_equal(cs.ns(|| "Test 2"), &one, condition)?;
         Ok(())
     }
 }

--- a/crypto-primitives/src/nizk/gm17/mod.rs
+++ b/crypto-primitives/src/nizk/gm17/mod.rs
@@ -35,10 +35,10 @@ impl<E: PairingEngine, C: ConstraintSynthesizer<E::Fr>, V: ToConstraintField<E::
 {
     type Circuit = C;
     type AssignedCircuit = C;
+    type VerifierInput = V;
     type ProvingParameters = Parameters<E>;
     type VerificationParameters = VerifyingKey<E>;
     type PreparedVerificationParameters = PreparedVerifyingKey<E>;
-    type VerifierInput = V;
     type Proof = Proof<E>;
 
     fn setup<R: Rng>(

--- a/crypto-primitives/src/nizk/groth16/constraints.rs
+++ b/crypto-primitives/src/nizk/groth16/constraints.rs
@@ -120,7 +120,13 @@ where
         I: Iterator<Item = &'a T>,
         T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
     {
-        <Self as NIZKVerifierGadget<Groth16<PairingE, C, V>, ConstraintF>>::conditional_check_verify(cs, vk, public_inputs, proof, &Boolean::constant(true))
+        <Self as NIZKVerifierGadget<Groth16<PairingE, C, V>, ConstraintF>>::conditional_check_verify(
+            cs,
+            vk,
+            public_inputs,
+            proof,
+            &Boolean::constant(true),
+        )
     }
 
     fn conditional_check_verify<'a, CS, I, T>(
@@ -130,10 +136,10 @@ where
         proof: &Self::ProofGadget,
         condition: &Boolean,
     ) -> Result<(), SynthesisError>
-        where
-            CS: ConstraintSystem<ConstraintF>,
-            I: Iterator<Item = &'a T>,
-            T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
+    where
+        CS: ConstraintSystem<ConstraintF>,
+        I: Iterator<Item = &'a T>,
+        T: 'a + ToBitsGadget<ConstraintF> + ?Sized,
     {
         let pvk = vk.prepare(&mut cs.ns(|| "Prepare vk"))?;
 

--- a/crypto-primitives/src/nizk/groth16/mod.rs
+++ b/crypto-primitives/src/nizk/groth16/mod.rs
@@ -35,10 +35,10 @@ impl<E: PairingEngine, C: ConstraintSynthesizer<E::Fr>, V: ToConstraintField<E::
 {
     type Circuit = C;
     type AssignedCircuit = C;
+    type VerifierInput = V;
     type ProvingParameters = Parameters<E>;
     type VerificationParameters = VerifyingKey<E>;
     type PreparedVerificationParameters = PreparedVerifyingKey<E>;
-    type VerifierInput = V;
     type Proof = Proof<E>;
 
     fn setup<R: Rng>(

--- a/r1cs-std/src/bits/boolean.rs
+++ b/r1cs-std/src/bits/boolean.rs
@@ -550,9 +550,9 @@ impl Boolean {
     }
 
     pub fn kary_or<ConstraintF, CS>(mut cs: CS, bits: &[Self]) -> Result<Self, SynthesisError>
-        where
-            ConstraintF: Field,
-            CS: ConstraintSystem<ConstraintF>,
+    where
+        ConstraintF: Field,
+        CS: ConstraintSystem<ConstraintF>,
     {
         assert!(!bits.is_empty());
         let mut bits = bits.iter();

--- a/r1cs-std/src/bits/boolean.rs
+++ b/r1cs-std/src/bits/boolean.rs
@@ -549,6 +549,22 @@ impl Boolean {
         Ok(cur)
     }
 
+    pub fn kary_or<ConstraintF, CS>(mut cs: CS, bits: &[Self]) -> Result<Self, SynthesisError>
+        where
+            ConstraintF: Field,
+            CS: ConstraintSystem<ConstraintF>,
+    {
+        assert!(!bits.is_empty());
+        let mut bits = bits.iter();
+
+        let mut cur: Self = *bits.next().unwrap();
+        for (i, next) in bits.enumerate() {
+            cur = Boolean::or(cs.ns(|| format!("OR {}", i)), &cur, next)?;
+        }
+
+        Ok(cur)
+    }
+
     /// Asserts that at least one operand is false.
     pub fn enforce_nand<ConstraintF, CS>(mut cs: CS, bits: &[Self]) -> Result<(), SynthesisError>
     where

--- a/r1cs-std/src/bits/mod.rs
+++ b/r1cs-std/src/bits/mod.rs
@@ -58,7 +58,29 @@ impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for Vec<Boolean> {
     }
 }
 
+impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for UInt8 {
+    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+        &self,
+        _cs: CS,
+    ) -> Result<Vec<Boolean>, SynthesisError> {
+        Ok(self.into_bits_le())
+    }
+}
+
 impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for [UInt8] {
+    fn to_bits<CS: ConstraintSystem<ConstraintF>>(
+        &self,
+        _cs: CS,
+    ) -> Result<Vec<Boolean>, SynthesisError> {
+        let mut result = Vec::with_capacity(&self.len() * 8);
+        for byte in self {
+            result.extend_from_slice(&byte.into_bits_le());
+        }
+        Ok(result)
+    }
+}
+
+impl<ConstraintF: Field> ToBitsGadget<ConstraintF> for Vec<UInt8> {
     fn to_bits<CS: ConstraintSystem<ConstraintF>>(
         &self,
         _cs: CS,


### PR DESCRIPTION
Just some quick and easy implementations:

1. Added a conditional_check_verify function to Groth16Verifier and Gm17Verifier Gadgets.
2. Implemented ToBitsGadget for UInt8 and Vec<UInt8>.
3. Added a kary_or function to Boolean.