### PR TITLE
fix log2 function

### DIFF
--- a/algebra-core/src/lib.rs
+++ b/algebra-core/src/lib.rs
@@ -128,5 +128,11 @@ pub fn log2(x: usize) -> u32 {
     }
 
     let n = x.leading_zeros();
-    core::mem::size_of::<usize>() as u32 * 8 - n
+    let r = core::mem::size_of::<usize>() as u32 * 8 - n;
+    if 1usize << (r - 1) == x
+    {
+        r - 1
+    } else {
+        r
+    }
 }


### PR DESCRIPTION
Seems that there is a little bug in *log2(x: usize)* function in the algebra-core lib. When *x* is 2^i, the function returns i+1.