### PR TITLE
Add unchecked serialization/deserialization

### DIFF
--- a/algebra-benches/src/macros/ec.rs
+++ b/algebra-benches/src/macros/ec.rs
@@ -83,6 +83,98 @@ macro_rules! ec_bench {
         }
 
         #[bench]
+        fn bench_g1_deser(b: &mut ::test::Bencher) {
+            use algebra::{CanonicalDeserialize, CanonicalSerialize, ProjectiveCurve};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let mut num_bytes = 0;
+            let tmp = G1::rand(&mut rng).into_affine();
+            let v: Vec<_> = (0..SAMPLES)
+                .flat_map(|_| {
+                    let mut bytes = Vec::with_capacity(1000);
+                    tmp.serialize(&mut bytes).unwrap();
+                    num_bytes = bytes.len();
+                    bytes
+                })
+                .collect();
+
+            let mut count = 0;
+            b.iter(|| {
+                count = (count + 1) % SAMPLES;
+                let index = count * num_bytes;
+                G1Affine::deserialize(&mut &v[index..(index + num_bytes)]).unwrap()
+            });
+        }
+
+        #[bench]
+        fn bench_g1_ser(b: &mut ::test::Bencher) {
+            use algebra::{CanonicalSerialize, ProjectiveCurve};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let mut v: Vec<_> = (0..SAMPLES).map(|_| G1::rand(&mut rng)).collect();
+            let v = G1::batch_normalization_into_affine(v.as_mut_slice());
+            let mut bytes = Vec::with_capacity(1000);
+
+            let mut count = 0;
+            b.iter(|| {
+                let tmp = v[count];
+                count = (count + 1) % SAMPLES;
+                bytes.clear();
+                tmp.serialize(&mut &mut bytes)
+            });
+        }
+
+        #[bench]
+        fn bench_g1_deser_unchecked(b: &mut ::test::Bencher) {
+            use algebra::{CanonicalDeserialize, CanonicalSerialize, ProjectiveCurve};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let mut num_bytes = 0;
+            let tmp = G1::rand(&mut rng).into_affine();
+            let v: Vec<_> = (0..SAMPLES)
+                .flat_map(|_| {
+                    let mut bytes = Vec::with_capacity(1000);
+                    tmp.serialize_unchecked(&mut bytes).unwrap();
+                    num_bytes = bytes.len();
+                    bytes
+                })
+                .collect();
+
+            let mut count = 0;
+            b.iter(|| {
+                count = (count + 1) % SAMPLES;
+                let index = count * num_bytes;
+                G1Affine::deserialize_unchecked(&mut &v[index..(index + num_bytes)]).unwrap()
+            });
+        }
+
+        #[bench]
+        fn bench_g1_ser_unchecked(b: &mut ::test::Bencher) {
+            use algebra::{CanonicalSerialize, ProjectiveCurve};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let mut v: Vec<_> = (0..SAMPLES).map(|_| G1::rand(&mut rng)).collect();
+            let v = G1::batch_normalization_into_affine(v.as_mut_slice());
+            let mut bytes = Vec::with_capacity(1000);
+
+            let mut count = 0;
+            b.iter(|| {
+                let tmp = v[count];
+                count = (count + 1) % SAMPLES;
+                bytes.clear();
+                tmp.serialize_unchecked(&mut &mut bytes)
+            });
+        }
+
+        #[bench]
         fn bench_g2_rand(b: &mut ::test::Bencher) {
             let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
             b.iter(|| G2::rand(&mut rng));
@@ -161,6 +253,98 @@ macro_rules! ec_bench {
                 tmp.double_in_place();
                 count = (count + 1) % SAMPLES;
                 tmp
+            });
+        }
+
+        #[bench]
+        fn bench_g2_deser(b: &mut ::test::Bencher) {
+            use algebra::{CanonicalDeserialize, CanonicalSerialize, ProjectiveCurve};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let mut num_bytes = 0;
+            let tmp = G2::rand(&mut rng).into_affine();
+            let v: Vec<_> = (0..SAMPLES)
+                .flat_map(|_| {
+                    let mut bytes = Vec::with_capacity(1000);
+                    tmp.serialize(&mut bytes).unwrap();
+                    num_bytes = bytes.len();
+                    bytes
+                })
+                .collect();
+
+            let mut count = 0;
+            b.iter(|| {
+                count = (count + 1) % SAMPLES;
+                let index = count * num_bytes;
+                G2Affine::deserialize(&mut &v[index..(index + num_bytes)]).unwrap()
+            });
+        }
+
+        #[bench]
+        fn bench_g2_ser(b: &mut ::test::Bencher) {
+            use algebra::{CanonicalSerialize, ProjectiveCurve};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let mut v: Vec<_> = (0..SAMPLES).map(|_| G2::rand(&mut rng)).collect();
+            let v = G2::batch_normalization_into_affine(v.as_mut_slice());
+            let mut bytes = Vec::with_capacity(1000);
+
+            let mut count = 0;
+            b.iter(|| {
+                let tmp = v[count];
+                count = (count + 1) % SAMPLES;
+                bytes.clear();
+                tmp.serialize(&mut &mut bytes)
+            });
+        }
+
+        #[bench]
+        fn bench_g2_deser_unchecked(b: &mut ::test::Bencher) {
+            use algebra::{CanonicalDeserialize, CanonicalSerialize, ProjectiveCurve};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let mut num_bytes = 0;
+            let tmp = G2::rand(&mut rng).into_affine();
+            let v: Vec<_> = (0..SAMPLES)
+                .flat_map(|_| {
+                    let mut bytes = Vec::with_capacity(1000);
+                    tmp.serialize_unchecked(&mut bytes).unwrap();
+                    num_bytes = bytes.len();
+                    bytes
+                })
+                .collect();
+
+            let mut count = 0;
+            b.iter(|| {
+                count = (count + 1) % SAMPLES;
+                let index = count * num_bytes;
+                G2Affine::deserialize_unchecked(&mut &v[index..(index + num_bytes)]).unwrap()
+            });
+        }
+
+        #[bench]
+        fn bench_g2_ser_unchecked(b: &mut ::test::Bencher) {
+            use algebra::{CanonicalSerialize, ProjectiveCurve};
+            const SAMPLES: usize = 1000;
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            let mut v: Vec<_> = (0..SAMPLES).map(|_| G2::rand(&mut rng)).collect();
+            let v = G2::batch_normalization_into_affine(v.as_mut_slice());
+            let mut bytes = Vec::with_capacity(1000);
+
+            let mut count = 0;
+            b.iter(|| {
+                let tmp = v[count];
+                count = (count + 1) % SAMPLES;
+                bytes.clear();
+                tmp.serialize_unchecked(&mut &mut bytes)
             });
         }
     };

