### PR TITLE
Replace k/2-th Frobenius powers by conjugations

### DIFF
--- a/algebra-core/src/curves/models/bls12/mod.rs
+++ b/algebra-core/src/curves/models/bls12/mod.rs
@@ -135,7 +135,7 @@ impl<P: Bls12Parameters> PairingEngine for Bls12<P> {
 
         // f1 = r.conjugate() = f^(p^6)
         let mut f1 = *f;
-        f1.frobenius_map(6);
+        f1.conjugate();
 
         f.inverse().and_then(|mut f2| {
             {

--- a/algebra-core/src/curves/models/bw6/mod.rs
+++ b/algebra-core/src/curves/models/bw6/mod.rs
@@ -91,7 +91,7 @@ impl<P: BW6Parameters> BW6<P> {
 
         // elt_q3 = elt^(q^3)
         let mut elt_q3 = elt.clone();
-        elt_q3.frobenius_map(3);
+        elt_q3.conjugate();
         // elt_q3_over_elt = elt^(q^3-1)
         let elt_q3_over_elt = elt_q3 * elt_inv;
         // alpha = elt^((q^3-1) * q)
@@ -140,20 +140,20 @@ impl<P: BW6Parameters> BW6<P> {
 
         // step 5
         let mut f5p_p3 = f5p;
-        f5p_p3.frobenius_map(3);
+        f5p_p3.conjugate();
         let result1 = f3p * &f6p * &f5p_p3;
 
         // step 6
         let result2 = result1.square();
         let f4_2p = f4 * &f2p;
         let mut tmp1_p3 = f0 * &f1 * &f3 * &f4_2p * &f8p;
-        tmp1_p3.frobenius_map(3);
+        tmp1_p3.conjugate();
         let result3 = result2 * &f5 * &f0p * &tmp1_p3;
 
         // step 7
         let result4 = result3.square();
         let mut f7_p3 = f7;
-        f7_p3.frobenius_map(3);
+        f7_p3.conjugate();
         let result5 = result4 * &f9p * &f7_p3;
 
         // step 8
@@ -161,13 +161,13 @@ impl<P: BW6Parameters> BW6<P> {
         let f2_4p = f2 * &f4p;
         let f4_2p_5p = f4_2p * &f5p;
         let mut tmp2_p3 = f2_4p * &f3 * &f3p;
-        tmp2_p3.frobenius_map(3);
+        tmp2_p3.conjugate();
         let result7 = result6 * &f4_2p_5p * &f6 * &f7p * &tmp2_p3;
 
         // step 9
         let result8 = result7.square();
         let mut tmp3_p3 = f0p * &f9p;
-        tmp3_p3.frobenius_map(3);
+        tmp3_p3.conjugate();
         let result9 = result8 * &f0 * &f7 * &f1p * &tmp3_p3;
 
         // step 10
@@ -175,7 +175,7 @@ impl<P: BW6Parameters> BW6<P> {
         let f6p_8p = f6p * &f8p;
         let f5_7p = f5 * &f7p;
         let mut tmp4_p3 = f6p_8p;
-        tmp4_p3.frobenius_map(3);
+        tmp4_p3.conjugate();
         let result11 = result10 * &f5_7p * &f2p * &tmp4_p3;
 
         // step 11
@@ -183,25 +183,25 @@ impl<P: BW6Parameters> BW6<P> {
         let f3_6 = f3 * &f6;
         let f1_7 = f1 * &f7;
         let mut tmp5_p3 = f1_7 * &f2;
-        tmp5_p3.frobenius_map(3);
+        tmp5_p3.conjugate();
         let result13 = result12 * &f3_6 * &f9p * &tmp5_p3;
 
         // step 12
         let result14 = result13.square();
         let mut tmp6_p3 = f4_2p * &f5_7p * &f6p_8p;
-        tmp6_p3.frobenius_map(3);
+        tmp6_p3.conjugate();
         let result15 = result14 * &f0 * &f0p * &f3p * &f5p * &tmp6_p3;
 
         // step 13
         let result16 = result15.square();
         let mut tmp7_p3 = f3_6;
-        tmp7_p3.frobenius_map(3);
+        tmp7_p3.conjugate();
         let result17 = result16 * &f1p * &tmp7_p3;
 
         // step 14
         let result18 = result17.square();
         let mut tmp8_p3 = f2_4p * &f4_2p_5p * &f9p;
-        tmp8_p3.frobenius_map(3);
+        tmp8_p3.conjugate();
         let result19 = result18 * &f1_7 * &f5_7p * &f0p * &tmp8_p3;
 
         result19

--- a/algebra-core/src/curves/models/mnt4/mod.rs
+++ b/algebra-core/src/curves/models/mnt4/mod.rs
@@ -172,7 +172,7 @@ impl<P: MNT4Parameters> MNT4<P> {
 
         // elt_q2 = elt^(q^2)
         let mut elt_q2 = elt.clone();
-        elt_q2.frobenius_map(2);
+        elt_q2.conjugate();
         // elt_q2_over_elt = elt^(q^2-1)
         elt_q2 * elt_inv
     }

--- a/algebra-core/src/curves/models/mnt6/mod.rs
+++ b/algebra-core/src/curves/models/mnt6/mod.rs
@@ -172,7 +172,7 @@ impl<P: MNT6Parameters> MNT6<P> {
 
         // elt_q3 = elt^(q^3)
         let mut elt_q3 = elt.clone();
-        elt_q3.frobenius_map(3);
+        elt_q3.conjugate();
         // elt_q3_over_elt = elt^(q^3-1)
         let elt_q3_over_elt = elt_q3 * elt_inv;
         // alpha = elt^((q^3-1) * q)

--- a/algebra-core/src/fields/models/fp4.rs
+++ b/algebra-core/src/fields/models/fp4.rs
@@ -63,6 +63,10 @@ impl<P: Fp4Parameters> Fp4<P> {
         }
     }
 
+    pub fn conjugate(&mut self) {
+        self.c1 = self.c1.neg();
+    }
+
     pub fn unitary_inverse(&self) -> Self {
         Self::new(self.c0, -self.c1)
     }


### PR DESCRIPTION
 This PR replaces `k/2`-th Frobenius powers by conjugations in the final exponentiation of the pairing implementation for the curves BN, BLS12, BW6, MNT6, MNT4.
*Type: Enhancement
Label: Ready to review
Priority: Medium*

## Motivation
In Tate-based pairings, the target group `GT` is the `r`-th root of unity in `Fq^k` where `q` is the finite field prime, `r` the curve subgroup order and `k` the embedding degree. The pairing requires also a final exponentiation to `(q^k-1)/r` to reduce the output to a unique value. Using k-th cyclotomic polynomial, the exponent can be simplified into an easy part `(q^k-1)/phi_k(q)` and a hard part `phi_k(q)/r`. The easy part can be computed cheaply using Frobenius powers. However, if there is a power to `k/2` it should be replaced by a simple conjugation. An element `f` in `Fq^k` satisfies `f^(q^k-1)=1` which means `f^(q^(k/2)+1)=1` (otherwise the order isn't `q^k-1`). So an inverse is a power to `q^(k/2)` but since there is a `q^(k/2)-1` component in that exponent, the element `f` becomes unitary (i.e. norm 1) and the inversion becomes a simple conjugation. 

## Description
This PR replaces `frobenius_map(6)` by `conjugate()` in BN and BLS12 pairing implementation `frobenius_map(3)` by `conjugate()` in MNT6 and BW6 and `frobenius_map(2)` by `conjugate()` in MNT4.