### PR TITLE
allow log_size_of_group == Self::FftParams::TWO_ADICITY

### DIFF
--- a/algebra-core/src/fields/mod.rs
+++ b/algebra-core/src/fields/mod.rs
@@ -282,7 +282,7 @@ pub trait FftField: Field + From<u128> + From<u64> + From<u32> + From<u16> + Fro
             let size = n.next_power_of_two() as u64;
             let log_size_of_group = size.trailing_zeros();
 
-            if n != size as usize || log_size_of_group >= Self::FftParams::TWO_ADICITY {
+            if n != size as usize || log_size_of_group > Self::FftParams::TWO_ADICITY {
                 return None;
             }
 


### PR DESCRIPTION
@paberr I feel here we should as well allow `log_size_of_group == Self::FftParams::TWO_ADICITY`.

Any thoughts?