### PR TITLE
Merkle tree fixes

### DIFF
--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -268,6 +268,10 @@ fn log2(number: usize) -> usize {
 /// Returns the height of the tree, given the size of the tree.
 #[inline]
 fn tree_height(tree_size: usize) -> usize {
+    if tree_size == 1 {
+        return 1;
+    }
+
     log2(tree_size)
 }
 

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -161,14 +161,16 @@ impl<P: MerkleTreeConfig> MerkleHashTree<P> {
         let mut cur_height = tree_height;
         let mut padding_tree = Vec::new();
         let mut cur_hash = tree[0].clone();
-        while cur_height < (Self::HEIGHT - 1) as usize {
-            cur_hash = hash_inner_node::<P::H>(&parameters, &cur_hash, &empty_hash, &mut buffer)?;
-            padding_tree.push((cur_hash.clone(), empty_hash.clone()));
-            cur_height += 1;
-        }
-
-        let root_hash = hash_inner_node::<P::H>(&parameters, &cur_hash, &empty_hash, &mut buffer)?;
-
+        let root_hash = if cur_height < Self::HEIGHT as usize {
+            while cur_height < (Self::HEIGHT - 1) as usize {
+                cur_hash = hash_inner_node::<P::H>(&parameters, &cur_hash, &empty_hash, &mut buffer)?;
+                padding_tree.push((cur_hash.clone(), empty_hash.clone()));
+                cur_height += 1;
+            }
+            hash_inner_node::<P::H>(&parameters, &cur_hash, &empty_hash, &mut buffer)?
+        } else {
+            cur_hash
+        };
         end_timer!(new_time);
 
         Ok(MerkleHashTree {

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -163,7 +163,8 @@ impl<P: MerkleTreeConfig> MerkleHashTree<P> {
         let mut cur_hash = tree[0].clone();
         let root_hash = if cur_height < Self::HEIGHT as usize {
             while cur_height < (Self::HEIGHT - 1) as usize {
-                cur_hash = hash_inner_node::<P::H>(&parameters, &cur_hash, &empty_hash, &mut buffer)?;
+                cur_hash =
+                    hash_inner_node::<P::H>(&parameters, &cur_hash, &empty_hash, &mut buffer)?;
                 padding_tree.push((cur_hash.clone(), empty_hash.clone()));
                 cur_height += 1;
             }

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -418,6 +418,11 @@ mod test {
         generate_merkle_tree(&leaves);
     }
 
+    #[test]
+    fn single_leaf_test() {
+        generate_merkle_tree(&[[1u8; 8]]);
+    }
+
     fn bad_merkle_tree_verify<L: ToBytes + Clone + Eq>(leaves: &[L]) -> () {
         let mut rng = XorShiftRng::seed_from_u64(13423423u64);
 

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -378,7 +378,7 @@ mod test {
     struct JubJubMerkleTreeParams;
 
     impl MerkleTreeConfig for JubJubMerkleTreeParams {
-        const HEIGHT: usize = 32;
+        const HEIGHT: usize = 8;
         type H = H;
     }
     type JubJubMerkleTree = MerkleHashTree<JubJubMerkleTreeParams>;
@@ -404,6 +404,15 @@ mod test {
         generate_merkle_tree(&leaves);
         let mut leaves = Vec::new();
         for i in 0..100u8 {
+            leaves.push([i, i, i, i, i, i, i, i]);
+        }
+        generate_merkle_tree(&leaves);
+    }
+
+    #[test]
+    fn no_dummy_nodes_test() {
+        let mut leaves = Vec::new();
+        for i in 0..(1u8 << JubJubMerkleTree::HEIGHT - 1) {
             leaves.push([i, i, i, i, i, i, i, i]);
         }
         generate_merkle_tree(&leaves);


### PR DESCRIPTION
Noticed two issues with the Merkle tree implementation
1. height = log(number_of_nodes) resulted in height = 0 for number_of_nodes = 1
2. It added an additional layer (a dummy node) even when effective tree height matched the required height, thus resulting in wrong Merkle root