### PR TITLE
Improve Serialization/Deserialization API to use `mut reader/writer: R/W`

### DIFF
--- a/algebra-benches/src/macros/ec.rs
+++ b/algebra-benches/src/macros/ec.rs
@@ -104,7 +104,7 @@ macro_rules! ec_bench {
             b.iter(|| {
                 count = (count + 1) % SAMPLES;
                 let index = count * num_bytes;
-                G1Affine::deserialize(&mut &v[index..(index + num_bytes)]).unwrap()
+                G1Affine::deserialize(&v[index..(index + num_bytes)]).unwrap()
             });
         }
 
@@ -124,7 +124,7 @@ macro_rules! ec_bench {
                 let tmp = v[count];
                 count = (count + 1) % SAMPLES;
                 bytes.clear();
-                tmp.serialize(&mut &mut bytes)
+                tmp.serialize(&mut bytes)
             });
         }
 
@@ -150,7 +150,7 @@ macro_rules! ec_bench {
             b.iter(|| {
                 count = (count + 1) % SAMPLES;
                 let index = count * num_bytes;
-                G1Affine::deserialize_unchecked(&mut &v[index..(index + num_bytes)]).unwrap()
+                G1Affine::deserialize_unchecked(&v[index..(index + num_bytes)]).unwrap()
             });
         }
 
@@ -170,7 +170,7 @@ macro_rules! ec_bench {
                 let tmp = v[count];
                 count = (count + 1) % SAMPLES;
                 bytes.clear();
-                tmp.serialize_unchecked(&mut &mut bytes)
+                tmp.serialize_unchecked(&mut bytes)
             });
         }
 
@@ -278,7 +278,7 @@ macro_rules! ec_bench {
             b.iter(|| {
                 count = (count + 1) % SAMPLES;
                 let index = count * num_bytes;
-                G2Affine::deserialize(&mut &v[index..(index + num_bytes)]).unwrap()
+                G2Affine::deserialize(&v[index..(index + num_bytes)]).unwrap()
             });
         }
 
@@ -298,7 +298,7 @@ macro_rules! ec_bench {
                 let tmp = v[count];
                 count = (count + 1) % SAMPLES;
                 bytes.clear();
-                tmp.serialize(&mut &mut bytes)
+                tmp.serialize(&mut bytes)
             });
         }
 
@@ -324,7 +324,7 @@ macro_rules! ec_bench {
             b.iter(|| {
                 count = (count + 1) % SAMPLES;
                 let index = count * num_bytes;
-                G2Affine::deserialize_unchecked(&mut &v[index..(index + num_bytes)]).unwrap()
+                G2Affine::deserialize_unchecked(&v[index..(index + num_bytes)]).unwrap()
             });
         }
 
@@ -344,7 +344,7 @@ macro_rules! ec_bench {
                 let tmp = v[count];
                 count = (count + 1) % SAMPLES;
                 bytes.clear();
-                tmp.serialize_unchecked(&mut &mut bytes)
+                tmp.serialize_unchecked(&mut bytes)
             });
         }
     };

--- a/algebra-benches/src/macros/field.rs
+++ b/algebra-benches/src/macros/field.rs
@@ -146,7 +146,7 @@ macro_rules! field_common {
                 b.iter(|| {
                     count = (count + 1) % SAMPLES;
                     let index = count * num_bytes;
-                    $f_type::deserialize(&mut &v[index..(index + num_bytes)]).unwrap()
+                    $f_type::deserialize(&v[index..(index + num_bytes)]).unwrap()
                 });
             }
 
@@ -165,7 +165,7 @@ macro_rules! field_common {
                     let tmp = v[count];
                     count = (count + 1) % SAMPLES;
                     bytes.clear();
-                    tmp.serialize(&mut &mut bytes)
+                    tmp.serialize(&mut bytes)
 
                 });
             }
@@ -190,7 +190,7 @@ macro_rules! field_common {
                 b.iter(|| {
                     count = (count + 1) % SAMPLES;
                     let index = count * num_bytes;
-                    $f_type::deserialize_unchecked(&mut &v[index..(index + num_bytes)]).unwrap()
+                    $f_type::deserialize_unchecked(&v[index..(index + num_bytes)]).unwrap()
                 });
             }
 