--- a/algebra-benches/src/macros/field.rs
+++ b/algebra-benches/src/macros/field.rs
@@ -125,6 +125,94 @@ macro_rules! field_common {
                     tmp
                 });
             }
+
+            #[bench]
+            fn [<bench_ $field_ident _deser>](b: &mut ::test::Bencher) {
+                use algebra::{CanonicalSerialize, CanonicalDeserialize};
+                const SAMPLES: usize = 1000;
+
+                let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+                let mut num_bytes = 0;
+                let v: Vec<_> = (0..SAMPLES).flat_map(|_| {
+                    let mut bytes = Vec::with_capacity(1000);
+                    let tmp = $f::rand(&mut rng);
+                    tmp.serialize(&mut bytes).unwrap();
+                    num_bytes = bytes.len();
+                    bytes
+                }).collect();
+
+                let mut count = 0;
+                b.iter(|| {
+                    count = (count + 1) % SAMPLES;
+                    let index = count * num_bytes;
+                    $f_type::deserialize(&mut &v[index..(index + num_bytes)]).unwrap()
+                });
+            }
+
+            #[bench]
+            fn [<bench_ $field_ident _ser>](b: &mut ::test::Bencher) {
+                use algebra::CanonicalSerialize;
+                const SAMPLES: usize = 1000;
+
+                let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+                let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
+                let mut bytes = Vec::with_capacity(1000);
+
+                let mut count = 0;
+                b.iter(|| {
+                    let tmp = v[count];
+                    count = (count + 1) % SAMPLES;
+                    bytes.clear();
+                    tmp.serialize(&mut &mut bytes)
+
+                });
+            }
+
+            #[bench]
+            fn [<bench_ $field_ident _deser_unchecked>](b: &mut ::test::Bencher) {
+                use algebra::{CanonicalSerialize, CanonicalDeserialize};
+                const SAMPLES: usize = 1000;
+
+                let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+                let mut num_bytes = 0;
+                let v: Vec<_> = (0..SAMPLES).flat_map(|_| {
+                    let mut bytes = Vec::with_capacity(1000);
+                    let tmp = $f::rand(&mut rng);
+                    tmp.serialize_unchecked(&mut bytes).unwrap();
+                    num_bytes = bytes.len();
+                    bytes
+                }).collect();
+
+                let mut count = 0;
+                b.iter(|| {
+                    count = (count + 1) % SAMPLES;
+                    let index = count * num_bytes;
+                    $f_type::deserialize_unchecked(&mut &v[index..(index + num_bytes)]).unwrap()
+                });
+            }
+
+            #[bench]
+            fn [<bench_ $field_ident _ser_unchecked>](b: &mut ::test::Bencher) {
+                use algebra::CanonicalSerialize;
+                const SAMPLES: usize = 1000;
+
+                let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+                let v: Vec<$f_type> = (0..SAMPLES).map(|_| $f::rand(&mut rng)).collect();
+                let mut bytes = Vec::with_capacity(1000);
+
+                let mut count = 0;
+                b.iter(|| {
+                    let tmp = v[count];
+                    count = (count + 1) % SAMPLES;
+                    bytes.clear();
+                    tmp.serialize_unchecked(&mut &mut bytes)
+
+                });
+            }
         }
     };
 }

