### PR TITLE
Implement `ToConstraintField` for `AffineCurve`

### DIFF
--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -2,7 +2,8 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::{Field, PrimeField, SquareRootField},
     groups::Group,
-    CanonicalDeserialize, CanonicalSerialize, ConstantSerializedSize, UniformRand, Vec,
+    CanonicalDeserialize, CanonicalSerialize, ConstantSerializedSize, ToConstraintField,
+    UniformRand, Vec,
 };
 use core::{
     fmt::{Debug, Display},
@@ -221,6 +222,7 @@ pub trait AffineCurve:
     + Display
     + Zero
     + Neg<Output = Self>
+    + ToConstraintField<<<Self as AffineCurve>::BaseField as Field>::BaseRepresentationField>
     + From<<Self as AffineCurve>::Projective>
 {
     const COFACTOR: &'static [u64];

--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -18,7 +18,7 @@ pub use self::models::*;
 
 pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     /// This is the scalar field of the G1/G2 groups.
-    type Fr: PrimeField + SquareRootField;
+    type Fr: PrimeField + SquareRootField + ToConstraintField<Self::Fr>;
 
     /// The projective representation of an element in G1.
     type G1Projective: ProjectiveCurve<BaseField = Self::Fq, ScalarField = Self::Fr, Affine = Self::G1Affine>
@@ -28,6 +28,7 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
 
     /// The affine representation of an element in G1.
     type G1Affine: AffineCurve<BaseField = Self::Fq, ScalarField = Self::Fr, Projective = Self::G1Projective>
+        + ToConstraintField<<Self::Fq as Field>::BaseRepresentationField>
         + From<Self::G1Projective>
         + Into<Self::G1Projective>
         + Into<Self::G1Prepared>;
@@ -43,6 +44,7 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
 
     /// The affine representation of an element in G2.
     type G2Affine: AffineCurve<BaseField = Self::Fqe, ScalarField = Self::Fr, Projective = Self::G2Projective>
+        + ToConstraintField<<Self::Fqe as Field>::BaseRepresentationField>
         + From<Self::G2Projective>
         + Into<Self::G2Projective>
         + Into<Self::G2Prepared>;
@@ -51,7 +53,7 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     type G2Prepared: ToBytes + Default + Clone + Send + Sync + Debug + From<Self::G2Affine>;
 
     /// The base field that hosts G1.
-    type Fq: PrimeField + SquareRootField;
+    type Fq: PrimeField + SquareRootField + ToConstraintField<Self::Fq>;
 
     /// The extension field that hosts G2.
     type Fqe: SquareRootField;
@@ -127,6 +129,7 @@ pub trait ProjectiveCurve:
     type ScalarField: PrimeField + SquareRootField;
     type BaseField: Field;
     type Affine: AffineCurve<Projective = Self, ScalarField = Self::ScalarField, BaseField = Self::BaseField>
+        + ToConstraintField<<Self::BaseField as Field>::BaseRepresentationField>
         + From<Self>
         + Into<Self>;
 
@@ -303,6 +306,10 @@ pub trait CycleEngine: Sized + 'static + Copy + Debug + Sync + Send
 where
     <Self::E2 as PairingEngine>::G1Projective: MulAssign<<Self::E1 as PairingEngine>::Fq>,
     <Self::E2 as PairingEngine>::G2Projective: MulAssign<<Self::E1 as PairingEngine>::Fq>,
+    <Self::E2 as PairingEngine>::G1Affine:
+        ToConstraintField<<<Self::E1 as PairingEngine>::Fr as Field>::BaseRepresentationField>,
+    <Self::E2 as PairingEngine>::G2Affine:
+        ToConstraintField<<<Self::E1 as PairingEngine>::Fr as Field>::BaseRepresentationField>,
 {
     type E1: PairingEngine;
     type E2: PairingEngine<

--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -45,6 +45,7 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     /// The affine representation of an element in G2.
     type G2Affine: AffineCurve<BaseField = Self::Fqe, ScalarField = Self::Fr, Projective = Self::G2Projective>
         + ToConstraintField<<Self::Fqe as Field>::BaseRepresentationField>
+        + ToConstraintField<<Self::Fq as Field>::BaseRepresentationField>
         + From<Self::G2Projective>
         + Into<Self::G2Projective>
         + Into<Self::G2Prepared>;

--- a/algebra-core/src/curves/models/bls12/mod.rs
+++ b/algebra-core/src/curves/models/bls12/mod.rs
@@ -9,6 +9,7 @@ use crate::{
         fp6_3over2::Fp6Parameters,
         BitIterator, Field, Fp2, PrimeField, SquareRootField,
     },
+    ToConstraintField,
 };
 use num_traits::One;
 
@@ -23,7 +24,10 @@ pub trait Bls12Parameters: 'static {
     const X: &'static [u64];
     const X_IS_NEGATIVE: bool;
     const TWIST_TYPE: TwistType;
-    type Fp: PrimeField + SquareRootField + Into<<Self::Fp as PrimeField>::BigInt>;
+    type Fp: PrimeField
+        + SquareRootField
+        + ToConstraintField<Self::Fp>
+        + Into<<Self::Fp as PrimeField>::BigInt>;
     type Fp2Params: Fp2Parameters<Fp = Self::Fp>;
     type Fp6Params: Fp6Parameters<Fp2Params = Self::Fp2Params>;
     type Fp12Params: Fp12Parameters<Fp6Params = Self::Fp6Params>;

--- a/algebra-core/src/curves/models/bn/mod.rs
+++ b/algebra-core/src/curves/models/bn/mod.rs
@@ -9,6 +9,7 @@ use crate::{
         fp6_3over2::Fp6Parameters,
         Field, Fp2, PrimeField, SquareRootField,
     },
+    ToConstraintField,
 };
 use num_traits::One;
 
@@ -27,7 +28,10 @@ pub trait BnParameters: 'static {
     const TWIST_TYPE: TwistType;
     const TWIST_MUL_BY_Q_X: Fp2<Self::Fp2Params>;
     const TWIST_MUL_BY_Q_Y: Fp2<Self::Fp2Params>;
-    type Fp: PrimeField + SquareRootField + Into<<Self::Fp as PrimeField>::BigInt>;
+    type Fp: PrimeField
+        + SquareRootField
+        + ToConstraintField<Self::Fp>
+        + Into<<Self::Fp as PrimeField>::BigInt>;
     type Fp2Params: Fp2Parameters<Fp = Self::Fp>;
     type Fp6Params: Fp6Parameters<Fp2Params = Self::Fp2Params>;
     type Fp12Params: Fp12Parameters<Fp6Params = Self::Fp6Params>;

--- a/algebra-core/src/curves/models/bw6/mod.rs
+++ b/algebra-core/src/curves/models/bw6/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         fp6_2over3::{Fp6, Fp6Parameters},
         BitIterator, Field, PrimeField, SquareRootField,
     },
