### PR TITLE
Add constant folding to FpGadget<F>

### DIFF
--- a/r1cs-core/src/impl_lc.rs
+++ b/r1cs-core/src/impl_lc.rs
@@ -1,4 +1,4 @@
-use crate::{LinearCombination, SmallVec, Variable, Index};
+use crate::{Index, LinearCombination, SmallVec, Variable};
 use algebra_core::Field;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
 use smallvec::smallvec;
@@ -86,8 +86,7 @@ impl<F: Field> LinearCombination<F> {
 
         // Check if the only variable in the LC is the variable corresponding to constants
         let var = self.0[0].0;
-        if var.0 != Index::Input(0)
-        {
+        if var.0 != Index::Input(0) {
             return false;
         }
         true

--- a/r1cs-core/src/impl_lc.rs
+++ b/r1cs-core/src/impl_lc.rs
@@ -75,6 +75,10 @@ impl<F: Field> LinearCombination<F> {
     /// Return whether or not a particular linear combination represents a constant
     #[inline]
     pub fn is_constant(&self) -> bool {
+        // Linear combination is 0
+        if self.0.len() == 0 {
+            return true;
+        }
         // Linear combination has more than one variable, so it must not be a constant
         if self.0.len() != 1 {
             return false;

--- a/r1cs-core/src/impl_lc.rs
+++ b/r1cs-core/src/impl_lc.rs
@@ -1,4 +1,4 @@
-use crate::{LinearCombination, SmallVec, Variable};
+use crate::{LinearCombination, SmallVec, Variable, Index};
 use algebra_core::Field;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
 use smallvec::smallvec;
@@ -70,6 +70,23 @@ impl<F: Field> LinearCombination<F> {
             self.0
                 .binary_search_by_key(search_var, |&(cur_var, _)| cur_var)
         }
+    }
+
+    /// Return whether or not a particular linear combination represents a constant
+    #[inline]
+    pub fn is_constant(&self) -> bool {
+        // Linear combination has more than one variable, so it must not be a constant
+        if self.0.len() != 1 {
+            return false;
+        }
+
+        // Check if the only variable in the LC is the variable corresponding to constants
+        let var = self.0[0].0;
+        if var.0 != Index::Input(0)
+        {
+            return false;
+        }
+        true
     }
 }
 

--- a/r1cs-std/src/fields/fp/mod.rs
+++ b/r1cs-std/src/fields/fp/mod.rs
@@ -164,7 +164,6 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
         // Apply constant folding if it applies
         // unwrap is used, because these values are guaranteed to exist. 
         if other.is_constant() {
-            println!("Called!");
             return self.mul_by_constant(cs, &other.get_value().unwrap());
         } else if self.is_constant() {
             return other.mul_by_constant(cs, &self.get_value().unwrap());

--- a/r1cs-std/src/fields/fp/mod.rs
+++ b/r1cs-std/src/fields/fp/mod.rs
@@ -23,17 +23,17 @@ impl<F: PrimeField> FpGadget<F> {
         Self::alloc(cs.ns(|| "from"), || Ok(*value)).unwrap()
     }
 
-    fn is_constant(&self) -> bool
-    {
+    fn is_constant(&self) -> bool {
         match &self.variable {
-            // If you don't do alloc_constant, you are guaranteed to get a variable
-            // So we assume here that all variables are not the constant variable. 
-            // Technically this omits recognizing some constants where if you variables w,x,y,z with constraints:
+            // If you don't do alloc_constant, you are guaranteed to get a variable,
+            // hence we assume that all variables are not the constant variable.
+            // Technically this omits recognizing some constants.
+            // E.g. given variables w,x,y,z with constraints:
             // w = x + 1
             // y = -x + 1
             // and then created the variable z = w + y,
             // this would not recognize that z is in fact a constant.
-            // Since this is an edge case, we leave this as a TODO.
+            // Since this is an edge case, this is left as a TODO.
             Var(_v) => false,
             LC(l) => l.is_constant(),
         }
@@ -162,13 +162,13 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
         other: &Self,
     ) -> Result<Self, SynthesisError> {
         // Apply constant folding if it applies
-        // unwrap is used, because these values are guaranteed to exist. 
+        // unwrap is used, because these values are guaranteed to exist.
         if other.is_constant() {
             return self.mul_by_constant(cs, &other.get_value().unwrap());
         } else if self.is_constant() {
             return other.mul_by_constant(cs, &self.get_value().unwrap());
         }
-        
+
         let product = Self::alloc(cs.ns(|| "mul"), || {
             Ok(self.value.get()? * &other.value.get()?)
         })?;

--- a/r1cs-std/src/fields/fp/mod.rs
+++ b/r1cs-std/src/fields/fp/mod.rs
@@ -22,6 +22,22 @@ impl<F: PrimeField> FpGadget<F> {
     pub fn from<CS: ConstraintSystem<F>>(mut cs: CS, value: &F) -> Self {
         Self::alloc(cs.ns(|| "from"), || Ok(*value)).unwrap()
     }
+
+    fn is_constant(&self) -> bool
+    {
+        match &self.variable {
+            // If you don't do alloc_constant, you are guaranteed to get a variable
+            // So we assume here that all variables are not the constant variable. 
+            // Technically this omits recognizing some constants where if you variables w,x,y,z with constraints:
+            // w = x + 1
+            // y = -x + 1
+            // and then created the variable z = w + y,
+            // this would not recognize that z is in fact a constant.
+            // Since this is an edge case, we leave this as a TODO.
+            Var(_v) => false,
+            LC(l) => l.is_constant(),
+        }
+    }
 }
 
 impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
@@ -145,6 +161,15 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
         mut cs: CS,
         other: &Self,
     ) -> Result<Self, SynthesisError> {
+        // Apply constant folding if it applies
+        // unwrap is used, because these values are guaranteed to exist. 
+        if other.is_constant() {
+            println!("Called!");
+            return self.mul_by_constant(cs, &other.get_value().unwrap());
+        } else if self.is_constant() {
+            return other.mul_by_constant(cs, &self.get_value().unwrap());
+        }
+        
         let product = Self::alloc(cs.ns(|| "mul"), || {
             Ok(self.value.get()? * &other.value.get()?)
         })?;

--- a/r1cs-std/src/fields/mod.rs
+++ b/r1cs-std/src/fields/mod.rs
@@ -290,6 +290,7 @@ pub(crate) mod tests {
         let b_native = FE::rand(&mut rng);
         let a = F::alloc(&mut cs.ns(|| "generate_a"), || Ok(a_native)).unwrap();
         let b = F::alloc(&mut cs.ns(|| "generate_b"), || Ok(b_native)).unwrap();
+        let b_const = F::alloc_constant(&mut cs.ns(|| "generate_b_as_constant"), b_native).unwrap();
 
         let zero = F::zero(cs.ns(|| "zero")).unwrap();
         let zero_native = zero.get_value().unwrap();
@@ -397,6 +398,13 @@ pub(crate) mod tests {
         let ba = b.mul(cs.ns(|| "b_times_a"), &a).unwrap();
         assert_eq!(ab, ba);
         assert_eq!(ab.get_value().unwrap(), a_native * &b_native);
+
+        println!("wave");
+        let ab_const = a.mul(cs.ns(|| "a_times_b_const"), &b_const).unwrap();
+        let b_const_a = b_const.mul(cs.ns(|| "b_const_times_a"), &a).unwrap();
+        assert_eq!(ab_const, b_const_a);
+        assert_eq!(ab_const, ab);
+        assert_eq!(ab_const.get_value().unwrap(), a_native * &b_native);
 
         // (a * b) * a = a * (b * a)
         let ab_a = ab.mul(cs.ns(|| "ab_times_a"), &a).unwrap();

--- a/r1cs-std/src/fields/mod.rs
+++ b/r1cs-std/src/fields/mod.rs
@@ -399,7 +399,6 @@ pub(crate) mod tests {
         assert_eq!(ab, ba);
         assert_eq!(ab.get_value().unwrap(), a_native * &b_native);
 
-        println!("wave");
         let ab_const = a.mul(cs.ns(|| "a_times_b_const"), &b_const).unwrap();
         let b_const_a = b_const.mul(cs.ns(|| "b_const_times_a"), &a).unwrap();
         assert_eq!(ab_const, b_const_a);


### PR DESCRIPTION
This PR adds constant folding to FpGadget<F>. The only place where constant folding needs special casing is from within `.mul()`. (Square reduces to a call to mul) Constant folding for this is achieved by checking if either argument to mul is a constant, and if so doing mul_by_constant.

Currently this checks if its a constant by a newly implemented method on linear combination. While not shown in the tests (as micro-counting number of constraints isn't really well supported), I have confirmed in a separate circuit that this does lower the number of constraints when alloc_constant is used.