--- a/algebra-core/algebra-core-derive/src/lib.rs
+++ b/algebra-core/algebra-core-derive/src/lib.rs
@@ -15,6 +15,7 @@ fn impl_serialize_field(
     serialize_body: &mut Vec<TokenStream>,
     serialized_size_body: &mut Vec<TokenStream>,
     serialize_uncompressed_body: &mut Vec<TokenStream>,
+    serialize_unchecked_body: &mut Vec<TokenStream>,
     uncompressed_size_body: &mut Vec<TokenStream>,
     idents: &mut Vec<Box<dyn ToTokens>>,
     ty: &Type,
@@ -29,6 +30,7 @@ fn impl_serialize_field(
                     serialize_body,
                     serialized_size_body,
                     serialize_uncompressed_body,
+                    serialize_unchecked_body,
                     uncompressed_size_body,
                     idents,
                     elem_ty,
@@ -43,6 +45,9 @@ fn impl_serialize_field(
                 .push(quote! { size += CanonicalSerialize::serialized_size(&self.#(#idents).*); });
             serialize_uncompressed_body.push(
                 quote! { CanonicalSerialize::serialize_uncompressed(&self.#(#idents).*, writer)?; },
+            );
+            serialize_unchecked_body.push(
+                quote! { CanonicalSerialize::serialize_unchecked(&self.#(#idents).*, writer)?; },
             );
             uncompressed_size_body.push(
                 quote! { size += CanonicalSerialize::uncompressed_size(&self.#(#idents).*); },
@@ -59,6 +64,7 @@ fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
     let mut serialize_body = Vec::<TokenStream>::new();
     let mut serialized_size_body = Vec::<TokenStream>::new();
     let mut serialize_uncompressed_body = Vec::<TokenStream>::new();
+    let mut serialize_unchecked_body = Vec::<TokenStream>::new();
     let mut uncompressed_size_body = Vec::<TokenStream>::new();
 
     match ast.data {
@@ -79,6 +85,7 @@ fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
                     &mut serialize_body,
                     &mut serialized_size_body,
                     &mut serialize_uncompressed_body,
+                    &mut serialize_unchecked_body,
                     &mut uncompressed_size_body,
                     &mut idents,
                     &field.ty,
@@ -109,6 +116,12 @@ fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
                 #(#serialize_uncompressed_body)*
                 Ok(())
             }
+
+            #[allow(unused_mut, unused_variables)]
+            fn serialize_unchecked<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+                #(#serialize_unchecked_body)*
+                Ok(())
+            }
             #[allow(unused_mut, unused_variables)]
             fn uncompressed_size(&self) -> usize {
                 let mut size = 0;
@@ -126,27 +139,31 @@ pub fn derive_canonical_deserialize(input: proc_macro::TokenStream) -> proc_macr
     proc_macro::TokenStream::from(impl_canonical_deserialize(&ast))
 }
 
-/// Returns two TokenStreams, one for the compressed deserialize, one for the
-/// uncompressed.
-fn impl_deserialize_field(ty: &Type) -> (TokenStream, TokenStream) {
+/// Returns three TokenStreams, one for the compressed deserialize, one for the
+/// uncompressed, and one for the unchecked.
+fn impl_deserialize_field(ty: &Type) -> (TokenStream, TokenStream, TokenStream) {
     // Check if type is a tuple.
     match ty {
         Type::Tuple(tuple) => {
             let mut compressed_fields = Vec::new();
             let mut uncompressed_fields = Vec::new();
+            let mut unchecked_fields = Vec::new();
             for elem_ty in tuple.elems.iter() {
-                let (compressed, uncompressed) = impl_deserialize_field(elem_ty);
+                let (compressed, uncompressed, unchecked) = impl_deserialize_field(elem_ty);
                 compressed_fields.push(compressed);
                 uncompressed_fields.push(uncompressed);
+                unchecked_fields.push(unchecked);
             }
             (
                 quote! { (#(#compressed_fields)*), },
                 quote! { (#(#uncompressed_fields)*), },
+                quote! { (#(#unchecked_fields)*), },
             )
         }
         _ => (
             quote! { CanonicalDeserialize::deserialize(reader)?, },
             quote! { CanonicalDeserialize::deserialize_uncompressed(reader)?, },
+            quote! { CanonicalDeserialize::deserialize_unchecked(reader)?, },
         ),
     }
 }
@@ -158,26 +175,31 @@ fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
 
     let deserialize_body;
     let deserialize_uncompressed_body;
+    let deserialize_unchecked_body;
 
     match ast.data {
         Data::Struct(ref data_struct) => {
             let mut tuple = false;
             let mut compressed_field_cases = Vec::<TokenStream>::new();
             let mut uncompressed_field_cases = Vec::<TokenStream>::new();
+            let mut unchecked_field_cases = Vec::<TokenStream>::new();
             for field in data_struct.fields.iter() {
                 match &field.ident {
                     None => {
                         tuple = true;
-                        let (compressed, uncompressed) = impl_deserialize_field(&field.ty);
+                        let (compressed, uncompressed, unchecked) =
+                            impl_deserialize_field(&field.ty);
                         compressed_field_cases.push(compressed);
                         uncompressed_field_cases.push(uncompressed);
+                        unchecked_field_cases.push(unchecked);
                     }
                     // struct field without len_type
                     Some(ident) => {
-                        let (compressed_field, uncompressed_field) =
+                        let (compressed_field, uncompressed_field, unchecked_field) =
                             impl_deserialize_field(&field.ty);
                         compressed_field_cases.push(quote! { #ident: #compressed_field });
                         uncompressed_field_cases.push(quote! { #ident: #uncompressed_field });
+                        unchecked_field_cases.push(quote! { #ident: #unchecked_field });
                     }
                 }
             }
@@ -193,6 +215,11 @@ fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
                         #(#uncompressed_field_cases)*
                     ))
                 });
+                deserialize_unchecked_body = quote!({
+                    Ok(#name (
+                        #(#unchecked_field_cases)*
+                    ))
+                });
             } else {
                 deserialize_body = quote!({
                     Ok(#name {
@@ -202,6 +229,11 @@ fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
                 deserialize_uncompressed_body = quote!({
                     Ok(#name {
                         #(#uncompressed_field_cases)*
+                    })
+                });
+                deserialize_unchecked_body = quote!({
+                    Ok(#name {
+                        #(#unchecked_field_cases)*
                     })
                 });
             }
@@ -221,6 +253,11 @@ fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
             #[allow(unused_mut,unused_variables)]
             fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
                 #deserialize_uncompressed_body
+            }
+
+            #[allow(unused_mut,unused_variables)]
+            fn deserialize_unchecked<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+                #deserialize_unchecked_body
             }
         }
     };

--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -15,7 +15,7 @@ pub mod models;
 
 pub use self::models::*;
 
-pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
+pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send + Eq + PartialEq {
     /// This is the scalar field of the G1/G2 groups.
     type Fr: PrimeField + SquareRootField;
 

--- a/algebra-core/src/curves/models/bw6/mod.rs
+++ b/algebra-core/src/curves/models/bw6/mod.rs
@@ -18,7 +18,7 @@ pub enum TwistType {
     D,
 }
 
-pub trait BW6Parameters: 'static {
+pub trait BW6Parameters: 'static + Eq + PartialEq {
     const X: <Self::Fp as PrimeField>::BigInt;
     const X_IS_NEGATIVE: bool;
     const ATE_LOOP_COUNT_1: &'static [u64];

--- a/algebra/src/bw6_761/curves/mod.rs
+++ b/algebra/src/bw6_761/curves/mod.rs
@@ -10,6 +10,7 @@ pub mod g2;
 #[cfg(test)]
 mod tests;
 
+#[derive(PartialEq, Eq)]
 pub struct Parameters;
 
 impl BW6Parameters for Parameters {

--- a/algebra/src/cp6_782/curves/mod.rs
+++ b/algebra/src/cp6_782/curves/mod.rs
@@ -19,7 +19,7 @@ mod tests;
 
 pub type GT = Fq6;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct CP6_782;
 
 impl PairingEngine for CP6_782 {

--- a/gm17/src/lib.rs
+++ b/gm17/src/lib.rs
@@ -49,7 +49,7 @@ mod test;
 pub use self::{generator::*, prover::*, verifier::*};
 
 /// A proof in the GM17 SNARK.
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(PartialEq, Eq, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<E: PairingEngine> {
     pub a: E::G1Affine,
     pub b: E::G2Affine,
@@ -65,12 +65,6 @@ impl<E: PairingEngine> ToBytes for Proof<E> {
     }
 }
 
-impl<E: PairingEngine> PartialEq for Proof<E> {
-    fn eq(&self, other: &Self) -> bool {
-        self.a == other.a && self.b == other.b && self.c == other.c
-    }
-}
-
 impl<E: PairingEngine> Default for Proof<E> {
     fn default() -> Self {
         Self {
@@ -81,23 +75,8 @@ impl<E: PairingEngine> Default for Proof<E> {
     }
 }
 
-impl<E: PairingEngine> Proof<E> {
-    /// Serialize the proof into bytes, for storage on disk or transmission
-    /// over the network.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the proof from bytes.
-    pub fn read<R: Read>(mut _reader: R) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-}
-
 /// A verification key in the GM17 SNARK.
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Eq, PartialEq, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifyingKey<E: PairingEngine> {
     pub h_g2: E::G2Affine,
     pub g_alpha_g1: E::G1Affine,
@@ -134,34 +113,8 @@ impl<E: PairingEngine> Default for VerifyingKey<E> {
     }
 }
 
-impl<E: PairingEngine> PartialEq for VerifyingKey<E> {
-    fn eq(&self, other: &Self) -> bool {
-        self.h_g2 == other.h_g2
-            && self.g_alpha_g1 == other.g_alpha_g1
-            && self.h_beta_g2 == other.h_beta_g2
-            && self.g_gamma_g1 == other.g_gamma_g1
-            && self.h_gamma_g2 == other.h_gamma_g2
-            && self.query == other.query
-    }
-}
-
-impl<E: PairingEngine> VerifyingKey<E> {
-    /// Serialize the verification key into bytes, for storage on disk
-    /// or transmission over the network.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the verification key from bytes.
-    pub fn read<R: Read>(mut _reader: R) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-}
-
 /// Full public (prover and verifier) parameters for the GM17 zkSNARK.
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(PartialEq, Eq, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Parameters<E: PairingEngine> {
     pub vk: VerifyingKey<E>,
     pub a_query: Vec<E::G1Affine>,
@@ -175,38 +128,9 @@ pub struct Parameters<E: PairingEngine> {
     pub g_gamma2_z_t: Vec<E::G1Affine>,
 }
 
-impl<E: PairingEngine> PartialEq for Parameters<E> {
-    fn eq(&self, other: &Self) -> bool {
-        self.vk == other.vk
-            && self.a_query == other.a_query
-            && self.b_query == other.b_query
-            && self.c_query_1 == other.c_query_1
-            && self.c_query_2 == other.c_query_2
-            && self.g_gamma_z == other.g_gamma_z
-            && self.h_gamma_z == other.h_gamma_z
-            && self.g_ab_gamma_z == other.g_ab_gamma_z
-            && self.g_gamma2_z2 == other.g_gamma2_z2
-            && self.g_gamma2_z_t == other.g_gamma2_z_t
-    }
-}
-
-impl<E: PairingEngine> Parameters<E> {
-    /// Serialize the parameters to bytes.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the public parameters from bytes.
-    pub fn read<R: Read>(mut _reader: R, _checked: bool) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-}
-
 /// Preprocessed verification key parameters that enable faster verification
 /// at the expense of larger size in memory.
-#[derive(Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct PreparedVerifyingKey<E: PairingEngine> {
     pub vk: VerifyingKey<E>,
     pub g_alpha: E::G1Affine,

--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -75,21 +75,6 @@ impl<E: PairingEngine> Default for Proof<E> {
     }
 }
 
-impl<E: PairingEngine> Proof<E> {
-    /// Serialize the proof into bytes, for storage on disk or transmission
-    /// over the network.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the proof from bytes.
-    pub fn read<R: Read>(mut _reader: R) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-}
-
 /// A verification key in the Groth16 SNARK.
 #[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifyingKey<E: PairingEngine> {
@@ -125,21 +110,6 @@ impl<E: PairingEngine> Default for VerifyingKey<E> {
     }
 }
 
-impl<E: PairingEngine> VerifyingKey<E> {
-    /// Serialize the verification key into bytes, for storage on disk
-    /// or transmission over the network.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the verification key from bytes.
-    pub fn read<R: Read>(mut _reader: R) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-}
-
 /// Full public (prover and verifier) parameters for the Groth16 zkSNARK.
 #[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Parameters<E: PairingEngine> {
@@ -151,20 +121,6 @@ pub struct Parameters<E: PairingEngine> {
     pub b_g2_query: Vec<E::G2Affine>,
     pub h_query: Vec<E::G1Affine>,
     pub l_query: Vec<E::G1Affine>,
-}
-
-impl<E: PairingEngine> Parameters<E> {
-    /// Serialize the parameters to bytes.
-    pub fn write<W: Write>(&self, mut _writer: W) -> io::Result<()> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
-
-    /// Deserialize the public parameters from bytes.
-    pub fn read<R: Read>(mut _reader: R, _checked: bool) -> io::Result<Self> {
-        // TODO: implement serialization
-        unimplemented!()
-    }
 }
 
 /// Preprocessed verification key parameters that enable faster verification


### PR DESCRIPTION
Add unchecked serialization and deserialization, for the case when one knows that the serialized output will be stored in a trusted location (for example: serialized and deserialized by the same machine).

cc @ChaitanyaKonda @iAmMichaelConnor, this might solve your use case in a cleaner way.

cc also @kobigurk @paberr 