+    ToConstraintField,
 };
 use num_traits::One;
 
@@ -26,7 +27,10 @@ pub trait BW6Parameters: 'static {
     const ATE_LOOP_COUNT_2: &'static [i8];
     const ATE_LOOP_COUNT_2_IS_NEGATIVE: bool;
     const TWIST_TYPE: TwistType;
-    type Fp: PrimeField + SquareRootField + Into<<Self::Fp as PrimeField>::BigInt>;
+    type Fp: PrimeField
+        + SquareRootField
+        + ToConstraintField<Self::Fp>
+        + Into<<Self::Fp as PrimeField>::BigInt>;
     type Fp3Params: Fp3Parameters<Fp = Self::Fp>;
     type Fp6Params: Fp6Parameters<Fp3Params = Self::Fp3Params>;
     type G1Parameters: SWModelParameters<BaseField = Self::Fp>;

--- a/algebra-core/src/curves/models/mnt4/mod.rs
+++ b/algebra-core/src/curves/models/mnt4/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         fp4::{Fp4, Fp4Parameters},
         BitIterator, Field, PrimeField, SquareRootField,
     },
-    One, Zero,
+    One, ToConstraintField, Zero,
 };
 
 use core::marker::PhantomData;
@@ -32,7 +32,10 @@ pub trait MNT4Parameters: 'static {
     const FINAL_EXPONENT_LAST_CHUNK_1: <Self::Fp as PrimeField>::BigInt;
     const FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG: bool;
     const FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0: <Self::Fp as PrimeField>::BigInt;
