### PR TITLE
Implementing deserialization for Proof, VerifyingKey, Parameters in GM17

### DIFF
--- a/gm17/Cargo.toml
+++ b/gm17/Cargo.toml
@@ -22,6 +22,8 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
+byteorder = "1"
+num-traits = { version = "0.2", default-features = false }
 algebra-core = { path = "../algebra-core", default-features = false, features = [ "derive" ] }
 bench-utils = { path = "../bench-utils" }
 ff-fft = { path = "../ff-fft", default-features = false }

--- a/gm17/Cargo.toml
+++ b/gm17/Cargo.toml
@@ -22,8 +22,6 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-byteorder = "1"
-num-traits = { version = "0.2", default-features = false }
 algebra-core = { path = "../algebra-core", default-features = false, features = [ "derive" ] }
 bench-utils = { path = "../bench-utils" }
 ff-fft = { path = "../ff-fft", default-features = false }

--- a/gm17/src/lib.rs
+++ b/gm17/src/lib.rs
@@ -81,20 +81,20 @@ impl<E: PairingEngine> Default for Proof<E> {
     }
 }
 
-impl<E: PairingEngine> Proof<E> {
-    /// Serialize the proof into bytes, for storage on disk or transmission
-    /// over the network.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the proof from bytes.
-    pub fn read<R: Read>(mut _reader: R) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-}
+// impl<E: PairingEngine> Proof<E> {
+//     /// Serialize the proof into bytes, for storage on disk or transmission
+//     /// over the network.
+//     pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
+//         // TODO: implement serialization
+//         unimplemented!()
+//     }
+//
+//     /// Deserialize the proof from bytes.
+//     pub fn read<R: Read>(mut _reader: R) -> io::Result<Self> {
+//         // TODO: implement serialization
+//         unimplemented!()
+//     }
+// }
 
 /// A verification key in the GM17 SNARK.
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
@@ -145,20 +145,20 @@ impl<E: PairingEngine> PartialEq for VerifyingKey<E> {
     }
 }
 
-impl<E: PairingEngine> VerifyingKey<E> {
-    /// Serialize the verification key into bytes, for storage on disk
-    /// or transmission over the network.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the verification key from bytes.
-    pub fn read<R: Read>(mut _reader: R) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-}
+// impl<E: PairingEngine> VerifyingKey<E> {
+//     /// Serialize the verification key into bytes, for storage on disk
+//     /// or transmission over the network.
+//     pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
+//         // TODO: implement serialization
+//         unimplemented!()
+//     }
+//
+//     /// Deserialize the verification key from bytes.
+//     pub fn read<R: Read>(mut _reader: R) -> io::Result<Self> {
+//         // TODO: implement serialization
+//         unimplemented!()
+//     }
+// }
 
 /// Full public (prover and verifier) parameters for the GM17 zkSNARK.
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
@@ -173,6 +173,32 @@ pub struct Parameters<E: PairingEngine> {
     pub g_ab_gamma_z: E::G1Affine,
     pub g_gamma2_z2: E::G1Affine,
     pub g_gamma2_z_t: Vec<E::G1Affine>,
+}
+
+impl<E: PairingEngine> ToBytes for Parameters<E> {
+    fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.vk.write(&mut writer)?;
+        for a_q in &self.a_query {
+            a_q.write(&mut writer)?;
+        }
+        for b_q in &self.b_query {
+            b_q.write(&mut writer)?;
+        }
+        for c_q1 in &self.c_query_1 {
+            c_q1.write(&mut writer)?;
+        }
+        for c_q2 in &self.c_query_2 {
+            c_q2.write(&mut writer)?;
+        }
+        self.g_gamma_z.write(&mut writer)?;
+        self.h_gamma_z.write(&mut writer)?;
+        self.g_ab_gamma_z.write(&mut writer)?;
+        self.g_gamma2_z2.write(&mut writer)?;
+        for g in &self.g_gamma2_z_t {
+            g.write(&mut writer)?;
+        }
+        Ok(())
+    }
 }
 
 impl<E: PairingEngine> PartialEq for Parameters<E> {
@@ -190,19 +216,19 @@ impl<E: PairingEngine> PartialEq for Parameters<E> {
     }
 }
 
-impl<E: PairingEngine> Parameters<E> {
-    /// Serialize the parameters to bytes.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the public parameters from bytes.
-    pub fn read<R: Read>(mut _reader: R, _checked: bool) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-}
+// impl<E: PairingEngine> Parameters<E> {
+//     /// Serialize the parameters to bytes.
+//     pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
+//         // TODO: implement serialization
+//         unimplemented!()
+//     }
+//
+//     /// Deserialize the public parameters from bytes.
+//     pub fn read<R: Read>(mut _reader: R, _checked: bool) -> io::Result<Self>
+// {         // TODO: implement serialization
+//         unimplemented!()
+//     }
+// }
 
 /// Preprocessed verification key parameters that enable faster verification
 /// at the expense of larger size in memory.