@@ -209,7 +209,7 @@ macro_rules! field_common {
                     let tmp = v[count];
                     count = (count + 1) % SAMPLES;
                     bytes.clear();
-                    tmp.serialize_unchecked(&mut &mut bytes)
+                    tmp.serialize_unchecked(&mut bytes)
 
                 });
             }

--- a/algebra-core/algebra-core-derive/src/lib.rs
+++ b/algebra-core/algebra-core-derive/src/lib.rs
@@ -40,14 +40,14 @@ fn impl_serialize_field(
         }
         _ => {
             serialize_body
-                .push(quote! { CanonicalSerialize::serialize(&self.#(#idents).*, writer)?; });
+                .push(quote! { CanonicalSerialize::serialize(&self.#(#idents).*, &mut writer)?; });
             serialized_size_body
                 .push(quote! { size += CanonicalSerialize::serialized_size(&self.#(#idents).*); });
             serialize_uncompressed_body.push(
-                quote! { CanonicalSerialize::serialize_uncompressed(&self.#(#idents).*, writer)?; },
+                quote! { CanonicalSerialize::serialize_uncompressed(&self.#(#idents).*, &mut writer)?; },
             );
             serialize_unchecked_body.push(
-                quote! { CanonicalSerialize::serialize_unchecked(&self.#(#idents).*, writer)?; },
+                quote! { CanonicalSerialize::serialize_unchecked(&self.#(#idents).*, &mut writer)?; },
             );
             uncompressed_size_body.push(
                 quote! { size += CanonicalSerialize::uncompressed_size(&self.#(#idents).*); },
@@ -101,7 +101,7 @@ fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
     let gen = quote! {
         impl #impl_generics CanonicalSerialize for #name #ty_generics #where_clause {
             #[allow(unused_mut, unused_variables)]
-            fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+            fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
                 #(#serialize_body)*
                 Ok(())
             }
@@ -112,13 +112,13 @@ fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
                 size
             }
             #[allow(unused_mut, unused_variables)]
-            fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+            fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
                 #(#serialize_uncompressed_body)*
                 Ok(())
             }
 
             #[allow(unused_mut, unused_variables)]
-            fn serialize_unchecked<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+            fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
                 #(#serialize_unchecked_body)*
                 Ok(())
             }
@@ -161,9 +161,9 @@ fn impl_deserialize_field(ty: &Type) -> (TokenStream, TokenStream, TokenStream) 
             )
         }
         _ => (
-            quote! { CanonicalDeserialize::deserialize(reader)?, },
-            quote! { CanonicalDeserialize::deserialize_uncompressed(reader)?, },
-            quote! { CanonicalDeserialize::deserialize_unchecked(reader)?, },
+            quote! { CanonicalDeserialize::deserialize(&mut reader)?, },
+            quote! { CanonicalDeserialize::deserialize_uncompressed(&mut reader)?, },
+            quote! { CanonicalDeserialize::deserialize_unchecked(&mut reader)?, },
         ),
     }
 }
@@ -247,16 +247,16 @@ fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
     let gen = quote! {
         impl #impl_generics CanonicalDeserialize for #name #ty_generics #where_clause {
             #[allow(unused_mut,unused_variables)]
-            fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+            fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
                 #deserialize_body
             }
             #[allow(unused_mut,unused_variables)]
-            fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+            fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
                 #deserialize_uncompressed_body
             }
 
             #[allow(unused_mut,unused_variables)]
-            fn deserialize_unchecked<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+            fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
                 #deserialize_unchecked_body
             }
         }

--- a/algebra-core/src/biginteger/mod.rs
+++ b/algebra-core/src/biginteger/mod.rs
@@ -24,7 +24,7 @@ bigint_impl!(BigInteger832, 13);
 
 impl<T: BigInteger> CanonicalSerialize for T {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         self.write(writer)?;
         Ok(())
     }
@@ -42,7 +42,7 @@ impl<T: BigInteger> ConstantSerializedSize for T {
 
 impl<T: BigInteger> CanonicalDeserialize for T {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize<R: Read>(reader: R) -> Result<Self, SerializationError> {
         let value = Self::read(reader)?;
         Ok(value)
     }

--- a/algebra-core/src/fields/models/cubic_extension.rs
+++ b/algebra-core/src/fields/models/cubic_extension.rs
@@ -494,19 +494,19 @@ impl<P: CubicExtParameters> CanonicalSerializeWithFlags for CubicExtField<P> {
     #[inline]
     fn serialize_with_flags<W: Write, F: Flags>(
         &self,
-        writer: &mut W,
+        mut writer: W,
         flags: F,
     ) -> Result<(), SerializationError> {
-        self.c0.serialize(writer)?;
-        self.c1.serialize(writer)?;
-        self.c2.serialize_with_flags(writer, flags)?;
+        self.c0.serialize(&mut writer)?;
+        self.c1.serialize(&mut writer)?;
+        self.c2.serialize_with_flags(&mut writer, flags)?;
         Ok(())
     }
 }
 
 impl<P: CubicExtParameters> CanonicalSerialize for CubicExtField<P> {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         self.serialize_with_flags(writer, EmptyFlags)
     }
 
@@ -524,22 +524,22 @@ impl<P: CubicExtParameters> ConstantSerializedSize for CubicExtField<P> {
 impl<P: CubicExtParameters> CanonicalDeserializeWithFlags for CubicExtField<P> {
     #[inline]
     fn deserialize_with_flags<R: Read, F: Flags>(
-        reader: &mut R,
+        mut reader: R,
     ) -> Result<(Self, F), SerializationError> {
-        let c0: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
-        let c1: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
+        let c0: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
+        let c1: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
         let (c2, flags): (P::BaseField, _) =
-            CanonicalDeserializeWithFlags::deserialize_with_flags(reader)?;
+            CanonicalDeserializeWithFlags::deserialize_with_flags(&mut reader)?;
         Ok((CubicExtField::new(c0, c1, c2), flags))
     }
 }
 
 impl<P: CubicExtParameters> CanonicalDeserialize for CubicExtField<P> {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let c0: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
-        let c1: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
-        let c2: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let c0: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
+        let c1: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
+        let c2: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
         Ok(CubicExtField::new(c0, c1, c2))
     }
 }

--- a/algebra-core/src/fields/models/quadratic_extension.rs
+++ b/algebra-core/src/fields/models/quadratic_extension.rs
@@ -493,18 +493,18 @@ impl<P: QuadExtParameters> CanonicalSerializeWithFlags for QuadExtField<P> {
     #[inline]
     fn serialize_with_flags<W: Write, F: Flags>(
         &self,
-        writer: &mut W,
+        mut writer: W,
         flags: F,
     ) -> Result<(), SerializationError> {
-        self.c0.serialize(writer)?;
-        self.c1.serialize_with_flags(writer, flags)?;
+        self.c0.serialize(&mut writer)?;
+        self.c1.serialize_with_flags(&mut writer, flags)?;
         Ok(())
     }
 }
 
 impl<P: QuadExtParameters> CanonicalSerialize for QuadExtField<P> {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         self.serialize_with_flags(writer, EmptyFlags)
     }
 
@@ -522,20 +522,20 @@ impl<P: QuadExtParameters> ConstantSerializedSize for QuadExtField<P> {
 impl<P: QuadExtParameters> CanonicalDeserializeWithFlags for QuadExtField<P> {
     #[inline]
     fn deserialize_with_flags<R: Read, F: Flags>(
-        reader: &mut R,
+        mut reader: R,
     ) -> Result<(Self, F), SerializationError> {
-        let c0: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
+        let c0: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
         let (c1, flags): (P::BaseField, _) =
-            CanonicalDeserializeWithFlags::deserialize_with_flags(reader)?;
+            CanonicalDeserializeWithFlags::deserialize_with_flags(&mut reader)?;
         Ok((QuadExtField::new(c0, c1), flags))
     }
 }
 
 impl<P: QuadExtParameters> CanonicalDeserialize for QuadExtField<P> {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let c0: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
-        let c1: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let c0: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
+        let c1: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
         Ok(QuadExtField::new(c0, c1))
     }
 }

--- a/algebra-core/src/serialize/mod.rs
+++ b/algebra-core/src/serialize/mod.rs
@@ -19,7 +19,7 @@ pub trait CanonicalSerializeWithFlags: CanonicalSerialize {
     /// Serializes `self` and `flags` into `writer`.
     fn serialize_with_flags<W: Write, F: Flags>(
         &self,
-        writer: &mut W,
+        writer: W,
         flags: F,
     ) -> Result<(), SerializationError>;
 }
@@ -51,13 +51,13 @@ pub trait ConstantSerializedSize: CanonicalSerialize {
 /// when importing `algebra::serialize::*`.
 pub trait CanonicalSerialize {
     /// Serializes `self` into `writer`.
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError>;
+    fn serialize<W: Write>(&self, writer: W) -> Result<(), SerializationError>;
 
     fn serialized_size(&self) -> usize;
 
     /// Serializes `self` into `writer` without compression.
     #[inline]
-    fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize_uncompressed<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         self.serialize(writer)
     }
 
@@ -65,7 +65,7 @@ pub trait CanonicalSerialize {
     /// validity checks. Should be used *only* when there is no danger of
     /// adversarial manipulation of the output.
     #[inline]
-    fn serialize_unchecked<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize_unchecked<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         self.serialize_uncompressed(writer)
     }
 
@@ -80,7 +80,7 @@ pub trait CanonicalDeserializeWithFlags: Sized {
     /// Reads `Self` and `Flags` from `reader`.
     /// Returns empty flags by default.
     fn deserialize_with_flags<R: Read, F: Flags>(
-        reader: &mut R,
+        reader: R,
     ) -> Result<(Self, F), SerializationError>;
 }
 
@@ -105,18 +105,18 @@ pub trait CanonicalDeserializeWithFlags: Sized {
 /// when importing `algebra::serialize::*`.
 pub trait CanonicalDeserialize: Sized {
     /// Reads `Self` from `reader`.
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError>;
+    fn deserialize<R: Read>(reader: R) -> Result<Self, SerializationError>;
 
     /// Reads `Self` from `reader` without compression.
     #[inline]
-    fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize_uncompressed<R: Read>(reader: R) -> Result<Self, SerializationError> {
         Self::deserialize(reader)
     }
 
     /// Reads `self` from `reader` without compression, and without performing
     /// validity checks. Should be used *only* when the input is trusted.
     #[inline]
-    fn deserialize_unchecked<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize_unchecked<R: Read>(reader: R) -> Result<Self, SerializationError> {
         Self::deserialize_uncompressed(reader)
     }
 }
@@ -125,7 +125,7 @@ macro_rules! impl_uint {
     ($ty: ident) => {
         impl CanonicalSerialize for $ty {
             #[inline]
-            fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+            fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
                 Ok(writer.write_all(&self.to_le_bytes())?)
             }
 
@@ -142,7 +142,7 @@ macro_rules! impl_uint {
 
         impl CanonicalDeserialize for $ty {
             #[inline]
-            fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+            fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
                 let mut bytes = [0u8; Self::SERIALIZED_SIZE];
                 reader.read_exact(&mut bytes)?;
                 Ok($ty::from_le_bytes(bytes))
@@ -158,7 +158,7 @@ impl_uint!(u64);
 
 impl CanonicalSerialize for usize {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
         Ok(writer.write_all(&(*self as u64).to_le_bytes())?)
     }
 
@@ -175,7 +175,7 @@ impl ConstantSerializedSize for usize {
 
 impl CanonicalDeserialize for usize {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let mut bytes = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut bytes)?;
         usize::try_from(u64::from_le_bytes(bytes)).map_err(|_| SerializationError::InvalidData)
@@ -184,11 +184,11 @@ impl CanonicalDeserialize for usize {
 
 impl<T: CanonicalSerialize> CanonicalSerialize for Vec<T> {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
         let len = self.len() as u64;
-        len.serialize(writer)?;
+        len.serialize(&mut writer)?;
         for item in self.iter() {
-            item.serialize(writer)?;
+            item.serialize(&mut writer)?;
         }
         Ok(())
     }
@@ -202,21 +202,21 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Vec<T> {
     }
 
     #[inline]
-    fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
         let len = self.len() as u64;
-        len.serialize(writer)?;
+        len.serialize(&mut writer)?;
         for item in self.iter() {
-            item.serialize_uncompressed(writer)?;
+            item.serialize_uncompressed(&mut writer)?;
         }
         Ok(())
     }
 
     #[inline]
-    fn serialize_unchecked<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
         let len = self.len() as u64;
-        len.serialize(writer)?;
+        len.serialize(&mut writer)?;
         for item in self.iter() {
-            item.serialize_unchecked(writer)?;
+            item.serialize_unchecked(&mut writer)?;
         }
         Ok(())
     }
@@ -232,31 +232,31 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Vec<T> {
 
 impl<T: CanonicalDeserialize> CanonicalDeserialize for Vec<T> {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let len = u64::deserialize(reader)?;
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = u64::deserialize(&mut reader)?;
         let mut values = vec![];
         for _ in 0..len {
-            values.push(T::deserialize(reader)?);
+            values.push(T::deserialize(&mut reader)?);
         }
         Ok(values)
     }
 
     #[inline]
-    fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let len = u64::deserialize(reader)?;
+    fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = u64::deserialize(&mut reader)?;
         let mut values = vec![];
         for _ in 0..len {
-            values.push(T::deserialize_uncompressed(reader)?);
+            values.push(T::deserialize_uncompressed(&mut reader)?);
         }
         Ok(values)
     }
 
     #[inline]
-    fn deserialize_unchecked<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let len = u64::deserialize(reader)?;
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let len = u64::deserialize(&mut reader)?;
         let mut values = vec![];
         for _ in 0..len {
-            values.push(T::deserialize_unchecked(reader)?);
+            values.push(T::deserialize_unchecked(&mut reader)?);
         }
         Ok(values)
     }
@@ -279,7 +279,7 @@ macro_rules! impl_prime_field_serializer {
             #[allow(unused_qualifications)]
             fn serialize_with_flags<W: crate::io::Write, F: crate::serialize::Flags>(
                 &self,
-                writer: &mut W,
+                mut writer: W,
                 flags: F,
             ) -> Result<(), crate::serialize::SerializationError> {
                 const BYTE_SIZE: usize = $byte_size;
@@ -312,7 +312,7 @@ macro_rules! impl_prime_field_serializer {
             #[inline]
             fn serialize<W: crate::io::Write>(
                 &self,
-                writer: &mut W,
+                writer: W,
             ) -> Result<(), crate::serialize::SerializationError> {
                 self.serialize_with_flags(writer, crate::serialize::EmptyFlags)
             }
@@ -326,7 +326,7 @@ macro_rules! impl_prime_field_serializer {
         impl<P: $params> CanonicalDeserializeWithFlags for $field<P> {
             #[allow(unused_qualifications)]
             fn deserialize_with_flags<R: crate::io::Read, F: crate::serialize::Flags>(
-                reader: &mut R,
+                mut reader: R,
             ) -> Result<(Self, F), crate::serialize::SerializationError> {
                 const BYTE_SIZE: usize = $byte_size;
 
@@ -348,7 +348,7 @@ macro_rules! impl_prime_field_serializer {
         impl<P: $params> CanonicalDeserialize for $field<P> {
             #[allow(unused_qualifications)]
             fn deserialize<R: crate::io::Read>(
-                reader: &mut R,
+                mut reader: R,
             ) -> Result<Self, crate::serialize::SerializationError> {
                 const BYTE_SIZE: usize = $byte_size;
 
@@ -370,7 +370,7 @@ macro_rules! impl_sw_curve_serializer {
             #[inline]
             fn serialize<W: crate::io::Write>(
                 &self,
-                writer: &mut W,
+                writer: W,
             ) -> Result<(), crate::serialize::SerializationError> {
                 if self.is_zero() {
                     let flags = crate::serialize::SWFlags::infinity();
@@ -391,15 +391,15 @@ macro_rules! impl_sw_curve_serializer {
             #[inline]
             fn serialize_uncompressed<W: crate::io::Write>(
                 &self,
-                writer: &mut W,
+                mut writer: W,
             ) -> Result<(), crate::serialize::SerializationError> {
                 let flags = if self.is_zero() {
                     crate::serialize::SWFlags::infinity()
                 } else {
                     crate::serialize::SWFlags::default()
                 };
-                self.x.serialize(writer)?;
-                self.y.serialize_with_flags(writer, flags)?;
+                self.x.serialize(&mut writer)?;
+                self.y.serialize_with_flags(&mut writer, flags)?;
                 Ok(())
             }
 
@@ -419,7 +419,7 @@ macro_rules! impl_sw_curve_serializer {
         impl<P: $params> CanonicalDeserialize for GroupAffine<P> {
             #[allow(unused_qualifications)]
             fn deserialize<R: crate::io::Read>(
-                reader: &mut R,
+                reader: R,
             ) -> Result<Self, crate::serialize::SerializationError> {
                 let (x, flags): (P::BaseField, crate::serialize::SWFlags) =
                     CanonicalDeserializeWithFlags::deserialize_with_flags(reader)?;
@@ -437,7 +437,7 @@ macro_rules! impl_sw_curve_serializer {
 
             #[allow(unused_qualifications)]
             fn deserialize_uncompressed<R: crate::io::Read>(
-                reader: &mut R,
+                reader: R,
             ) -> Result<Self, crate::serialize::SerializationError> {
                 let p = Self::deserialize_unchecked(reader)?;
 
@@ -449,11 +449,11 @@ macro_rules! impl_sw_curve_serializer {
 
             #[allow(unused_qualifications)]
             fn deserialize_unchecked<R: crate::io::Read>(
-                reader: &mut R,
+                mut reader: R,
             ) -> Result<Self, crate::serialize::SerializationError> {
-                let x: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
+                let x: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
                 let (y, flags): (P::BaseField, crate::serialize::SWFlags) =
-                    CanonicalDeserializeWithFlags::deserialize_with_flags(reader)?;
+                    CanonicalDeserializeWithFlags::deserialize_with_flags(&mut reader)?;
                 let p = GroupAffine::<P>::new(x, y, flags.is_infinity());
                 Ok(p)
             }
@@ -468,7 +468,7 @@ macro_rules! impl_edwards_curve_serializer {
             #[inline]
             fn serialize<W: crate::io::Write>(
                 &self,
-                writer: &mut W,
+                writer: W,
             ) -> Result<(), crate::serialize::SerializationError> {
                 if self.is_zero() {
                     let flags = crate::serialize::EdwardsFlags::default();
@@ -489,10 +489,10 @@ macro_rules! impl_edwards_curve_serializer {
             #[inline]
             fn serialize_uncompressed<W: crate::io::Write>(
                 &self,
-                writer: &mut W,
+                mut writer: W,
             ) -> Result<(), crate::serialize::SerializationError> {
-                self.x.serialize_uncompressed(writer)?;
-                self.y.serialize_uncompressed(writer)?;
+                self.x.serialize_uncompressed(&mut writer)?;
+                self.y.serialize_uncompressed(&mut writer)?;
                 Ok(())
             }
 
@@ -512,10 +512,10 @@ macro_rules! impl_edwards_curve_serializer {
         impl<P: $params> CanonicalDeserialize for GroupAffine<P> {
             #[allow(unused_qualifications)]
             fn deserialize<R: crate::io::Read>(
-                reader: &mut R,
+                mut reader: R,
             ) -> Result<Self, crate::serialize::SerializationError> {
                 let (x, flags): (P::BaseField, crate::serialize::EdwardsFlags) =
-                    CanonicalDeserializeWithFlags::deserialize_with_flags(reader)?;
+                    CanonicalDeserializeWithFlags::deserialize_with_flags(&mut reader)?;
                 if x == P::BaseField::zero() {
                     Ok(Self::zero())
                 } else {
@@ -530,7 +530,7 @@ macro_rules! impl_edwards_curve_serializer {
 
             #[allow(unused_qualifications)]
             fn deserialize_uncompressed<R: crate::io::Read>(
-                reader: &mut R,
+                reader: R,
             ) -> Result<Self, crate::serialize::SerializationError> {
                 let p = Self::deserialize_unchecked(reader)?;
 
@@ -542,10 +542,10 @@ macro_rules! impl_edwards_curve_serializer {
 
             #[allow(unused_qualifications)]
             fn deserialize_unchecked<R: crate::io::Read>(
-                reader: &mut R,
+                mut reader: R,
             ) -> Result<Self, crate::serialize::SerializationError> {
-                let x: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
-                let y: P::BaseField = CanonicalDeserialize::deserialize(reader)?;
+                let x: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
+                let y: P::BaseField = CanonicalDeserialize::deserialize(&mut reader)?;
 
                 let p = GroupAffine::<P>::new(x, y);
                 Ok(p)
@@ -561,8 +561,8 @@ macro_rules! impl_tuple {
             $($ty: CanonicalSerialize,)+
         {
             #[inline]
-            fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-                $(self.$no.serialize(writer)?;)*
+            fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+                $(self.$no.serialize(&mut writer)?;)*
                 Ok(())
             }
 
@@ -574,8 +574,14 @@ macro_rules! impl_tuple {
             }
 
             #[inline]
-            fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-                $(self.$no.serialize_uncompressed(writer)?;)*
+            fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+                $(self.$no.serialize_uncompressed(&mut writer)?;)*
+                Ok(())
+            }
+
+            #[inline]
+            fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+                $(self.$no.serialize_unchecked(&mut writer)?;)*
                 Ok(())
             }
 
@@ -591,16 +597,23 @@ macro_rules! impl_tuple {
             $($ty: CanonicalDeserialize,)+
         {
             #[inline]
-            fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+            fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
                 Ok(($(
-                    $ty::deserialize(reader)?,
+                    $ty::deserialize(&mut reader)?,
                 )+))
             }
 
             #[inline]
-            fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+            fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
                 Ok(($(
-                    $ty::deserialize_uncompressed(reader)?,
+                    $ty::deserialize_uncompressed(&mut reader)?,
+                )+))
+            }
+
+            #[inline]
+            fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+                Ok(($(
+                    $ty::deserialize_unchecked(&mut reader)?,
                 )+))
             }
         }
@@ -614,7 +627,7 @@ impl_tuple!(A:0, B:1, C:2, D:3,);
 // No-op
 impl<T> CanonicalSerialize for core::marker::PhantomData<T> {
     #[inline]
-    fn serialize<W: Write>(&self, _writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, _writer: W) -> Result<(), SerializationError> {
         Ok(())
     }
 
@@ -624,26 +637,26 @@ impl<T> CanonicalSerialize for core::marker::PhantomData<T> {
     }
 
     #[inline]
-    fn serialize_uncompressed<W: Write>(&self, _writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize_uncompressed<W: Write>(&self, _writer: W) -> Result<(), SerializationError> {
         Ok(())
     }
 }
 
 impl<T> CanonicalDeserialize for core::marker::PhantomData<T> {
     #[inline]
-    fn deserialize<R: Read>(_reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize<R: Read>(_reader: R) -> Result<Self, SerializationError> {
         Ok(core::marker::PhantomData)
     }
 
     #[inline]
-    fn deserialize_uncompressed<R: Read>(_reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize_uncompressed<R: Read>(_reader: R) -> Result<Self, SerializationError> {
         Ok(core::marker::PhantomData)
     }
 }
 
 impl<'a, T: CanonicalSerialize + ToOwned> CanonicalSerialize for Cow<'a, T> {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         self.as_ref().serialize(writer)
     }
 
@@ -653,7 +666,7 @@ impl<'a, T: CanonicalSerialize + ToOwned> CanonicalSerialize for Cow<'a, T> {
     }
 
     #[inline]
-    fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize_uncompressed<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         self.as_ref().serialize_uncompressed(writer)
     }
 }
@@ -664,12 +677,12 @@ where
     <T as ToOwned>::Owned: CanonicalDeserialize,
 {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize<R: Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(Cow::Owned(<T as ToOwned>::Owned::deserialize(reader)?))
     }
 
     #[inline]
-    fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize_uncompressed<R: Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(Cow::Owned(<T as ToOwned>::Owned::deserialize_uncompressed(
             reader,
         )?))
@@ -678,10 +691,10 @@ where
 
 impl<T: CanonicalSerialize> CanonicalSerialize for Option<T> {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-        self.is_some().serialize(writer)?;
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        self.is_some().serialize(&mut writer)?;
         if let Some(item) = self {
-            item.serialize(writer)?;
+            item.serialize(&mut writer)?;
         }
 
         Ok(())
@@ -689,18 +702,19 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Option<T> {
 
     #[inline]
     fn serialized_size(&self) -> usize {
-        8 + if let Some(item) = self {
-            item.serialized_size()
-        } else {
-            0
-        }
+        self.is_some().serialized_size()
+            + if let Some(item) = self {
+                item.serialized_size()
+            } else {
+                0
+            }
     }
 
     #[inline]
-    fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-        self.is_some().serialize_uncompressed(writer)?;
+    fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        self.is_some().serialize_uncompressed(&mut writer)?;
         if let Some(item) = self {
-            item.serialize_uncompressed(writer)?;
+            item.serialize_uncompressed(&mut writer)?;
         }
 
         Ok(())
@@ -709,10 +723,10 @@ impl<T: CanonicalSerialize> CanonicalSerialize for Option<T> {
 
 impl<T: CanonicalDeserialize> CanonicalDeserialize for Option<T> {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let is_some = bool::deserialize(reader)?;
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let is_some = bool::deserialize(&mut reader)?;
         let data = if is_some {
-            Some(T::deserialize(reader)?)
+            Some(T::deserialize(&mut reader)?)
         } else {
             None
         };
@@ -721,10 +735,10 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Option<T> {
     }
 
     #[inline]
-    fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let is_some = bool::deserialize(reader)?;
+    fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let is_some = bool::deserialize(&mut reader)?;
         let data = if is_some {
-            Some(T::deserialize_uncompressed(reader)?)
+            Some(T::deserialize_uncompressed(&mut reader)?)
         } else {
             None
         };
@@ -735,7 +749,7 @@ impl<T: CanonicalDeserialize> CanonicalDeserialize for Option<T> {
 
 impl CanonicalSerialize for bool {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, writer: W) -> Result<(), SerializationError> {
         Ok(self.write(writer)?)
     }
 
@@ -747,7 +761,7 @@ impl CanonicalSerialize for bool {
 
 impl CanonicalDeserialize for bool {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+    fn deserialize<R: Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(bool::read(reader)?)
     }
 }
@@ -762,19 +776,18 @@ mod test {
         data: T,
     ) {
         let mut serialized = vec![0; data.serialized_size()];
-        data.serialize(&mut &mut serialized[..]).unwrap();
-        let de = T::deserialize(&mut &serialized[..]).unwrap();
+        data.serialize(&mut serialized[..]).unwrap();
+        let de = T::deserialize(&serialized[..]).unwrap();
         assert_eq!(data, de);
 
         let mut serialized = vec![0; data.uncompressed_size()];
-        data.serialize_uncompressed(&mut &mut serialized[..])
-            .unwrap();
-        let de = T::deserialize_uncompressed(&mut &serialized[..]).unwrap();
+        data.serialize_uncompressed(&mut serialized[..]).unwrap();
+        let de = T::deserialize_uncompressed(&serialized[..]).unwrap();
         assert_eq!(data, de);
 
         let mut serialized = vec![0; data.uncompressed_size()];
-        data.serialize_unchecked(&mut &mut serialized[..]).unwrap();
-        let de = T::deserialize_unchecked(&mut &serialized[..]).unwrap();
+        data.serialize_unchecked(&mut serialized[..]).unwrap();
+        let de = T::deserialize_unchecked(&serialized[..]).unwrap();
         assert_eq!(data, de);
     }
 

--- a/r1cs-core/src/lib.rs
+++ b/r1cs-core/src/lib.rs
@@ -65,18 +65,18 @@ pub enum Index {
 
 impl CanonicalSerialize for Index {
     #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
         let inner = match *self {
             Index::Input(inner) => {
-                true.serialize(writer)?;
+                true.serialize(&mut writer)?;
                 inner
             }
             Index::Aux(inner) => {
-                false.serialize(writer)?;
+                false.serialize(&mut writer)?;
                 inner
             }
         };
-        inner.serialize(writer)?;
+        inner.serialize(&mut writer)?;
         Ok(())
     }
 
@@ -93,9 +93,9 @@ impl ConstantSerializedSize for Index {
 
 impl CanonicalDeserialize for Index {
     #[inline]
-    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        let is_input = bool::deserialize(reader)?;
-        let inner = usize::deserialize(reader)?;
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let is_input = bool::deserialize(&mut reader)?;
+        let inner = usize::deserialize(&mut reader)?;
         Ok(if is_input {
             Index::Input(inner)
         } else {


### PR DESCRIPTION
In the process of working on #253, I decided to fix a small nit with the current API of `CanonicalSerialize/Deserialize`. *This is a breaking change*, albeit one that's easily fixed via the following substitutions: `s/\<reader\>: &mut R/mut reader: R/g` and `s/\<writer\>: &mut W/mut writer: W/g`, along with passing `reader`/`writer` by mutable reference to subroutines.

cc @kobigurk @paberr