-    type Fp: PrimeField + SquareRootField + Into<<Self::Fp as PrimeField>::BigInt>;
+    type Fp: PrimeField
+        + SquareRootField
+        + ToConstraintField<Self::Fp>
+        + Into<<Self::Fp as PrimeField>::BigInt>;
     type Fp2Params: Fp2Parameters<Fp = Self::Fp>;
     type Fp4Params: Fp4Parameters<Fp2Params = Self::Fp2Params>;
     type G1Parameters: SWModelParameters<BaseField = Self::Fp>;

--- a/algebra-core/src/curves/models/mnt6/mod.rs
+++ b/algebra-core/src/curves/models/mnt6/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         fp6_2over3::{Fp6, Fp6Parameters},
         BitIterator, Field, PrimeField, SquareRootField,
     },
-    One, Zero,
+    One, ToConstraintField, Zero,
 };
 
 use core::marker::PhantomData;
@@ -32,7 +32,10 @@ pub trait MNT6Parameters: 'static {
     const FINAL_EXPONENT_LAST_CHUNK_1: <Self::Fp as PrimeField>::BigInt;
     const FINAL_EXPONENT_LAST_CHUNK_W0_IS_NEG: bool;
     const FINAL_EXPONENT_LAST_CHUNK_ABS_OF_W0: <Self::Fp as PrimeField>::BigInt;
-    type Fp: PrimeField + SquareRootField + Into<<Self::Fp as PrimeField>::BigInt>;
+    type Fp: PrimeField
+        + SquareRootField
+        + ToConstraintField<Self::Fp>
+        + Into<<Self::Fp as PrimeField>::BigInt>;
     type Fp3Params: Fp3Parameters<Fp = Self::Fp>;
     type Fp6Params: Fp6Parameters<Fp3Params = Self::Fp3Params>;
     type G1Parameters: SWModelParameters<BaseField = Self::Fp>;

--- a/algebra-core/src/curves/models/mod.rs
+++ b/algebra-core/src/curves/models/mod.rs
@@ -1,4 +1,5 @@
 use crate::fields::{Field, PrimeField, SquareRootField};
+use crate::ToConstraintField;
 
 pub mod bls12;
 pub mod bn;
@@ -11,7 +12,10 @@ pub mod twisted_edwards_extended;
 
 pub trait ModelParameters: Send + Sync + 'static {
     type BaseField: Field + SquareRootField;
-    type ScalarField: PrimeField + SquareRootField + Into<<Self::ScalarField as PrimeField>::BigInt>;
+    type ScalarField: PrimeField
+        + SquareRootField
+        + ToConstraintField<Self::ScalarField>
+        + Into<<Self::ScalarField as PrimeField>::BigInt>;
 }
 
 pub trait SWModelParameters: ModelParameters {

--- a/algebra-core/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra-core/src/curves/models/short_weierstrass_projective.rs
@@ -2,7 +2,7 @@ use crate::{
     curves::models::SWModelParameters as Parameters,
     io::{Read, Result as IoResult, Write},
     serialize::{Flags, SWFlags},
-    CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
+    Box, CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, ConstantSerializedSize, ToConstraintField, UniformRand, Vec,
 };
 use core::{

--- a/algebra-core/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra-core/src/curves/models/short_weierstrass_projective.rs
@@ -3,7 +3,7 @@ use crate::{
     io::{Read, Result as IoResult, Write},
     serialize::{Flags, SWFlags},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, ConstantSerializedSize, UniformRand, Vec,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, ToConstraintField, UniformRand, Vec,
 };
 use core::{
     fmt::{Display, Formatter, Result as FmtResult},
@@ -582,6 +582,27 @@ impl<P: Parameters> From<GroupProjective<P>> for GroupAffine<P> {
             let y = p.y * &z_inv;
             GroupAffine::new(x, y, false)
         }
+    }
+}
+
+impl<P: Parameters> ToConstraintField<<P::BaseField as Field>::BaseRepresentationField>
+    for GroupAffine<P>
+{
+    fn to_field_elements(
+        &self,
+    ) -> Result<Vec<<P::BaseField as Field>::BaseRepresentationField>, Box<dyn crate::Error>> {
+        let mut res = Vec::new();
+
+        let mut x_elems = self.x.to_field_elements()?;
+        let mut y_elems = self.y.to_field_elements()?;
+
+        let mut infinity_elems = self.infinity.to_field_elements()?;
+
+        res.append(&mut x_elems);
+        res.append(&mut y_elems);
+        res.append(&mut infinity_elems);
+
+        Ok(res)
     }
 }
 

--- a/algebra-core/src/fields/macros.rs
+++ b/algebra-core/src/fields/macros.rs
@@ -64,7 +64,15 @@ macro_rules! impl_Fp {
             }
         }
 