--- a/gm17/src/test.rs
+++ b/gm17/src/test.rs
@@ -24,6 +24,16 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<C
             },
         )?;
 
+        // let mut i = 0;
+
+        // while i < 100001 {
+        //     cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
+        //     i = i + 1;
+        // }
+
+        cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
+        cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
+        cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
         cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
 
         Ok(())
@@ -34,10 +44,13 @@ mod bls12_377 {
     use super::*;
     use crate::{
         create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
+        Parameters,
     };
-    use algebra_core::{test_rng, UniformRand};
-
     use algebra::bls12_377::{Bls12_377, Fr};
+    use algebra_core::{
+        bytes::{FromBytes, ToBytes},
+        test_rng, UniformRand,
+    };
     use core::ops::MulAssign;
 
     #[test]
@@ -47,6 +60,25 @@ mod bls12_377 {
         let params =
             generate_random_parameters::<Bls12_377, _, _>(MySillyCircuit { a: None, b: None }, rng)
                 .unwrap();
+
+        // bytes::ToBytes,
+
+        let mut pk: Vec<u8> = Vec::new();
+        params.write(&mut pk).unwrap();
+        println!("Here {:?}", pk);
+        // println!("Here {:?}", &params);
+        // let mut pk: Vec<u8> = Vec::new();
+        // params.serialize_uncompressed(&mut pk).unwrap();
+        // println!("Here {:?}", pk);
+
+        // let mut pk: Vec<u8> = Vec::new();
+        // let b = Parameters::<Bls12_377>::deserialize_uncompressed(&mut
+        // pk.as_slice()).unwrap(); println!("Here {:?}", b);
+        let mut reader = pk.as_slice();
+        let b = Parameters::<Bls12_377>::read(&mut reader).unwrap();
+        assert!(reader.is_empty());
+        assert_eq!(b, params);
+        println!("Here {:?}", b);
 
         let pvk = prepare_verifying_key::<Bls12_377>(&params.vk);
 

--- a/gm17/src/test.rs
+++ b/gm17/src/test.rs
@@ -24,16 +24,6 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<C
             },
         )?;
 
-        // let mut i = 0;
-
-        // while i < 100001 {
-        //     cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
-        //     i = i + 1;
-        // }
-
-        cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
-        cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
-        cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
         cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
 
         Ok(())
@@ -44,13 +34,9 @@ mod bls12_377 {
     use super::*;
     use crate::{
         create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
-        Parameters,
     };
     use algebra::bls12_377::{Bls12_377, Fr};
-    use algebra_core::{
-        bytes::{FromBytes, ToBytes},
-        test_rng, UniformRand,
-    };
+    use algebra_core::{test_rng, UniformRand};
     use core::ops::MulAssign;
 
     #[test]
@@ -60,25 +46,6 @@ mod bls12_377 {
         let params =
             generate_random_parameters::<Bls12_377, _, _>(MySillyCircuit { a: None, b: None }, rng)
                 .unwrap();
-
-        // bytes::ToBytes,
-
-        let mut pk: Vec<u8> = Vec::new();
-        params.write(&mut pk).unwrap();
-        println!("Here {:?}", pk);
-        // println!("Here {:?}", &params);
-        // let mut pk: Vec<u8> = Vec::new();
-        // params.serialize_uncompressed(&mut pk).unwrap();
-        // println!("Here {:?}", pk);
-
-        // let mut pk: Vec<u8> = Vec::new();
-        // let b = Parameters::<Bls12_377>::deserialize_uncompressed(&mut
-        // pk.as_slice()).unwrap(); println!("Here {:?}", b);
-        let mut reader = pk.as_slice();
-        let b = Parameters::<Bls12_377>::read(&mut reader).unwrap();
-        assert!(reader.is_empty());
-        assert_eq!(b, params);
-        println!("Here {:?}", b);
 
         let pvk = prepare_verifying_key::<Bls12_377>(&params.vk);
 


### PR DESCRIPTION
Implemented `fn read<R: Read>(mut _reader: R, _checked: bool) -> io::Result<Self>` for Proof, VerifyingKey, Parameters in GM17. Currently they are unimplemented as shown below.

https://github.com/scipr-lab/zexe/blob/9b04691267687bc93beb96a1170d414e3b9182ef/gm17/src/lib.rs#L93
https://github.com/scipr-lab/zexe/blob/9b04691267687bc93beb96a1170d414e3b9182ef/gm17/src/lib.rs#L157
https://github.com/scipr-lab/zexe/blob/9b04691267687bc93beb96a1170d414e3b9182ef/gm17/src/lib.rs#L201

PRing this code on behalf EY.

fixes #224 