### PR TITLE
Removes unused type parameter from create_proof_no_zk

### DIFF
--- a/groth16/src/prover/mod.rs
+++ b/groth16/src/prover/mod.rs
@@ -25,7 +25,7 @@ where
 }
 
 #[inline]
-pub fn create_proof_no_zk<E, C, D>(
+pub fn create_proof_no_zk<E, C>(
     circuit: C,
     params: &Parameters<E>,
 ) -> Result<Proof<E>, SynthesisError>


### PR DESCRIPTION
The domain parameter is not needed in the non generic version.