+        impl<P: $FpParameters> ToConstraintField<<Self as Field>::BaseRepresentationField> for $Fp<P> {
+            fn to_field_elements(&self) -> Result<Vec<<Self as Field>::BaseRepresentationField>, Box<dyn crate::Error>> {
+               Ok(vec![self.clone()])
+            }
+        }
+
         impl<P: $FpParameters> Field for $Fp<P> {
+            type BaseRepresentationField = Self;
+
             #[inline]
             fn double(&self) -> Self {
                 let mut temp = *self;

--- a/algebra-core/src/fields/mod.rs
+++ b/algebra-core/src/fields/mod.rs
@@ -83,6 +83,11 @@ pub trait Field:
     + SubAssign<Self>
     + MulAssign<Self>
     + DivAssign<Self>
+    + From<u128>
+    + From<u64>
+    + From<u32>
+    + From<u16>
+    + From<u8>
     + for<'a> Add<&'a Self, Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> Mul<&'a Self, Output = Self>
@@ -233,7 +238,7 @@ pub trait FpParameters: FftParameters {
 }
 
 /// The interface for fields that are able to be used in FFTs.
-pub trait FftField: Field + From<u128> + From<u64> + From<u32> + From<u16> + From<u8> {
+pub trait FftField: Field {
     type FftParams: FftParameters;
 
     /// Returns the 2^s root of unity.

--- a/algebra-core/src/fields/mod.rs
+++ b/algebra-core/src/fields/mod.rs
@@ -314,6 +314,7 @@ pub trait PrimeField:
     + FromStr
     + From<<Self as PrimeField>::BigInt>
     + Into<<Self as PrimeField>::BigInt>
+    + ToConstraintField<Self>
 {
     type Params: FpParameters<BigInt = Self::BigInt>;
     type BigInt: BigInteger;

--- a/algebra-core/src/fields/mod.rs
+++ b/algebra-core/src/fields/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     bytes::{FromBytes, ToBytes},
     fields::utils::k_adicity,
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
-    CanonicalSerializeWithFlags, ConstantSerializedSize, UniformRand, Vec,
+    CanonicalSerializeWithFlags, ConstantSerializedSize, ToConstraintField, UniformRand, Vec,
 };
 use core::{
     fmt::{Debug, Display},
@@ -74,6 +74,7 @@ pub trait Field:
     + CanonicalSerializeWithFlags
     + CanonicalDeserialize
     + CanonicalDeserializeWithFlags
+    + ToConstraintField<<Self as Field>::BaseRepresentationField>
     + Add<Self, Output = Self>
     + Sub<Self, Output = Self>
     + Mul<Self, Output = Self>
@@ -95,6 +96,8 @@ pub trait Field:
     + core::iter::Product<Self>
     + for<'a> core::iter::Product<&'a Self>
 {
+    type BaseRepresentationField: Field;
+
     /// Returns the characteristic of the field.
     fn characteristic<'a>() -> &'a [u64];
 

--- a/algebra-core/src/fields/models/cubic_extension.rs
+++ b/algebra-core/src/fields/models/cubic_extension.rs
@@ -1,7 +1,7 @@
 use crate::{
-    CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
+    Box, CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
-    ToConstraintField, UniformRand,
+    ToConstraintField, UniformRand, Vec,
 };
 use core::{
     cmp::{Ord, Ordering, PartialOrd},

--- a/algebra-core/src/fields/models/cubic_extension.rs
+++ b/algebra-core/src/fields/models/cubic_extension.rs
@@ -1,7 +1,7 @@
 use crate::{
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
-    UniformRand,
+    ToConstraintField, UniformRand,
 };
 use core::{
     cmp::{Ord, Ordering, PartialOrd},
@@ -133,7 +133,29 @@ impl<P: CubicExtParameters> One for CubicExtField<P> {
     }
 }
 
+impl<P: CubicExtParameters> ToConstraintField<<Self as Field>::BaseRepresentationField>
+    for CubicExtField<P>
+{
+    fn to_field_elements(
+        &self,
+    ) -> Result<Vec<<Self as Field>::BaseRepresentationField>, Box<dyn crate::Error>> {
+        let mut res = Vec::new();
+        let mut c0_elems = self.c0.to_field_elements()?;
+        let mut c1_elems = self.c1.to_field_elements()?;
+        let mut c2_elems = self.c2.to_field_elements()?;
+
+        res.append(&mut c0_elems);
+        res.append(&mut c1_elems);
+        res.append(&mut c2_elems);
+
+        Ok(res)
+    }
+}
+
 impl<P: CubicExtParameters> Field for CubicExtField<P> {
+    type BaseRepresentationField =
+        <<P as CubicExtParameters>::BaseField as Field>::BaseRepresentationField;
+
     #[inline]
     fn characteristic<'a>() -> &'a [u64] {
         P::BaseField::characteristic()

--- a/algebra-core/src/fields/models/mod.rs
+++ b/algebra-core/src/fields/models/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     io::{Read, Result as IoResult, Write},
     serialize::CanonicalDeserialize,
     to_field_vec::ToConstraintField,
+    Box, Vec,
 };
 
 #[cfg(use_asm)]

--- a/algebra-core/src/fields/models/mod.rs
+++ b/algebra-core/src/fields/models/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     fields::{FftField, Field, FpParameters, LegendreSymbol, PrimeField, SquareRootField},
     io::{Read, Result as IoResult, Write},
     serialize::CanonicalDeserialize,
+    to_field_vec::ToConstraintField,
 };
 
 #[cfg(use_asm)]

--- a/algebra-core/src/fields/models/quadratic_extension.rs
+++ b/algebra-core/src/fields/models/quadratic_extension.rs
@@ -1,8 +1,8 @@
 use crate::{
     io::{Read, Result as IoResult, Write},
-    CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
+    Box, CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
-    ToConstraintField, UniformRand,
+    ToConstraintField, UniformRand, Vec,
 };
 use core::{
     cmp::{Ord, Ordering, PartialOrd},

--- a/algebra-core/src/fields/models/quadratic_extension.rs
+++ b/algebra-core/src/fields/models/quadratic_extension.rs
@@ -2,7 +2,7 @@ use crate::{
     io::{Read, Result as IoResult, Write},
     CanonicalDeserialize, CanonicalDeserializeWithFlags, CanonicalSerialize,
     CanonicalSerializeWithFlags, ConstantSerializedSize, EmptyFlags, Flags, SerializationError,
-    UniformRand,
+    ToConstraintField, UniformRand,
 };
 use core::{
     cmp::{Ord, Ordering, PartialOrd},
@@ -152,7 +152,27 @@ impl<P: QuadExtParameters> One for QuadExtField<P> {
     }
 }
 
+impl<P: QuadExtParameters> ToConstraintField<<Self as Field>::BaseRepresentationField>
+    for QuadExtField<P>
+{
+    fn to_field_elements(
+        &self,
+    ) -> Result<Vec<<Self as Field>::BaseRepresentationField>, Box<dyn crate::Error>> {
+        let mut res = Vec::new();
+        let mut c0_elems = self.c0.to_field_elements()?;
+        let mut c1_elems = self.c1.to_field_elements()?;
+
+        res.append(&mut c0_elems);
+        res.append(&mut c1_elems);
+
+        Ok(res)
+    }
+}
+
 impl<P: QuadExtParameters> Field for QuadExtField<P> {
+    type BaseRepresentationField =
+        <<P as QuadExtParameters>::BaseField as Field>::BaseRepresentationField;
+
     #[inline]
     fn characteristic<'a>() -> &'a [u64] {
         P::BaseField::characteristic()

--- a/algebra-core/src/to_field_vec.rs
+++ b/algebra-core/src/to_field_vec.rs
@@ -18,13 +18,6 @@ pub trait ToConstraintField<F: Field> {
 }
 
 // Impl for base field
-impl<F: Field> ToConstraintField<F> for [F] {
-    #[inline]
-    fn to_field_elements(&self) -> Result<Vec<F>, Error> {
-        Ok(self.to_vec())
-    }
-}
-
 impl<ConstraintF: Field> ToConstraintField<ConstraintF> for () {
     #[inline]
     fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
@@ -146,29 +139,5 @@ impl<ConstraintF: PrimeField> ToConstraintField<ConstraintF> for Vec<u8> {
             .map_err(crate::SerializationError::from)
             .map_err(|e| Box::new(e))?;
         Ok(fes)
-    }
-}
-
-impl<ConstraintField: PrimeField, T: ToConstraintField<ConstraintField>>
-    ToConstraintField<ConstraintField> for &[T]
-{
-    fn to_field_elements(&self) -> Result<Vec<ConstraintField>, Error> {
-        let mut res = Vec::new();
-        for elem in self.iter() {
-            res.append(&mut elem.to_field_elements()?);
-        }
-        Ok(res)
-    }
-}
-
-impl<ConstraintField: PrimeField, T: ToConstraintField<ConstraintField>>
-    ToConstraintField<ConstraintField> for &Vec<T>
-{
-    fn to_field_elements(&self) -> Result<Vec<ConstraintField>, Error> {
-        let mut res = Vec::new();
-        for elem in self.iter() {
-            res.append(&mut elem.to_field_elements()?);
-        }
-        Ok(res)
     }
 }

--- a/algebra-core/src/to_field_vec.rs
+++ b/algebra-core/src/to_field_vec.rs
@@ -148,3 +148,15 @@ impl<ConstraintF: PrimeField> ToConstraintField<ConstraintF> for Vec<u8> {
         Ok(fes)
     }
 }
+
+impl<ConstraintField: PrimeField, T: ToConstraintField<ConstraintField>>
+    ToConstraintField<ConstraintField> for &[T]
+{
+    fn to_field_elements(&self) -> Result<Vec<ConstraintField>, Error> {
+        let mut res = Vec::new();
+        for elem in self.iter() {
+            res.append(&mut elem.to_field_elements()?);
+        }
+        Ok(res)
+    }
+}

--- a/algebra-core/src/to_field_vec.rs
+++ b/algebra-core/src/to_field_vec.rs
@@ -160,3 +160,15 @@ impl<ConstraintField: PrimeField, T: ToConstraintField<ConstraintField>>
         Ok(res)
     }
 }
+
+impl<ConstraintField: PrimeField, T: ToConstraintField<ConstraintField>>
+    ToConstraintField<ConstraintField> for &Vec<T>
+{
+    fn to_field_elements(&self) -> Result<Vec<ConstraintField>, Error> {
+        let mut res = Vec::new();
+        for elem in self.iter() {
+            res.append(&mut elem.to_field_elements()?);
+        }
+        Ok(res)
+    }
+}

--- a/algebra-core/src/to_field_vec.rs
+++ b/algebra-core/src/to_field_vec.rs
@@ -18,6 +18,13 @@ pub trait ToConstraintField<F: Field> {
 }
 
 // Impl for base field
+impl<F: Field> ToConstraintField<F> for [F] {
+    #[inline]
+    fn to_field_elements(&self) -> Result<Vec<F>, Error> {
+        Ok(self.to_vec())
+    }
+}
+
 impl<ConstraintF: Field> ToConstraintField<ConstraintF> for () {
     #[inline]
     fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {

--- a/algebra-core/src/to_field_vec.rs
+++ b/algebra-core/src/to_field_vec.rs
@@ -44,12 +44,13 @@ impl<F: Field> ToConstraintField<F> for bool {
     }
 }
 
-impl<M: TEModelParameters, ConstraintF: Field> ToConstraintField<ConstraintF> for TEAffine<M>
-where
-    M::BaseField: ToConstraintField<ConstraintF>,
+impl<M: TEModelParameters> ToConstraintField<<M::BaseField as Field>::BaseRepresentationField>
+    for TEAffine<M>
 {
     #[inline]
-    fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
+    fn to_field_elements(
+        &self,
+    ) -> Result<Vec<<M::BaseField as Field>::BaseRepresentationField>, Error> {
         let mut x_fe = self.x.to_field_elements()?;
         let y_fe = self.y.to_field_elements()?;
         x_fe.extend_from_slice(&y_fe);
@@ -57,22 +58,24 @@ where
     }
 }
 
-impl<M: TEModelParameters, ConstraintF: Field> ToConstraintField<ConstraintF> for TEProjective<M>
-where
-    M::BaseField: ToConstraintField<ConstraintF>,
+impl<M: TEModelParameters> ToConstraintField<<M::BaseField as Field>::BaseRepresentationField>
+    for TEProjective<M>
 {
     #[inline]
-    fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
+    fn to_field_elements(
+        &self,
+    ) -> Result<Vec<<M::BaseField as Field>::BaseRepresentationField>, Error> {
         TEAffine::from(*self).to_field_elements()
     }
 }
 
-impl<M: SWModelParameters, ConstraintF: Field> ToConstraintField<ConstraintF> for SWAffine<M>
-where
-    M::BaseField: ToConstraintField<ConstraintF>,
+impl<M: SWModelParameters> ToConstraintField<<M::BaseField as Field>::BaseRepresentationField>
+    for SWAffine<M>
 {
     #[inline]
-    fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
+    fn to_field_elements(
+        &self,
+    ) -> Result<Vec<<M::BaseField as Field>::BaseRepresentationField>, Error> {
         let mut x_fe = self.x.to_field_elements()?;
         let y_fe = self.y.to_field_elements()?;
         let infinity_fe = self.infinity.to_field_elements()?;
@@ -82,12 +85,13 @@ where
     }
 }
 
-impl<M: SWModelParameters, ConstraintF: Field> ToConstraintField<ConstraintF> for SWProjective<M>
-where
-    M::BaseField: ToConstraintField<ConstraintF>,
+impl<M: SWModelParameters> ToConstraintField<<M::BaseField as Field>::BaseRepresentationField>
+    for SWProjective<M>
 {
     #[inline]
-    fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
+    fn to_field_elements(
+        &self,
+    ) -> Result<Vec<<M::BaseField as Field>::BaseRepresentationField>, Error> {
         SWAffine::from(*self).to_field_elements()
     }
 }

--- a/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
@@ -328,13 +328,19 @@ where
             .sub(cs.ns(|| "lambda^2 - x"), &self.x)?
             .sub(cs.ns(|| "lambda^2 - 2x"), &self.x)?;
 
+        let allocated_x = F::alloc(cs.ns(|| "allocated_x"), || Ok(x.get_value().get()?))?;
+        allocated_x.enforce_equal(cs.ns(|| "allocated_x_is_x"), &x);
+
         let y = self
             .x
             .sub(cs.ns(|| "x - self.x"), &x)?
             .mul(cs.ns(|| "times lambda"), &lambda)?
             .sub(cs.ns(|| "plus self.y"), &self.y)?;
 
-        *self = Self::new(x, y, Boolean::Constant(false));
+        let allocated_y = F::alloc(cs.ns(|| "allocated_y"), || Ok(y.get_value().get()?))?;
+        allocated_y.enforce_equal(cs.ns(|| "allocated_y_is_y"), &y);
+
+        *self = Self::new(allocated_x, allocated_y, Boolean::Constant(false));
         Ok(())
     }
 


### PR DESCRIPTION
This PR implements `ToConstraintField` for `AffineCurve`, which is to facilitate implementations of recursive proofs. To do so, `ToConstraintField` is now implemented for all fields, in which a field can be represented by the field's `BaseRepresentationField`, defined as follows:

- Fp320, Fp384, ...  -> Themselves
- Cubic of field X     -> X's BaseRepresentationField
- Quad of field X      -> X's BaseRepresentationField

A few repetitions of requirements are used to make the Rust compiler happy.

This PR has been used (and tested) in the ongoing implementation of Marlin's constraints.

Looking for initial feedback. 