### PR TITLE
Fix incorrect comments in SW Projective coordinates 

### DIFF
--- a/algebra-core/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra-core/src/curves/models/short_weierstrass_projective.rs
@@ -567,7 +567,7 @@ impl<P: Parameters> From<GroupAffine<P>> for GroupProjective<P> {
 }
 
 // The projective point X, Y, Z is represented in the affine
-// coordinates as X/Z^2, Y/Z^3.
+// coordinates as X/Z, Y/Z.
 impl<P: Parameters> From<GroupProjective<P>> for GroupAffine<P> {
     fn from(p: GroupProjective<P>) -> GroupAffine<P> {
         if p.is_zero() {


### PR DESCRIPTION
Hello, I'm learning your code now and I found a typo in comments. 

I really appreciate your work in building such an excellent rust library for finite fields and elliptic curves.