### PR TITLE
Use a `tracing`-based API for debugging and profiling constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
           target: thumbv6m-none-eabi
           override: true
 
+      - name: Install Rust ARM64 (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-none
+          override: true
+
       - uses: actions/cache@v2
         with:
           path: |
@@ -130,8 +137,8 @@ jobs:
       - name: r1cs-std
         run: |
           cd r1cs-std
-          cargo build -p r1cs-std --no-default-features --target thumbv6m-none-eabi
-          cargo check --examples -p r1cs-std --no-default-features --target thumbv6m-none-eabi
+          cargo build -p r1cs-std --no-default-features --target aarch64-unknown-none
+          cargo check --examples -p r1cs-std --no-default-features --target aarch64-unknown-none
           cd ..
 
       - name: ff-fft
@@ -158,6 +165,6 @@ jobs:
       - name: crypto-primitives
         run: |
           cd crypto-primitives
-          cargo build -p crypto-primitives --no-default-features --target thumbv6m-none-eabi
-          cargo check --examples -p crypto-primitives --no-default-features --target thumbv6m-none-eabi
+          cargo build -p crypto-primitives --no-default-features --target aarch64-unknown-none
+          cargo check --examples -p crypto-primitives --no-default-features --target aarch64-unknown-none
           cd ..

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -38,6 +38,7 @@ r1cs-std = { path = "../r1cs-std", optional = true, default-features = false }
 rand = { version = "0.7", default-features = false }
 rayon = { version = "1.0", optional = true }
 derivative = { version = "2.0", features = ["use_core"] }
+tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 
 [features]
 default = ["std", "r1cs"]

--- a/crypto-primitives/src/commitment/blake2s/constraints.rs
+++ b/crypto-primitives/src/commitment/blake2s/constraints.rs
@@ -24,6 +24,7 @@ impl<F: PrimeField> CommitmentGadget<blake2s::Commitment, F> for CommGadget {
     type ParametersVar = ParametersVar;
     type RandomnessVar = RandomnessVar<F>;
 
+    #[tracing::instrument(target = "r1cs", skip(input, r))]
     fn commit(
         _: &Self::ParametersVar,
         input: &[UInt8<F>],
@@ -43,6 +44,7 @@ impl<F: PrimeField> CommitmentGadget<blake2s::Commitment, F> for CommGadget {
 }
 
 impl<ConstraintF: Field> AllocVar<(), ConstraintF> for ParametersVar {
+    #[tracing::instrument(target = "r1cs", skip(_cs, _f))]
     fn new_variable<T: Borrow<()>>(
         _cs: impl Into<Namespace<ConstraintF>>,
         _f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -53,6 +55,7 @@ impl<ConstraintF: Field> AllocVar<(), ConstraintF> for ParametersVar {
 }
 
 impl<ConstraintF: PrimeField> AllocVar<[u8; 32], ConstraintF> for RandomnessVar<ConstraintF> {
+    #[tracing::instrument(target = "r1cs", skip(cs, f))]
     fn new_variable<T: Borrow<[u8; 32]>>(
         cs: impl Into<Namespace<ConstraintF>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -111,7 +114,7 @@ mod test {
 
         let parameters_var =
             <TestCOMMGadget as CommitmentGadget<TestCOMM, Fr>>::ParametersVar::new_witness(
-                cs.ns("gadget_parameters"),
+                r1cs_core::ns!(cs, "gadget_parameters"),
                 || Ok(&parameters),
             )
             .unwrap();

--- a/crypto-primitives/src/commitment/pedersen/constraints.rs
+++ b/crypto-primitives/src/commitment/pedersen/constraints.rs
@@ -53,6 +53,7 @@ where
     type ParametersVar = ParametersVar<C, GG>;
     type RandomnessVar = RandomnessVar<ConstraintF<C>>;
 
+    #[tracing::instrument(target = "r1cs", skip(parameters, r))]
     fn commit(
         parameters: &Self::ParametersVar,
         input: &[UInt8<ConstraintF<C>>],
@@ -183,13 +184,13 @@ mod test {
 
         let randomness_var =
             <TestCOMMGadget as CommitmentGadget<TestCOMM, Fq>>::RandomnessVar::new_witness(
-                cs.ns("gadget_randomness"),
+                r1cs_core::ns!(cs, "gadget_randomness"),
                 || Ok(&randomness),
             )
             .unwrap();
         let parameters_var =
             <TestCOMMGadget as CommitmentGadget<TestCOMM, Fq>>::ParametersVar::new_witness(
-                cs.ns("gadget_parameters"),
+                r1cs_core::ns!(cs, "gadget_parameters"),
                 || Ok(&parameters),
             )
             .unwrap();

--- a/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
@@ -51,6 +51,7 @@ where
     type OutputVar = AffineVar<P, F>;
     type ParametersVar = ParametersVar<P, W>;
 
+    #[tracing::instrument(target = "r1cs", skip(parameters, input))]
     fn evaluate(
         parameters: &Self::ParametersVar,
         input: &[UInt8<ConstraintF<P>>],
@@ -91,6 +92,7 @@ where
     P: TEModelParameters,
     W: Window,
 {
+    #[tracing::instrument(target = "r1cs", skip(_cs, f))]
     fn new_variable<T: Borrow<Parameters<P>>>(
         _cs: impl Into<Namespace<ConstraintF<P>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -158,7 +160,7 @@ mod test {
 
         let parameters_var =
             <TestCRHGadget as FixedLengthCRHGadget<TestCRH, Fr>>::ParametersVar::new_witness(
-                cs.ns("parameters_var"),
+                r1cs_core::ns!(cs, "parameters_var"),
                 || Ok(&parameters),
             )
             .unwrap();

--- a/crypto-primitives/src/crh/injective_map/constraints.rs
+++ b/crypto-primitives/src/crh/injective_map/constraints.rs
@@ -87,6 +87,7 @@ where
     type OutputVar = IG::OutputVar;
     type ParametersVar = ped_constraints::CRHParametersVar<C, GG>;
 
+    #[tracing::instrument(target = "r1cs", skip(parameters, input))]
     fn evaluate(
         parameters: &Self::ParametersVar,
         input: &[UInt8<ConstraintF<C>>],

--- a/crypto-primitives/src/crh/pedersen/constraints.rs
+++ b/crypto-primitives/src/crh/pedersen/constraints.rs
@@ -45,6 +45,7 @@ where
     type OutputVar = GG;
     type ParametersVar = CRHParametersVar<C, GG>;
 
+    #[tracing::instrument(target = "r1cs", skip(parameters, input))]
     fn evaluate(
         parameters: &Self::ParametersVar,
         input: &[UInt8<ConstraintF<C>>],
@@ -78,6 +79,7 @@ where
     GG: CurveVar<C, ConstraintF<C>>,
     for<'a> &'a GG: GroupOpsBounds<'a, C, GG>,
 {
+    #[tracing::instrument(target = "r1cs", skip(_cs, f))]
     fn new_variable<T: Borrow<Parameters<C>>>(
         _cs: impl Into<Namespace<ConstraintF<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -138,7 +140,8 @@ mod test {
         let primitive_result = TestCRH::evaluate(&parameters, &input).unwrap();
 
         let parameters_var =
-            CRHParametersVar::new_constant(cs.ns("CRH Parameters"), &parameters).unwrap();
+            CRHParametersVar::new_constant(r1cs_core::ns!(cs, "CRH Parameters"), &parameters)
+                .unwrap();
 
         let result_var = TestCRHGadget::evaluate(&parameters_var, &input_var).unwrap();
 

--- a/crypto-primitives/src/nizk/constraints.rs
+++ b/crypto-primitives/src/nizk/constraints.rs
@@ -15,6 +15,7 @@ pub trait NIZKVerifierGadget<N: NIZK, ConstraintF: Field> {
     /// subgroup checks.
     ///
     /// The default implementation doesn't omit these checks.
+    #[tracing::instrument(target = "r1cs", skip(cs, f))]
     fn new_proof_unchecked<T: Borrow<N::Proof>>(
         cs: impl Into<Namespace<ConstraintF>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -27,6 +28,7 @@ pub trait NIZKVerifierGadget<N: NIZK, ConstraintF: Field> {
     /// without performing subgroup checks.
     ///
     /// The default implementation doesn't omit these checks.
+    #[tracing::instrument(target = "r1cs", skip(cs, f))]
     fn new_verification_key_unchecked<T: Borrow<N::VerificationParameters>>(
         cs: impl Into<Namespace<ConstraintF>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,

--- a/crypto-primitives/src/nizk/mod.rs
+++ b/crypto-primitives/src/nizk/mod.rs
@@ -91,12 +91,7 @@ mod test {
                 let sum = cs.new_input_variable(|| Ok(self.sum.unwrap()))?;
                 let witness = cs.new_witness_variable(|| Ok(self.w.unwrap()))?;
 
-                cs.enforce_named_constraint(
-                    "enforce sum",
-                    lc!() + sum,
-                    lc!() + Variable::One,
-                    lc!() + input + witness,
-                )?;
+                cs.enforce_constraint(lc!() + sum, lc!() + Variable::One, lc!() + input + witness)?;
                 Ok(())
             }
         }

--- a/crypto-primitives/src/prf/constraints.rs
+++ b/crypto-primitives/src/prf/constraints.rs
@@ -2,7 +2,7 @@ use algebra_core::Field;
 use core::fmt::Debug;
 
 use crate::{prf::PRF, Vec};
-use r1cs_core::{ConstraintSystemRef, SynthesisError};
+use r1cs_core::{Namespace, SynthesisError};
 
 use r1cs_std::prelude::*;
 
@@ -14,7 +14,7 @@ pub trait PRFGadget<P: PRF, F: Field> {
         + Clone
         + Debug;
 
-    fn new_seed(cs: ConstraintSystemRef<F>, seed: &P::Seed) -> Vec<UInt8<F>>;
+    fn new_seed(cs: impl Into<Namespace<F>>, seed: &P::Seed) -> Vec<UInt8<F>>;
 
     fn evaluate(seed: &[UInt8<F>], input: &[UInt8<F>]) -> Result<Self::OutputVar, SynthesisError>;
 }

--- a/crypto-primitives/src/signature/schnorr/constraints.rs
+++ b/crypto-primitives/src/signature/schnorr/constraints.rs
@@ -56,6 +56,7 @@ where
     type ParametersVar = ParametersVar<C, GC>;
     type PublicKeyVar = PublicKeyVar<C, GC>;
 
+    #[tracing::instrument(target = "r1cs", skip(parameters, public_key, randomness))]
     fn randomize(
         parameters: &Self::ParametersVar,
         public_key: &Self::PublicKeyVar,

--- a/dpc/Cargo.toml
+++ b/dpc/Cargo.toml
@@ -34,6 +34,8 @@ derivative = "2"
 
 [dev-dependencies]
 rand_xorshift = { version = "0.2" }
+tracing-subscriber = { version = "0.2" }
+tracing = { version = "0.1", default-features = false }
 
 ###############################################################################
 

--- a/dpc/src/constraints/plain_dpc.rs
+++ b/dpc/src/constraints/plain_dpc.rs
@@ -170,37 +170,37 @@ where
         sn_nonce_crh_pp,
         ledger_pp,
     ) = {
-        let _ns = cs.ns("Declare Comm and CRH parameters");
+        let _ns = r1cs_core::ns!(cs, "Declare Comm and CRH parameters");
         let addr_comm_pp = AddrCGadget::ParametersVar::new_constant(
-            cs.ns("Declare Addr Comm parameters"),
+            r1cs_core::ns!(cs, "Declare Addr Comm parameters"),
             &comm_crh_parameters.addr_comm_pp,
         )?;
 
         let rec_comm_pp = RecCGadget::ParametersVar::new_constant(
-            cs.ns("Declare Rec Comm parameters"),
+            r1cs_core::ns!(cs, "Declare Rec Comm parameters"),
             &comm_crh_parameters.rec_comm_pp,
         )?;
 
         let local_data_comm_pp =
             <C::LocalDataCommGadget as CommitmentGadget<_, _>>::ParametersVar::new_constant(
-                cs.ns("Declare Local Data Comm parameters"),
+                r1cs_core::ns!(cs, "Declare Local Data Comm parameters"),
                 &comm_crh_parameters.local_data_comm_pp,
             )?;
 
         let pred_vk_comm_pp =
             <C::PredVkCommGadget as CommitmentGadget<_, C::CoreCheckF>>::ParametersVar::new_constant(
-                cs.ns("Declare Pred Vk COMM parameters"),
+                r1cs_core::ns!(cs, "Declare Pred Vk COMM parameters"),
                 &comm_crh_parameters.pred_vk_comm_pp,
             )?;
 
         let sn_nonce_crh_pp = SnNonceHGadget::ParametersVar::new_constant(
-            cs.ns("Declare SN Nonce CRH parameters"),
+            r1cs_core::ns!(cs, "Declare SN Nonce CRH parameters"),
             &comm_crh_parameters.sn_nonce_crh_pp,
         )?;
 
         let ledger_pp =
             <C::MerkleTreeHGadget as FixedLengthCRHGadget<_, _>>::ParametersVar::new_constant(
-                cs.ns("Declare Ledger Parameters"),
+                r1cs_core::ns!(cs, "Declare Ledger Parameters"),
                 ledger_parameters,
             )?;
         (
@@ -214,18 +214,17 @@ where
     };
 
     let digest_gadget = <C::MerkleTreeHGadget as FixedLengthCRHGadget<_, _>>::OutputVar::new_input(
-        cs.ns("Declare ledger digest"),
+        r1cs_core::ns!(cs, "Declare ledger digest"),
         || Ok(ledger_digest),
     )?;
 
-    for (i, (((record, witness), secret_key), given_serial_number)) in old_records
+    for (((record, witness), secret_key), given_serial_number) in old_records
         .iter()
         .zip(old_witnesses)
         .zip(old_address_secret_keys)
         .zip(old_serial_numbers)
-        .enumerate()
     {
-        let _input_ns = cs.ns(format!("Process input record {}", i));
+        let _input_ns = r1cs_core::ns!(cs, "Process input record");
         // Declare record contents
         let (
             given_apk,
@@ -237,46 +236,53 @@ where
             given_comm_rand,
             sn_nonce,
         ) = {
-            let _declare_ns = cs.ns("Declare input record");
+            let _declare_ns = r1cs_core::ns!(cs, "Declare input record");
             // No need to check that commitments, public keys and hashes are in
             // prime order subgroup because the commitment and CRH parameters
             // are trusted, and so when we recompute these, the newly computed
             // values will always be in correct subgroup. If the input cm, pk
             // or hash is incorrect, then it will not match the computed equivalent.
-            let given_apk = AddrCGadget::OutputVar::new_witness(cs.ns("Addr PubKey"), || {
-                Ok(&record.address_public_key().public_key)
-            })?;
+            let given_apk =
+                AddrCGadget::OutputVar::new_witness(r1cs_core::ns!(cs, "Addr PubKey"), || {
+                    Ok(&record.address_public_key().public_key)
+                })?;
             old_apks.push(given_apk.clone());
 
             let given_commitment =
-                RecCGadget::OutputVar::new_witness(
-                    cs.ns("Commitment"),
-                    || Ok(record.commitment()),
-                )?;
+                RecCGadget::OutputVar::new_witness(r1cs_core::ns!(cs, "Commitment"), || {
+                    Ok(record.commitment())
+                })?;
             old_rec_comms.push(given_commitment.clone());
 
-            let given_is_dummy = Boolean::new_witness(cs.ns("is_dummy"), || Ok(record.is_dummy()))?;
+            let given_is_dummy =
+                Boolean::new_witness(r1cs_core::ns!(cs, "is_dummy"), || Ok(record.is_dummy()))?;
             old_dummy_flags.push(given_is_dummy.clone());
 
-            let given_payload = UInt8::new_witness_vec(cs.ns("Payload"), record.payload())?;
+            let given_payload =
+                UInt8::new_witness_vec(r1cs_core::ns!(cs, "Payload"), record.payload())?;
             old_payloads.push(given_payload.clone());
 
-            let given_birth_pred_hash =
-                UInt8::new_witness_vec(cs.ns("Birth predicate"), &record.birth_predicate_repr())?;
+            let given_birth_pred_hash = UInt8::new_witness_vec(
+                r1cs_core::ns!(cs, "Birth predicate"),
+                &record.birth_predicate_repr(),
+            )?;
             old_birth_pred_hashes.push(given_birth_pred_hash.clone());
 
-            let given_death_pred_hash =
-                UInt8::new_witness_vec(cs.ns("Death predicate"), &record.death_predicate_repr())?;
+            let given_death_pred_hash = UInt8::new_witness_vec(
+                r1cs_core::ns!(cs, "Death predicate"),
+                &record.death_predicate_repr(),
+            )?;
             old_death_pred_hashes.push(given_death_pred_hash.clone());
 
-            let given_comm_rand =
-                RecCGadget::RandomnessVar::new_witness(cs.ns("Commitment randomness"), || {
-                    Ok(record.commitment_randomness())
-                })?;
+            let given_comm_rand = RecCGadget::RandomnessVar::new_witness(
+                r1cs_core::ns!(cs, "Commitment randomness"),
+                || Ok(record.commitment_randomness()),
+            )?;
 
-            let sn_nonce = SnNonceHGadget::OutputVar::new_witness(cs.ns("Sn nonce"), || {
-                Ok(record.serial_number_nonce())
-            })?;
+            let sn_nonce =
+                SnNonceHGadget::OutputVar::new_witness(r1cs_core::ns!(cs, "Sn nonce"), || {
+                    Ok(record.serial_number_nonce())
+                })?;
             (
                 given_apk,
                 given_commitment,
@@ -295,11 +301,11 @@ where
         // transaction set digest.
         // ********************************************************************
         {
-            let _witness_ns = cs.ns("Check membership witness");
+            let _witness_ns = r1cs_core::ns!(cs, "Check membership witness");
 
             let witness =
                 merkle_tree::constraints::PathVar::<_, C::MerkleTreeHGadget, _>::new_witness(
-                    cs.ns("Declare witness"),
+                    r1cs_core::ns!(cs, "Declare witness"),
                     || Ok(witness),
                 )?;
 
@@ -317,12 +323,16 @@ where
 
         let sk_prf = {
             // Declare variables for addr_sk contents.
-            let _address_ns = cs.ns("Check address keypair");
+            let _address_ns = r1cs_core::ns!(cs, "Check address keypair");
             let sk_prf = PGadget::new_seed(cs.clone(), &secret_key.sk_prf);
-            let metadata = UInt8::new_witness_vec(cs.ns("Declare metadata"), &secret_key.metadata)?;
-            let r_pk = AddrCGadget::RandomnessVar::new_witness(cs.ns("Declare r_pk"), || {
-                Ok(&secret_key.r_pk)
-            })?;
+            let metadata = UInt8::new_witness_vec(
+                r1cs_core::ns!(cs, "Declare metadata"),
+                &secret_key.metadata,
+            )?;
+            let r_pk = AddrCGadget::RandomnessVar::new_witness(
+                r1cs_core::ns!(cs, "Declare r_pk"),
+                || Ok(&secret_key.r_pk),
+            )?;
 
             let mut apk_input = sk_prf.clone();
             apk_input.extend_from_slice(&metadata);
@@ -338,17 +348,17 @@ where
         // Check that the serial number is derived correctly.
         // ********************************************************************
         let sn_nonce_bytes = {
-            let _sn_ns = cs.ns("Check that sn is derived correctly");
+            let _sn_ns = r1cs_core::ns!(cs, "Check that sn is derived correctly");
 
             let sn_nonce_bytes = sn_nonce.to_bytes()?;
 
             let prf_seed = sk_prf;
             let candidate_serial_number = PGadget::evaluate(&prf_seed, &sn_nonce_bytes)?;
 
-            let given_sn =
-                PGadget::OutputVar::new_input(cs.ns("Declare given serial number"), || {
-                    Ok(given_serial_number)
-                })?;
+            let given_sn = PGadget::OutputVar::new_input(
+                r1cs_core::ns!(cs, "Declare given serial number"),
+                || Ok(given_serial_number),
+            )?;
 
             candidate_serial_number.enforce_equal(&given_sn)?;
             old_sns.push(candidate_serial_number);
@@ -358,7 +368,7 @@ where
 
         // Check that the record is well-formed.
         {
-            let _comm_ns = cs.ns("Check that record is well-formed");
+            let _comm_ns = r1cs_core::ns!(cs, "Check that record is well-formed");
             let apk_bytes = given_apk.to_bytes()?;
             let is_dummy_bytes = given_is_dummy.to_bytes()?;
 
@@ -376,7 +386,7 @@ where
     }
 
     let sn_nonce_input = {
-        let _ns = cs.ns("Convert input serial numbers to bytes");
+        let _ns = r1cs_core::ns!(cs, "Convert input serial numbers to bytes");
         let mut sn_nonce_input = Vec::new();
         for (_i, old_sn) in old_sns.iter().enumerate() {
             let bytes = old_sn.to_bytes()?;
@@ -391,7 +401,7 @@ where
         .zip(new_commitments)
         .enumerate()
     {
-        let _ns = cs.ns(format!("Process output record {}", j));
+        let _ns = r1cs_core::ns!(cs, "Process output record");
         let j = j as u8;
 
         let (
@@ -405,40 +415,50 @@ where
             given_comm_rand,
             sn_nonce,
         ) = {
-            let _declare_ns = cs.ns("Declare output record");
-            let given_apk = AddrCGadget::OutputVar::new_witness(cs.ns("Addr PubKey"), || {
-                Ok(&record.address_public_key().public_key)
-            })?;
-            new_apks.push(given_apk.clone());
-            let given_record_comm =
-                RecCGadget::OutputVar::new_witness(cs.ns("Record Commitment"), || {
-                    Ok(record.commitment())
+            let _declare_ns = r1cs_core::ns!(cs, "Declare output record");
+            let given_apk =
+                AddrCGadget::OutputVar::new_witness(r1cs_core::ns!(cs, "Addr PubKey"), || {
+                    Ok(&record.address_public_key().public_key)
                 })?;
+            new_apks.push(given_apk.clone());
+            let given_record_comm = RecCGadget::OutputVar::new_witness(
+                r1cs_core::ns!(cs, "Record Commitment"),
+                || Ok(record.commitment()),
+            )?;
             new_rec_comms.push(given_record_comm.clone());
             let given_comm =
-                RecCGadget::OutputVar::new_input(cs.ns("Given Commitment"), || Ok(commitment))?;
-
-            let given_is_dummy = Boolean::new_witness(cs.ns("is_dummy"), || Ok(record.is_dummy()))?;
-            new_dummy_flags.push(given_is_dummy.clone());
-
-            let given_payload = UInt8::new_witness_vec(cs.ns("Payload"), record.payload())?;
-            new_payloads.push(given_payload.clone());
-
-            let given_birth_pred_hash =
-                UInt8::new_witness_vec(cs.ns("Birth predicate"), &record.birth_predicate_repr())?;
-            new_birth_pred_hashes.push(given_birth_pred_hash.clone());
-            let given_death_pred_hash =
-                UInt8::new_witness_vec(cs.ns("Death predicate"), &record.death_predicate_repr())?;
-            new_death_pred_hashes.push(given_death_pred_hash.clone());
-
-            let given_comm_rand =
-                RecCGadget::RandomnessVar::new_witness(cs.ns("Commitment randomness"), || {
-                    Ok(record.commitment_randomness())
+                RecCGadget::OutputVar::new_input(r1cs_core::ns!(cs, "Given Commitment"), || {
+                    Ok(commitment)
                 })?;
 
-            let sn_nonce = SnNonceHGadget::OutputVar::new_witness(cs.ns("Sn nonce"), || {
-                Ok(record.serial_number_nonce())
-            })?;
+            let given_is_dummy =
+                Boolean::new_witness(r1cs_core::ns!(cs, "is_dummy"), || Ok(record.is_dummy()))?;
+            new_dummy_flags.push(given_is_dummy.clone());
+
+            let given_payload =
+                UInt8::new_witness_vec(r1cs_core::ns!(cs, "Payload"), record.payload())?;
+            new_payloads.push(given_payload.clone());
+
+            let given_birth_pred_hash = UInt8::new_witness_vec(
+                r1cs_core::ns!(cs, "Birth predicate"),
+                &record.birth_predicate_repr(),
+            )?;
+            new_birth_pred_hashes.push(given_birth_pred_hash.clone());
+            let given_death_pred_hash = UInt8::new_witness_vec(
+                r1cs_core::ns!(cs, "Death predicate"),
+                &record.death_predicate_repr(),
+            )?;
+            new_death_pred_hashes.push(given_death_pred_hash.clone());
+
+            let given_comm_rand = RecCGadget::RandomnessVar::new_witness(
+                r1cs_core::ns!(cs, "Commitment randomness"),
+                || Ok(record.commitment_randomness()),
+            )?;
+
+            let sn_nonce =
+                SnNonceHGadget::OutputVar::new_witness(r1cs_core::ns!(cs, "Sn nonce"), || {
+                    Ok(record.serial_number_nonce())
+                })?;
 
             (
                 given_apk,
@@ -457,13 +477,13 @@ where
         // Check that the serial number nonce is computed correctly.
         // *******************************************************************
         {
-            let _sn_ns = cs.ns("Check that serial number nonce is computed correctly");
+            let _sn_ns = r1cs_core::ns!(cs, "Check that serial number nonce is computed correctly");
 
             let cur_record_num = UInt8::constant(j);
             let mut cur_record_num_bytes_le = vec![cur_record_num];
 
             let sn_nonce_randomness = UInt8::new_witness_vec(
-                cs.ns("Allocate serial number nonce randomness"),
+                r1cs_core::ns!(cs, "Allocate serial number nonce randomness"),
                 sn_nonce_rand,
             )?;
             cur_record_num_bytes_le.extend_from_slice(&sn_nonce_randomness);
@@ -480,7 +500,7 @@ where
         // Check that the record is well-formed.
         // *******************************************************************
         {
-            let _comm_ns = cs.ns("Check that record is well-formed");
+            let _comm_ns = r1cs_core::ns!(cs, "Check that record is well-formed");
             let apk_bytes = given_apk.to_bytes()?;
             let is_dummy_bytes = given_is_dummy.to_bytes()?;
             let sn_nonce_bytes = sn_nonce.to_bytes()?;
@@ -503,7 +523,7 @@ where
     // Check that predicate commitment is well formed.
     // *******************************************************************
     {
-        let _comm_ns = cs.ns("Check that predicate commitment is well-formed");
+        let _comm_ns = r1cs_core::ns!(cs, "Check that predicate commitment is well-formed");
 
         let mut input = Vec::new();
         for i in 0..C::NUM_INPUT_RECORDS {
@@ -516,13 +536,13 @@ where
 
         let given_comm_rand =
         <C::PredVkCommGadget as CommitmentGadget<_, C::CoreCheckF>>::RandomnessVar::new_witness(
-            cs.ns("Commitment randomness"),
+            r1cs_core::ns!(cs, "Commitment randomness"),
             || Ok(predicate_rand),
         )?;
 
         let given_comm =
             <C::PredVkCommGadget as CommitmentGadget<_, C::CoreCheckF>>::OutputVar::new_input(
-                cs.ns("Commitment output"),
+                r1cs_core::ns!(cs, "Commitment output"),
                 || Ok(predicate_comm),
             )?;
 
@@ -536,11 +556,11 @@ where
         candidate_commitment.enforce_equal(&given_comm)?;
     }
     {
-        let _ns = cs.ns("Check that local data commitment is valid.");
+        let _ns = r1cs_core::ns!(cs, "Check that local data commitment is valid.");
 
         let mut local_data_bytes = Vec::new();
         for i in 0..C::NUM_INPUT_RECORDS {
-            let _ns = cs.ns(format!("Construct local data with Input Record {}", i));
+            let _ns = r1cs_core::ns!(cs, "Construct local data with Input Record");
             local_data_bytes.extend_from_slice(&old_rec_comms[i].to_bytes()?);
             local_data_bytes.extend_from_slice(&old_apks[i].to_bytes()?);
             local_data_bytes.extend_from_slice(&old_dummy_flags[i].to_bytes()?);
@@ -551,7 +571,7 @@ where
         }
 
         for j in 0..C::NUM_OUTPUT_RECORDS {
-            let _ns = cs.ns(format!("Construct local data with Output Record {}", j));
+            let _ns = r1cs_core::ns!(cs, "Construct local data with Output Record");
             local_data_bytes.extend_from_slice(&new_rec_comms[j].to_bytes()?);
             local_data_bytes.extend_from_slice(&new_apks[j].to_bytes()?);
             local_data_bytes.extend_from_slice(&new_dummy_flags[j].to_bytes()?);
@@ -559,21 +579,22 @@ where
             local_data_bytes.extend_from_slice(&new_birth_pred_hashes[j]);
             local_data_bytes.extend_from_slice(&new_death_pred_hashes[j]);
         }
-        let memo = UInt8::new_input_vec(cs.ns("Allocate memorandum"), memo)?;
+        let memo = UInt8::new_input_vec(r1cs_core::ns!(cs, "Allocate memorandum"), memo)?;
         local_data_bytes.extend_from_slice(&memo);
 
-        let auxiliary = UInt8::new_witness_vec(cs.ns("Allocate auxiliary input"), auxiliary)?;
+        let auxiliary =
+            UInt8::new_witness_vec(r1cs_core::ns!(cs, "Allocate auxiliary input"), auxiliary)?;
         local_data_bytes.extend_from_slice(&auxiliary);
 
         let local_data_comm_rand =
             <C::LocalDataCommGadget as CommitmentGadget<_, _>>::RandomnessVar::new_witness(
-                cs.ns("Allocate local data commitment randomness"),
+                r1cs_core::ns!(cs, "Allocate local data commitment randomness"),
                 || Ok(local_data_rand),
             )?;
 
         let declared_local_data_comm =
             <C::LocalDataCommGadget as CommitmentGadget<_, _>>::OutputVar::new_input(
-                cs.ns("Allocate local data commitment"),
+                r1cs_core::ns!(cs, "Allocate local data commitment"),
                 || Ok(local_data_comm),
             )?;
 
@@ -611,16 +632,16 @@ where
 {
     // Declare public parameters.
     let (pred_vk_comm_pp, pred_vk_crh_pp) = {
-        let _ns = cs.ns("Declare Comm and CRH parameters");
+        let _ns = r1cs_core::ns!(cs, "Declare Comm and CRH parameters");
 
         let pred_vk_comm_pp =
             <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckF>>::ParametersVar::new_constant(
-                cs.ns("Declare Pred Vk COMM parameters"),
+                r1cs_core::ns!(cs, "Declare Pred Vk COMM parameters"),
                 &comm_crh_parameters.pred_vk_comm_pp,
             )?;
 
         let pred_vk_crh_pp = <C::PredVkHGadget as FixedLengthCRHGadget<_, C::ProofCheckF>>::ParametersVar::new_constant(
-            cs.ns("Declare Pred Vk CRH parameters"),
+            r1cs_core::ns!(cs, "Declare Pred Vk CRH parameters"),
             &comm_crh_parameters.pred_vk_crh_pp,
         )?;
 
@@ -648,8 +669,14 @@ where
     ];
 
     let pred_input_bytes = [
-        UInt8::new_input_vec(cs.ns("Allocate local data pp "), &pred_input[0])?,
-        UInt8::new_input_vec(cs.ns("Allocate local data comm"), &pred_input[1])?,
+        UInt8::new_input_vec(
+            r1cs_core::ns!(cs, "Allocate local data pp "),
+            &pred_input[0],
+        )?,
+        UInt8::new_input_vec(
+            r1cs_core::ns!(cs, "Allocate local data comm"),
+            &pred_input[1],
+        )?,
     ];
 
     let pred_input_bits = [
@@ -662,37 +689,37 @@ where
     let mut old_death_pred_hashes = Vec::new();
     let mut new_birth_pred_hashes = Vec::new();
     for i in 0..C::NUM_INPUT_RECORDS {
-        let _ns = cs.ns(format!("Check death predicate for input record {}", i));
+        let _ns = r1cs_core::ns!(cs, "Check death predicate for input record");
 
         let death_pred_proof =
             <C::PredicateNIZKGadget as NIZKVerifierGadget<_, _>>::ProofVar::new_witness(
-                cs.ns("Allocate proof"),
+                r1cs_core::ns!(cs, "Allocate proof"),
                 || Ok(&old_death_pred_vk_and_pf[i].proof),
             )?;
 
         let death_pred_vk =
             <C::PredicateNIZKGadget as NIZKVerifierGadget<_, _>>::new_verification_key_unchecked(
-                cs.ns("Allocate verification key"),
+                r1cs_core::ns!(cs, "Allocate verification key"),
                 || Ok(&old_death_pred_vk_and_pf[i].vk),
                 AllocationMode::Witness,
             )?;
 
-        let _ns = cs.ns("Convert vk to bytes");
+        let _ns = r1cs_core::ns!(cs, "Convert vk to bytes");
         let death_pred_vk_bytes = death_pred_vk.to_bytes()?;
         drop(_ns);
 
-        let _ns = cs.ns("Evaluate death predicate hash");
+        let _ns = r1cs_core::ns!(cs, "Evaluate death predicate hash");
         let claimed_death_pred_hash =
             C::PredVkHGadget::evaluate(&pred_vk_crh_pp, &death_pred_vk_bytes)?;
         drop(_ns);
 
-        let _ns = cs.ns("Convert death predicate hash to bytes");
+        let _ns = r1cs_core::ns!(cs, "Convert death predicate hash to bytes");
         let claimed_death_pred_hash_bytes = claimed_death_pred_hash.to_bytes()?;
         drop(_ns);
 
         old_death_pred_hashes.push(claimed_death_pred_hash_bytes);
 
-        let _ns = cs.ns("Verify death predicate");
+        let _ns = r1cs_core::ns!(cs, "Verify death predicate");
         let position = UInt8::constant(i as u8).to_bits_le()?;
         C::PredicateNIZKGadget::verify(
             &death_pred_vk,
@@ -705,37 +732,37 @@ where
     }
 
     for j in 0..C::NUM_OUTPUT_RECORDS {
-        let _ns = cs.ns(format!("Check birth predicate for output record {}", j));
+        let _ns = r1cs_core::ns!(cs, "Check birth predicate for output record");
 
         let birth_pred_proof =
             <C::PredicateNIZKGadget as NIZKVerifierGadget<_, _>>::ProofVar::new_witness(
-                cs.ns("Allocate proof"),
+                r1cs_core::ns!(cs, "Allocate proof"),
                 || Ok(&new_birth_pred_vk_and_pf[j].proof),
             )?;
 
         let birth_pred_vk =
             <C::PredicateNIZKGadget as NIZKVerifierGadget<_, _>>::new_verification_key_unchecked(
-                cs.ns("Allocate verification key"),
+                r1cs_core::ns!(cs, "Allocate verification key"),
                 || Ok(&new_birth_pred_vk_and_pf[j].vk),
                 AllocationMode::Witness,
             )?;
 
-        let _ns = cs.ns("Convert vk to bytes");
+        let _ns = r1cs_core::ns!(cs, "Convert vk to bytes");
         let birth_pred_vk_bytes = birth_pred_vk.to_bytes()?;
         drop(_ns);
 
-        let _ns = cs.ns("Evaluate birth predicate hash");
+        let _ns = r1cs_core::ns!(cs, "Evaluate birth predicate hash");
         let claimed_birth_pred_hash =
             C::PredVkHGadget::evaluate(&pred_vk_crh_pp, &birth_pred_vk_bytes)?;
         drop(_ns);
 
-        let _ns = cs.ns("Convert birth predicate hash to bytes");
+        let _ns = r1cs_core::ns!(cs, "Convert birth predicate hash to bytes");
         let claimed_birth_pred_hash_bytes = claimed_birth_pred_hash.to_bytes()?;
         drop(_ns);
 
         new_birth_pred_hashes.push(claimed_birth_pred_hash_bytes);
 
-        let _ns = cs.ns("Verify birth predicate");
+        let _ns = r1cs_core::ns!(cs, "Verify birth predicate");
         let position = UInt8::constant(j as u8).to_bits_le()?;
         C::PredicateNIZKGadget::verify(
             &birth_pred_vk,
@@ -747,7 +774,7 @@ where
         .enforce_equal(&Boolean::TRUE)?;
     }
     {
-        let _comm_ns = cs.ns("Check that predicate commitment is well-formed");
+        let _comm_ns = r1cs_core::ns!(cs, "Check that predicate commitment is well-formed");
 
         let mut input = Vec::new();
         for i in 0..C::NUM_INPUT_RECORDS {
@@ -760,13 +787,13 @@ where
 
         let given_comm_rand =
         <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckF>>::RandomnessVar::new_witness(
-            cs.ns("Commitment randomness"),
+            r1cs_core::ns!(cs, "Commitment randomness"),
             || Ok(predicate_rand),
         )?;
 
         let given_comm =
             <C::PredVkCommGadget as CommitmentGadget<_, C::ProofCheckF>>::OutputVar::new_input(
-                cs.ns("Commitment output"),
+                r1cs_core::ns!(cs, "Commitment output"),
                 || Ok(predicate_comm),
             )?;
 

--- a/dpc/src/dpc/delegable_dpc/mod.rs
+++ b/dpc/src/dpc/delegable_dpc/mod.rs
@@ -403,7 +403,7 @@ impl<Components: DelegableDPCComponents> DPC<Components> {
 
         // Compute the ledger membership witness and serial number from the old records.
         for (i, record) in old_records.iter().enumerate() {
-            let input_record_time = start_timer!(|| format!("Process input record {}", i));
+            let input_record_time = start_timer!(|| format!("Process input record"));
 
             if record.is_dummy() {
                 old_witnesses.push(merkle_tree::Path::default());

--- a/dpc/src/dpc/delegable_dpc/predicate_circuit.rs
+++ b/dpc/src/dpc/delegable_dpc/predicate_circuit.rs
@@ -158,10 +158,11 @@ impl<C: DelegableDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for EmptyPr
         self,
         cs: ConstraintSystemRef<C::CoreCheckF>,
     ) -> Result<(), SynthesisError> {
-        let _position = UInt8::new_input_vec(cs.ns("Alloc position"), &[self.position])?;
+        let _position =
+            UInt8::new_input_vec(r1cs_core::ns!(cs, "Alloc position"), &[self.position])?;
 
         <C::LocalDataCommGadget as CommitmentGadget<_, _>>::ParametersVar::new_constant(
-            cs.ns("Declare Pred Input Comm parameters"),
+            r1cs_core::ns!(cs, "Declare Pred Input Comm parameters"),
             self.comm_and_crh_parameters
                 .as_ref()
                 .get()?
@@ -171,7 +172,7 @@ impl<C: DelegableDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for EmptyPr
 
         let _local_data_comm =
             <C::LocalDataCommGadget as CommitmentGadget<_, _>>::OutputVar::new_witness(
-                cs.ns("Allocate predicate commitment"),
+                r1cs_core::ns!(cs, "Allocate predicate commitment"),
                 || self.local_data_comm.get(),
             )?;
 

--- a/dpc/src/dpc/delegable_dpc/test.rs
+++ b/dpc/src/dpc/delegable_dpc/test.rs
@@ -347,7 +347,7 @@ fn core_checks_gadget() {
     let mut core_cs = TestConstraintSystem::<Bls12_377>::new();
 
     execute_core_checks_gadget::<_, _>(
-        &mut core_cs.ns(|| "Core checks"),
+        &mut core_r1cs_core::ns!(cs, || "Core checks"),
         &comm_crh_sig_pp,
         ledger.parameters(),
         &ledger_digest,
@@ -496,7 +496,7 @@ fn proof_check_gadget() {
     let mut pf_check_cs = TestConstraintSystem::<CP6_782>::new();
 
     execute_proof_check_gadget::<_, _>(
-        &mut pf_check_cs.ns(|| "Check predicate proofs"),
+        &mut pf_check_r1cs_core::ns!(cs, || "Check predicate proofs"),
         &comm_crh_sig_pp,
         &old_proof_and_vk,
         &new_proof_and_vk,

--- a/dpc/src/dpc/plain_dpc/mod.rs
+++ b/dpc/src/dpc/plain_dpc/mod.rs
@@ -385,7 +385,7 @@ impl<Components: PlainDPCComponents> DPC<Components> {
 
         // Compute the ledger membership witness and serial number from the old records.
         for (i, record) in old_records.iter().enumerate() {
-            let input_record_time = start_timer!(|| format!("Process input record {}", i));
+            let input_record_time = start_timer!(|| format!("Process input record"));
 
             if record.is_dummy() {
                 old_witnesses.push(merkle_tree::Path::default());
@@ -410,7 +410,7 @@ impl<Components: PlainDPCComponents> DPC<Components> {
 
         // Generate new records and commitments for them.
         for j in 0..Components::NUM_OUTPUT_RECORDS {
-            let output_record_time = start_timer!(|| format!("Process output record {}", j));
+            let output_record_time = start_timer!(|| format!("Process output record"));
             let sn_nonce_time = start_timer!(|| "Generate serial number nonce");
 
             // Sample randomness sn_randomness for the CRH input.

--- a/dpc/src/dpc/plain_dpc/predicate_circuit.rs
+++ b/dpc/src/dpc/plain_dpc/predicate_circuit.rs
@@ -153,11 +153,12 @@ impl<C: PlainDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for EmptyPredic
         self,
         cs: ConstraintSystemRef<C::CoreCheckF>,
     ) -> Result<(), SynthesisError> {
-        let _position = UInt8::new_input_vec(cs.ns("Alloc position"), &[self.position])?;
+        let _position =
+            UInt8::new_input_vec(r1cs_core::ns!(cs, "Alloc position"), &[self.position])?;
 
         let _local_data_comm_pp =
             <C::LocalDataCommGadget as CommitmentGadget<_, _>>::ParametersVar::new_constant(
-                cs.ns("Declare Pred Input Comm parameters"),
+                r1cs_core::ns!(cs, "Declare Pred Input Comm parameters"),
                 self.comm_and_crh_parameters
                     .as_ref()
                     .get()?
@@ -167,7 +168,7 @@ impl<C: PlainDPCComponents> ConstraintSynthesizer<C::CoreCheckF> for EmptyPredic
 
         let _local_data_comm =
             <C::LocalDataCommGadget as CommitmentGadget<_, _>>::OutputVar::new_input(
-                cs.ns("Allocate predicate commitment"),
+                r1cs_core::ns!(cs, "Allocate predicate commitment"),
                 || self.local_data_comm.get(),
             )?;
 

--- a/dpc/src/predicates/plain_dpc/predicate_circuit.rs
+++ b/dpc/src/predicates/plain_dpc/predicate_circuit.rs
@@ -1,21 +1,16 @@
-use crate::plain_dpc::*;
-use crate::dpc::Record;
 use crate::common::ToConstraintField;
-use algebra::bytes::ToBytes;
-use std::io::{Write, Result as IoResult};
+use crate::constraints::Assignment;
 use crate::crypto_primitives::{CommitmentScheme, PRF};
 use crate::dpc::plain_dpc::DPCRecord;
-use r1cs_std::{utils::AllocGadget, uint8::UInt8};
-use crate::constraints::Assignment;
-
+use crate::dpc::Record;
+use crate::plain_dpc::*;
+use algebra::bytes::ToBytes;
+use r1cs_std::{uint8::UInt8, utils::AllocGadget};
+use std::io::{Result as IoResult, Write};
 
 use algebra::PairingEngine;
 
-use r1cs_core::{
-    ConstraintSynthesizer,
-    ConstraintSystem,
-    SynthesisError
-};
+use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
 
 use crate::Error;
 
@@ -24,35 +19,32 @@ pub struct ConserveCircuit<C: PlainDPCComponents> {
     comm_and_crh_parameters: Option<CommAndCRHPublicParameters<C>>,
 
     // Commitment to Predicate input.
-    local_data_comm:         Option<<C::LocalDataComm as CommitmentScheme>::Output>,
-    position:                u8,
+    local_data_comm: Option<<C::LocalDataComm as CommitmentScheme>::Output>,
+    position: u8,
 }
 
 impl<C: PlainDPCComponents> EmptyPredicateCircuit<C> {
-    pub fn blank(
-        comm_and_crh_parameters: &CommAndCRHPublicParameters<C>,
-    ) -> Self {
+    pub fn blank(comm_and_crh_parameters: &CommAndCRHPublicParameters<C>) -> Self {
         let local_data_comm = <C::LocalDataComm as CommitmentScheme>::Output::default();
 
         Self {
             comm_and_crh_parameters: Some(comm_and_crh_parameters.clone()),
-            local_data_comm:         Some(local_data_comm),
-            position:                0u8,
+            local_data_comm: Some(local_data_comm),
+            position: 0u8,
         }
     }
 
     pub fn new(
         comm_amd_crh_parameters: &CommAndCRHPublicParameters<C>,
-        local_data_comm:         &<C::LocalDataComm as CommitmentScheme>::Output,
-        position:                u8
+        local_data_comm: &<C::LocalDataComm as CommitmentScheme>::Output,
+        position: u8,
     ) -> Self {
-
         Self {
             // Parameters
-            comm_and_crh_parameters:   Some(comm_amd_crh_parameters.clone()),
+            comm_and_crh_parameters: Some(comm_amd_crh_parameters.clone()),
 
             // Other stuff
-            local_data_comm:           Some(local_data_comm.clone()),
+            local_data_comm: Some(local_data_comm.clone()),
             position,
         }
     }
@@ -61,76 +53,88 @@ impl<C: PlainDPCComponents> EmptyPredicateCircuit<C> {
 impl<C: PlainDPCComponents> ConstraintSynthesizer<C::E> for EmptyPredicateCircuit<C> {
     fn generate_constraints<CS: ConstraintSystem<C::E>>(
         self,
-        cs: &mut CS
+        cs: &mut CS,
     ) -> Result<(), SynthesisError> {
-        let _position = UInt8::alloc_input_vec(
-            cs.ns(|| "Alloc position"),
-            &[self.position]
-        )?;
+        let _position =
+            UInt8::alloc_input_vec(r1cs_core::ns!(cs, || "Alloc position"), &[self.position])?;
 
         {
-            let mut cs = cs.ns(|| "Declare public parameters");
+            let mut cs = r1cs_core::ns!(cs, || "Declare public parameters");
             let _local_data_comm_pp = <C::LocalDataCommGadget as CommitmentGadget<_, _>>::ParametersGadget::alloc_input_from_value(
-                &mut cs.ns(|| "Declare Pred Input Comm parameters"),
+                &mut r1cs_core::ns!(cs, || "Declare Pred Input Comm parameters"),
                 || self.comm_and_crh_parameters.get().map(|pp| &pp.local_data_comm_pp),
             )?;
         }
-        
 
-        let _local_data_comm = <C::LocalDataCommGadget as CommitmentGadget<_, _>>::OutputGadget::alloc_from_value(
-            cs.ns(|| "Allocate predicate commitment"),
-            || self.local_data_comm.get()
-        )?;
+        let _local_data_comm =
+            <C::LocalDataCommGadget as CommitmentGadget<_, _>>::OutputGadget::alloc_from_value(
+                r1cs_core::ns!(cs, || "Allocate predicate commitment"),
+                || self.local_data_comm.get(),
+            )?;
 
         {
-            let mut cs = cs.ns(|| "Check that local data commitment is valid.");
+            let mut cs = r1cs_core::ns!(cs, || "Check that local data commitment is valid.");
 
             let mut local_data_bytes = Vec::new();
             for i in 0..C::NUM_INPUT_RECORDS {
-                let mut cs = cs.ns(|| format!("Construct local data with Input Record {}", i));
-                local_data_bytes.extend_from_slice(&old_rec_comms[i].to_bytes(&mut cs.ns(|| "Record Comm"))?);
-                local_data_bytes.extend_from_slice(&old_apks[i].to_bytes(&mut cs.ns(|| "Apk"))?);
-                local_data_bytes.extend_from_slice(&old_dummy_flags[i].to_bytes(&mut cs.ns(|| "IsDummy"))?);
+                let mut cs =
+                    r1cs_core::ns!(cs, || format!("Construct local data with Input Record"));
+                local_data_bytes.extend_from_slice(
+                    &old_rec_comms[i].to_bytes(&mut r1cs_core::ns!(cs, || "Record Comm"))?,
+                );
+                local_data_bytes
+                    .extend_from_slice(&old_apks[i].to_bytes(&mut r1cs_core::ns!(cs, || "Apk"))?);
+                local_data_bytes.extend_from_slice(
+                    &old_dummy_flags[i].to_bytes(&mut r1cs_core::ns!(cs, || "IsDummy"))?,
+                );
                 local_data_bytes.extend_from_slice(&old_payloads[i]);
                 local_data_bytes.extend_from_slice(&old_birth_pred_hashes[i]);
                 local_data_bytes.extend_from_slice(&old_death_pred_hashes[i]);
-                local_data_bytes.extend_from_slice(&old_sns[i].to_bytes(&mut cs.ns(|| "Sn"))?);
+                local_data_bytes
+                    .extend_from_slice(&old_sns[i].to_bytes(&mut r1cs_core::ns!(cs, || "Sn"))?);
             }
 
             for j in 0..C::NUM_OUTPUT_RECORDS {
-                let mut cs = cs.ns(|| format!("Construct local data with Output Record {}", j));
-                local_data_bytes.extend_from_slice(&new_rec_comms[j].to_bytes(&mut cs.ns(|| "Record Comm"))?);
-                local_data_bytes.extend_from_slice(&new_apks[j].to_bytes(&mut cs.ns(|| "Apk"))?);
-                local_data_bytes.extend_from_slice(&new_dummy_flags[j].to_bytes(&mut cs.ns(|| "IsDummy"))?);
+                let mut cs =
+                    r1cs_core::ns!(cs, || format!("Construct local data with Output Record"));
+                local_data_bytes.extend_from_slice(
+                    &new_rec_comms[j].to_bytes(&mut r1cs_core::ns!(cs, || "Record Comm"))?,
+                );
+                local_data_bytes
+                    .extend_from_slice(&new_apks[j].to_bytes(&mut r1cs_core::ns!(cs, || "Apk"))?);
+                local_data_bytes.extend_from_slice(
+                    &new_dummy_flags[j].to_bytes(&mut r1cs_core::ns!(cs, || "IsDummy"))?,
+                );
                 local_data_bytes.extend_from_slice(&new_payloads[j]);
                 local_data_bytes.extend_from_slice(&new_birth_pred_hashes[j]);
                 local_data_bytes.extend_from_slice(&new_death_pred_hashes[j]);
             }
-            let memo = UInt8::alloc_input_vec(cs.ns(|| "Allocate memorandum"), memo)?;
+            let memo = UInt8::alloc_input_vec(r1cs_core::ns!(cs, || "Allocate memorandum"), memo)?;
             local_data_bytes.extend_from_slice(&memo);
 
-            let auxiliary = UInt8::alloc_vec(cs.ns(|| "Allocate auxiliary input"), auxiliary)?;
+            let auxiliary =
+                UInt8::alloc_vec(r1cs_core::ns!(cs, || "Allocate auxiliary input"), auxiliary)?;
             local_data_bytes.extend_from_slice(&auxiliary);
 
             let local_data_comm_rand = <C::LocalDataCommGadget as CommitmentGadget<_, _>>::RandomnessGadget::alloc_from_value(
-                cs.ns(|| "Allocate local data commitment randomness"),
+                r1cs_core::ns!(cs, || "Allocate local data commitment randomness"),
                 || Ok(local_data_rand)
             )?;
 
             let declared_local_data_comm = <C::LocalDataCommGadget as CommitmentGadget<_, _>>::OutputGadget::alloc_input_from_value(
-                cs.ns(|| "Allocate local data commitment"),
+                r1cs_core::ns!(cs, || "Allocate local data commitment"),
                 || self.local_data_comm.get()
             )?;
 
             let comm = C::LocalDataCommGadget::check_commitment_gadget(
-                cs.ns(|| "Commit to local data"),
+                r1cs_core::ns!(cs, || "Commit to local data"),
                 &local_data_comm_pp,
                 &local_data_bytes,
                 &local_data_comm_rand,
             )?;
 
             comm.enforce_equal(
-                &mut cs.ns(|| "Check that local data commitment is valid"),
+                &mut r1cs_core::ns!(cs, || "Check that local data commitment is valid"),
                 &declared_local_data_comm,
             )?;
         }

--- a/gm17/examples/recursive-snark/constraints.rs
+++ b/gm17/examples/recursive-snark/constraints.rs
@@ -89,8 +89,7 @@ impl<F: Field> ConstraintSynthesizer<F> for InnerCircuit<F> {
                 let (input_2_val, input_2_var) = variables[i + 1];
                 let result_val = input_1_val * input_2_val;
                 let result_var = cs.new_witness_variable(|| Ok(result_val))?;
-                cs.enforce_named_constraint(
-                    format!("Enforce constraint {}", i),
+                cs.enforce_constraint(
                     lc!() + input_1_var,
                     lc!() + input_2_var,
                     lc!() + result_var,
@@ -183,7 +182,7 @@ where
         let input_gadgets;
 
         {
-            let ns = cs.ns("Allocate Input");
+            let ns = r1cs_core::ns!(cs, "Allocate Input");
             let cs = ns.cs();
             // Chain all input values in one large byte array.
             let input_bytes = inputs
@@ -199,7 +198,7 @@ where
                 .collect::<Vec<_>>();
 
             // Allocate this byte array as input packed into field elements.
-            let input_bytes = UInt8::new_input_vec(cs.ns("Input"), &input_bytes[..])?;
+            let input_bytes = UInt8::new_input_vec(r1cs_core::ns!(cs, "Input"), &input_bytes[..])?;
             // 40 byte
             let element_size =
                 <<<C::TickGroup as PairingEngine>::Fr as PrimeField>::Params as FftParameters>::BigInt::NUM_LIMBS * 8;
@@ -219,9 +218,12 @@ where
             num_constraints
         );
 
-        let vk_var = InnerVkVar::<C, TickPairing>::new_witness(cs.ns("Vk"), || Ok(&params.vk))?;
+        let vk_var =
+            InnerVkVar::<C, TickPairing>::new_witness(r1cs_core::ns!(cs, "Vk"), || Ok(&params.vk))?;
         let proof_var =
-            InnerProofVar::<C, TickPairing>::new_witness(cs.ns("Proof"), || Ok(proof.clone()))?;
+            InnerProofVar::<C, TickPairing>::new_witness(r1cs_core::ns!(cs, "Proof"), || {
+                Ok(proof.clone())
+            })?;
         <InnerVerifierGadget<C, TickPairing> as NIZKVerifierGadget<
             InnerProofSystem<C>,
             <C::TockGroup as PairingEngine>::Fr,
@@ -302,11 +304,11 @@ where
             let bigint_size =
                 <<C::TickGroup as PairingEngine>::Fr as PrimeField>::BigInt::NUM_LIMBS * 64;
             let mut input_bits = Vec::new();
-            let ns = cs.ns("Allocate Input");
+            let ns = r1cs_core::ns!(cs, "Allocate Input");
             let cs = ns.cs();
 
-            for (i, input) in inputs.into_iter().enumerate() {
-                let input_gadget = FpVar::new_input(cs.ns(format!("Input {}", i)), || Ok(input))?;
+            for input in inputs.into_iter() {
+                let input_gadget = FpVar::new_input(r1cs_core::ns!(cs, "Input"), || Ok(input))?;
                 let mut fp_bits = input_gadget.to_bits_le()?;
 
                 // Use 320 bits per element.
@@ -338,9 +340,15 @@ where
             num_constraints
         );
 
-        let vk_var = MiddleVkVar::<C, TockPairing>::new_witness(cs.ns("Vk"), || Ok(&params.vk))?;
+        let vk_var =
+            MiddleVkVar::<C, TockPairing>::new_witness(
+                r1cs_core::ns!(cs, "Vk"),
+                || Ok(&params.vk),
+            )?;
         let proof_var =
-            MiddleProofVar::<C, TockPairing>::new_witness(cs.ns("Proof"), || Ok(proof.clone()))?;
+            MiddleProofVar::<C, TockPairing>::new_witness(r1cs_core::ns!(cs, "Proof"), || {
+                Ok(proof.clone())
+            })?;
         <MiddleVerifierGadget<C, TockPairing> as NIZKVerifierGadget<
             MiddleProofSystem<C, TickPairing>,
             <C::TickGroup as PairingEngine>::Fr,

--- a/gm17/examples/snark-scalability/constraints.rs
+++ b/gm17/examples/snark-scalability/constraints.rs
@@ -34,12 +34,7 @@ impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
                 let c_val = a_val * &b_val;
                 let c_var = cs.new_witness_variable(|| Ok(c_val))?;
 
-                cs.enforce_named_constraint(
-                    format!("{}: a * b = c", i),
-                    lc!() + a_var,
-                    lc!() + b_var,
-                    lc!() + c_var,
-                )?;
+                cs.enforce_constraint(lc!() + a_var, lc!() + b_var, lc!() + c_var)?;
 
                 assignments.push((c_val, c_var));
                 a_val = b_val;
@@ -50,12 +45,7 @@ impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
                 let c_val = a_val + &b_val;
                 let c_var = cs.new_witness_variable(|| Ok(c_val))?;
 
-                cs.enforce_named_constraint(
-                    format!("{}: a + b = c", i),
-                    lc!() + a_var + b_var,
-                    lc!() + Variable::One,
-                    lc!() + c_var,
-                )?;
+                cs.enforce_constraint(lc!() + a_var + b_var, lc!() + Variable::One, lc!() + c_var)?;
 
                 assignments.push((c_val, c_var));
                 a_val = b_val;
@@ -78,12 +68,7 @@ impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
 
         let c_var = cs.new_witness_variable(|| Ok(c_val))?;
 
-        cs.enforce_named_constraint(
-            "assignments.sum().square()",
-            lc!() + a_lc,
-            lc!() + b_lc,
-            lc!() + c_var,
-        )?;
+        cs.enforce_constraint(lc!() + a_lc, lc!() + b_lc, lc!() + c_var)?;
 
         Ok(())
     }

--- a/gm17/src/test.rs
+++ b/gm17/src/test.rs
@@ -21,12 +21,12 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<C
             Ok(a)
         })?;
 
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
 
         Ok(())
     }

--- a/gm17/tests/mimc.rs
+++ b/gm17/tests/mimc.rs
@@ -98,7 +98,7 @@ impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
 
         for i in 0..MIMC_ROUNDS {
             // xL, xR := xR + (xL + Ci)^3, xL
-            let ns = cs.ns(format!("round {}", i));
+            let ns = r1cs_core::ns!(cs, "round");
             let cs = ns.cs();
 
             // tmp = (xL + Ci)^2
@@ -110,8 +110,7 @@ impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
             let tmp =
                 cs.new_witness_variable(|| tmp_value.ok_or(SynthesisError::AssignmentMissing))?;
 
-            cs.enforce_named_constraint(
-                "tmp = (xL + Ci)^2",
+            cs.enforce_constraint(
                 lc!() + xl + (self.constants[i], Variable::One),
                 lc!() + xl + (self.constants[i], Variable::One),
                 lc!() + tmp,
@@ -135,8 +134,7 @@ impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
                 cs.new_witness_variable(|| new_xl_value.ok_or(SynthesisError::AssignmentMissing))?
             };
 
-            cs.enforce_named_constraint(
-                "new_xL = xR + (xL + Ci)^3",
+            cs.enforce_constraint(
                 lc!() + tmp,
                 lc!() + xl + (self.constants[i], Variable::One),
                 lc!() + new_xl - xr,

--- a/groth16/examples/snark-scalability/constraints.rs
+++ b/groth16/examples/snark-scalability/constraints.rs
@@ -34,12 +34,7 @@ impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
                 let c_val = a_val * &b_val;
                 let c_var = cs.new_witness_variable(|| Ok(c_val))?;
 
-                cs.enforce_named_constraint(
-                    format!("{}: a * b = c", i),
-                    lc!() + a_var,
-                    lc!() + b_var,
-                    lc!() + c_var,
-                )?;
+                cs.enforce_constraint(lc!() + a_var, lc!() + b_var, lc!() + c_var)?;
 
                 assignments.push((c_val, c_var));
                 a_val = b_val;
@@ -50,12 +45,7 @@ impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
                 let c_val = a_val + &b_val;
                 let c_var = cs.new_witness_variable(|| Ok(c_val))?;
 
-                cs.enforce_named_constraint(
-                    format!("{}: a + b = c", i),
-                    lc!() + a_var + b_var,
-                    lc!() + Variable::One,
-                    lc!() + c_var,
-                )?;
+                cs.enforce_constraint(lc!() + a_var + b_var, lc!() + Variable::One, lc!() + c_var)?;
 
                 assignments.push((c_val, c_var));
                 a_val = b_val;
@@ -78,12 +68,7 @@ impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
 
         let c_var = cs.new_witness_variable(|| Ok(c_val))?;
 
-        cs.enforce_named_constraint(
-            "assignments.sum().square()",
-            lc!() + a_lc,
-            lc!() + b_lc,
-            lc!() + c_var,
-        )?;
+        cs.enforce_constraint(lc!() + a_lc, lc!() + b_lc, lc!() + c_var)?;
 
         Ok(())
     }

--- a/groth16/src/test.rs
+++ b/groth16/src/test.rs
@@ -20,12 +20,12 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<C
             Ok(a)
         })?;
 
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
-        cs.enforce_named_constraint("a*b=c", lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
 
         Ok(())
     }

--- a/groth16/tests/mimc.rs
+++ b/groth16/tests/mimc.rs
@@ -98,7 +98,7 @@ impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
 
         for i in 0..MIMC_ROUNDS {
             // xL, xR := xR + (xL + Ci)^3, xL
-            let ns = cs.ns(format!("round {}", i));
+            let ns = r1cs_core::ns!(cs, "round");
             let cs = ns.cs();
 
             // tmp = (xL + Ci)^2
@@ -110,8 +110,7 @@ impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
             let tmp =
                 cs.new_witness_variable(|| tmp_value.ok_or(SynthesisError::AssignmentMissing))?;
 
-            cs.enforce_named_constraint(
-                "tmp = (xL + Ci)^2",
+            cs.enforce_constraint(
                 lc!() + xl + (self.constants[i], Variable::One),
                 lc!() + xl + (self.constants[i], Variable::One),
                 lc!() + tmp,
@@ -135,8 +134,7 @@ impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
                 cs.new_witness_variable(|| new_xl_value.ok_or(SynthesisError::AssignmentMissing))?
             };
 
-            cs.enforce_named_constraint(
-                "new_xL = xR + (xL + Ci)^3",
+            cs.enforce_constraint(
                 lc!() + tmp,
                 lc!() + xl + (self.constants[i], Variable::One),
                 lc!() + new_xl - xr,

--- a/r1cs-core/Cargo.toml
+++ b/r1cs-core/Cargo.toml
@@ -21,10 +21,12 @@ edition = "2018"
 
 [dependencies]
 algebra-core = { path = "../algebra-core", default-features = false }
+tracing = { version = "0.1", default-features = false, optional = true }
+tracing-subscriber = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 algebra = { path = "../algebra", default-features = false, features = [ "bls12_381" ] }
 
 [features]
 default = ["std"]
-std = ["algebra-core/std"]
+std = [ "algebra-core/std", "tracing-subscriber", "tracing/std" ]

--- a/r1cs-core/src/trace.rs
+++ b/r1cs-core/src/trace.rs
@@ -1,0 +1,328 @@
+// adapted from `tracing_error::{SpanTrace, ErrorLayer}`.
+
+use core::any::{type_name, TypeId};
+use core::fmt;
+use core::marker::PhantomData;
+use tracing::{span, Dispatch, Metadata, Subscriber};
+use tracing_subscriber::{
+    layer::{self, Layer},
+    registry::LookupSpan,
+};
+
+/// A subscriber [`Layer`] that enables capturing a trace of R1CS constraint generation.
+///
+/// [`Layer`]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/layer/trait.Layer.html
+/// [field formatter]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/trait.FormatFields.html
+/// [default format]: https://docs.rs/tracing-subscriber/0.2.10/tracing_subscriber/fmt/format/struct.DefaultFields.html
+pub struct ConstraintLayer<S> {
+    /// Mode of filtering.
+    pub mode: TracingMode,
+
+    get_context: WithContext,
+    _subscriber: PhantomData<fn(S)>,
+}
+
+/// Instructs `ConstraintLayer` to conditionally filter out spans.
+#[derive(PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
+pub enum TracingMode {
+    /// Instructs `ConstraintLayer` to filter out any spans that *do not* have `target == "r1cs"`.
+    OnlyConstraints,
+    /// Instructs `ConstraintLayer` to filter out any spans that *do* have `target == "r1cs"`.
+    NoConstraints,
+    /// Instructs `ConstraintLayer` to not filter out any spans.
+    All,
+}
+
+// this function "remembers" the types of the subscriber and the formatter,
+// so that we can downcast to something aware of them without knowing those
+// types at the callsite.
+pub(crate) struct WithContext(
+    fn(&Dispatch, &span::Id, f: &mut dyn FnMut(&'static Metadata<'static>, &str) -> bool),
+);
+
+impl<S> Layer<S> for ConstraintLayer<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn enabled(&self, metadata: &Metadata, _ctx: layer::Context<S>) -> bool {
+        match self.mode {
+            TracingMode::OnlyConstraints => metadata.target() == "r1cs",
+            TracingMode::NoConstraints => metadata.target() != "r1cs",
+            TracingMode::All => true,
+        }
+    }
+
+    /// Notifies this layer that a new span was constructed with the given
+    /// `Attributes` and `Id`.
+    fn new_span(&self, _attrs: &span::Attributes<'_>, _id: &span::Id, _ctx: layer::Context<'_, S>) {
+    }
+
+    #[allow(unsafe_code, trivial_casts)]
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        match id {
+            id if id == TypeId::of::<Self>() => Some(self as *const _ as *const ()),
+            id if id == TypeId::of::<WithContext>() => {
+                Some(&self.get_context as *const _ as *const ())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl<S> ConstraintLayer<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    /// Returns a new `ConstraintLayer`.
+    ///
+    /// If `mode == TracingMode::OnlyConstraints`, the resulting layer will
+    /// filter out any spans whose `target != "r1cs"`.
+    ///
+    /// If `mode == TracingMode::NoConstraints`, the resulting layer will
+    /// filter out any spans whose `target == "r1cs"`.
+    ///
+    /// Finally, if `mode == TracingMode::All`, the resulting layer will
+    /// not filter out any spans.
+    pub fn new(mode: TracingMode) -> Self {
+        Self {
+            mode,
+            get_context: WithContext(Self::get_context),
+            _subscriber: PhantomData,
+        }
+    }
+
+    fn get_context(
+        dispatch: &Dispatch,
+        id: &span::Id,
+        f: &mut dyn FnMut(&'static Metadata<'static>, &str) -> bool,
+    ) {
+        let subscriber = dispatch
+            .downcast_ref::<S>()
+            .expect("subscriber should downcast to expected type; this is a bug!");
+        let span = subscriber
+            .span(id)
+            .expect("registry should have a span for the current ID");
+        let parents = span.parents();
+        for span in std::iter::once(span).chain(parents) {
+            let cont = f(span.metadata(), "");
+            if !cont {
+                break;
+            }
+        }
+    }
+}
+
+impl WithContext {
+    pub(crate) fn with_context<'a>(
+        &self,
+        dispatch: &'a Dispatch,
+        id: &span::Id,
+        mut f: impl FnMut(&'static Metadata<'static>, &str) -> bool,
+    ) {
+        (self.0)(dispatch, id, &mut f)
+    }
+}
+
+impl<S> Default for ConstraintLayer<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn default() -> Self {
+        Self::new(TracingMode::All)
+    }
+}
+
+impl<S> fmt::Debug for ConstraintLayer<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConstraintLayer")
+            .field("subscriber", &format_args!("{}", type_name::<S>()))
+            .finish()
+    }
+}
+
+macro_rules! try_bool {
+    ($e:expr, $dest:ident) => {{
+        let ret = $e.unwrap_or_else(|e| $dest = Err(e));
+
+        if $dest.is_err() {
+            return false;
+        }
+
+        ret
+    }};
+}
+
+/// A captured trace of [`tracing`] spans that have `target = "r1cs"`.
+///
+/// This type can be thought of as a relative of
+/// [`std::backtrace::Backtrace`][`Backtrace`].
+/// However, rather than capturing the current call stack when it is
+/// constructed, a `ConstraintTrace` instead captures the current [span] and its
+/// [parents]. It allows inspection of the constraints that are left unsatisfied
+/// by a particular witness assignment to an R1CS instance.
+///
+/// # Formatting
+///
+/// The `ConstraintTrace` type implements `fmt::Display`, formatting the span trace
+/// similarly to how Rust formats panics. For example:
+///
+/// ```text
+///    0: r1cs-std::bits::something
+///           at r1cs-std/src/bits/test.rs:42
+///    1: r1cs-std::bits::another_thing
+///           at r1cs-std/src/bits/test.rs:15
+/// ```
+///
+/// [`tracing`]: https://docs.rs/tracing
+/// [`Backtrace`]: https://doc.rust-lang.org/std/backtrace/struct.Backtrace.html
+/// [span]: https://docs.rs/tracing/latest/tracing/span/index.html
+/// [parents]: https://docs.rs/tracing/latest/tracing/span/index.html#span-relationships
+#[derive(Clone, Debug)]
+pub struct ConstraintTrace {
+    span: span::Span,
+}
+
+// === impl ConstraintTrace ===
+
+impl ConstraintTrace {
+    /// Capture the current span trace.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use r1cs_core::ConstraintTrace;
+    ///
+    /// pub struct MyError {
+    ///     trace: Option<ConstraintTrace>,
+    ///     // ...
+    /// }
+    ///
+    /// # fn some_error_condition() -> bool { true }
+    ///
+    /// pub fn my_function(arg: &str) -> Result<(), MyError> {
+    ///     let _span = tracing::info_span!(target: "r1cs", "In my_function");
+    ///     let _guard = _span.enter();
+    ///     if some_error_condition() {
+    ///         return Err(MyError {
+    ///             trace: ConstraintTrace::capture(),
+    ///             // ...
+    ///         });
+    ///     }
+    ///
+    ///     // ...
+    /// #   Ok(())
+    /// }
+    /// ```
+    pub fn capture() -> Option<Self> {
+        let span = span::Span::current();
+
+        if span.is_none() {
+            None
+        } else {
+            let trace = Self { span };
+            Some(trace)
+        }
+    }
+
+    /// Apply a function to all captured spans in the trace until it returns
+    /// `false`.
+    ///
+    /// This will call the provided function with a reference to the
+    /// [`Metadata`] and a formatted representation of the [fields] of each span
+    /// captured in the trace, starting with the span that was current when the
+    /// trace was captured. The function may return `true` or `false` to
+    /// indicate whether to continue iterating over spans; if it returns
+    /// `false`, no additional spans will be visited.
+    ///
+    /// [fields]: https://docs.rs/tracing/latest/tracing/field/index.html
+    /// [`Metadata`]: https://docs.rs/tracing/latest/tracing/struct.Metadata.html
+    fn with_spans(&self, f: impl FnMut(&'static Metadata<'static>, &str) -> bool) {
+        self.span.with_subscriber(|(id, s)| {
+            if let Some(getcx) = s.downcast_ref::<WithContext>() {
+                getcx.with_context(s, id, f);
+            }
+        });
+    }
+
+    /// Compute a `Vec` of `TraceStep`s, one for each `Span` on the path from the root
+    /// `Span`.
+    ///
+    /// The output starts from the root of the span tree.
+    pub fn path(&self) -> Vec<TraceStep> {
+        let mut path = Vec::new();
+        self.with_spans(|metadata, _| {
+            if metadata.target() == "r1cs" {
+                let n = metadata.name();
+                let step = metadata
+                    .module_path()
+                    .map(|m| (n, m))
+                    .and_then(|(n, m)| metadata.file().map(|f| (n, m, f)))
+                    .and_then(|(n, m, f)| metadata.line().map(|l| (n, m, f, l)));
+                if let Some((name, module_path, file, line)) = step {
+                    let step = TraceStep {
+                        name,
+                        module_path,
+                        file,
+                        line,
+                    };
+                    path.push(step);
+                } else {
+                    return false;
+                }
+            }
+            true
+        });
+        path.reverse(); // root first
+        path
+    }
+}
+
+impl fmt::Display for ConstraintTrace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut err = Ok(());
+        let mut span = 0;
+
+        self.with_spans(|metadata, _| {
+            if metadata.target() != "r1cs" {
+                return true;
+            }
+            if span > 0 {
+                try_bool!(write!(f, "\n",), err);
+            }
+
+            try_bool!(
+                write!(
+                    f,
+                    "{:>4}: {}::{}",
+                    span,
+                    metadata.module_path().unwrap(),
+                    metadata.name()
+                ),
+                err
+            );
+
+            if let Some((file, line)) = metadata
+                .file()
+                .and_then(|file| metadata.line().map(|line| (file, line)))
+            {
+                try_bool!(write!(f, "\n             at {}:{}", file, line), err);
+            }
+
+            span += 1;
+            true
+        });
+
+        err
+    }
+}
+/// A step in the trace of a constraint generation step.
+#[derive(Debug, Clone, Copy)]
+pub struct TraceStep {
+    /// Name of the constraint generating span.
+    pub name: &'static str,
+    /// Name of the module containing the constraint generating span.
+    pub module_path: &'static str,
+    /// Name of the file containing the constraint generating span.
+    pub file: &'static str,
+    /// Line number of the constraint generating span.
+    pub line: u32,
+}

--- a/r1cs-std/Cargo.toml
+++ b/r1cs-std/Cargo.toml
@@ -25,6 +25,7 @@ edition = "2018"
 algebra = { path = "../algebra", default-features = false }
 r1cs-core = { path = "../r1cs-core", default-features = false }
 derivative = { version = "2", features = ["use_core"] }
+tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 
 [dev-dependencies]
 rand = { version = "0.7", default-features = false }

--- a/r1cs-std/src/alloc.rs
+++ b/r1cs-std/src/alloc.rs
@@ -34,6 +34,7 @@ where
         mode: AllocationMode,
     ) -> Result<Self, SynthesisError>;
 
+    #[tracing::instrument(target = "r1cs", skip(cs, t))]
     fn new_constant(
         cs: impl Into<Namespace<F>>,
         t: impl Borrow<V>,
@@ -41,6 +42,7 @@ where
         Self::new_variable(cs, || Ok(t), AllocationMode::Constant)
     }
 
+    #[tracing::instrument(target = "r1cs", skip(cs, f))]
     fn new_input<T: Borrow<V>>(
         cs: impl Into<Namespace<F>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -48,6 +50,7 @@ where
         Self::new_variable(cs, f, AllocationMode::Input)
     }
 
+    #[tracing::instrument(target = "r1cs", skip(cs, f))]
     fn new_witness<T: Borrow<V>>(
         cs: impl Into<Namespace<F>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,

--- a/r1cs-std/src/eq.rs
+++ b/r1cs-std/src/eq.rs
@@ -13,6 +13,7 @@ pub trait EqGadget<F: Field> {
 
     /// If `should_enforce == true`, enforce that `self` and `other` are equal; else,
     /// enforce a vacuously true statement.
+    #[tracing::instrument(target = "r1cs", skip(self, other))]
     fn conditional_enforce_equal(
         &self,
         other: &Self,
@@ -23,12 +24,14 @@ pub trait EqGadget<F: Field> {
     }
 
     /// Enforce that `self` and `other` are equal.
+    #[tracing::instrument(target = "r1cs", skip(self, other))]
     fn enforce_equal(&self, other: &Self) -> Result<(), SynthesisError> {
         self.conditional_enforce_equal(other, &Boolean::constant(true))
     }
 
     /// If `should_enforce == true`, enforce that `self` and `other` are not equal; else,
     /// enforce a vacuously true statement.
+    #[tracing::instrument(target = "r1cs", skip(self, other))]
     fn conditional_enforce_not_equal(
         &self,
         other: &Self,
@@ -39,12 +42,14 @@ pub trait EqGadget<F: Field> {
     }
 
     /// Enforce that `self` and `other` are not equal.
+    #[tracing::instrument(target = "r1cs", skip(self, other))]
     fn enforce_not_equal(&self, other: &Self) -> Result<(), SynthesisError> {
         self.conditional_enforce_not_equal(other, &Boolean::constant(true))
     }
 }
 
 impl<T: EqGadget<F> + R1CSVar<F>, F: Field> EqGadget<F> for [T] {
+    #[tracing::instrument(target = "r1cs", skip(self, other))]
     fn is_eq(&self, other: &Self) -> Result<Boolean<F>, SynthesisError> {
         assert_eq!(self.len(), other.len());
         assert!(!self.is_empty());
@@ -55,6 +60,7 @@ impl<T: EqGadget<F> + R1CSVar<F>, F: Field> EqGadget<F> for [T] {
         Boolean::kary_and(&results)
     }
 
+    #[tracing::instrument(target = "r1cs", skip(self, other))]
     fn conditional_enforce_equal(
         &self,
         other: &Self,
@@ -67,6 +73,7 @@ impl<T: EqGadget<F> + R1CSVar<F>, F: Field> EqGadget<F> for [T] {
         Ok(())
     }
 
+    #[tracing::instrument(target = "r1cs", skip(self, other))]
     fn conditional_enforce_not_equal(
         &self,
         other: &Self,

--- a/r1cs-std/src/fields/cubic_extension.rs
+++ b/r1cs-std/src/fields/cubic_extension.rs
@@ -147,6 +147,7 @@ where
     }
 
     #[inline]
+    #[tracing::instrument(target = "r1cs")]
     fn double(&self) -> Result<Self, SynthesisError> {
         let c0 = self.c0.double()?;
         let c1 = self.c1.double()?;
@@ -155,6 +156,7 @@ where
     }
 
     #[inline]
+    #[tracing::instrument(target = "r1cs")]
     fn negate(&self) -> Result<Self, SynthesisError> {
         let mut result = self.clone();
         result.c0.negate_in_place()?;
@@ -169,6 +171,7 @@ where
     /// Abstract Pairing-Friendly
     /// Fields.pdf; Section 4 (CH-SQR2))
     #[inline]
+    #[tracing::instrument(target = "r1cs")]
     fn square(&self) -> Result<Self, SynthesisError> {
         let a = self.c0.clone();
         let b = self.c1.clone();
@@ -188,6 +191,7 @@ where
         Ok(Self::new(c0, c1, c2))
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn mul_equals(&self, other: &Self, result: &Self) -> Result<(), SynthesisError> {
         // Karatsuba multiplication for cubic extensions:
         //     v0 = A.c0 * B.c0
@@ -237,6 +241,7 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn frobenius_map(&self, power: usize) -> Result<Self, SynthesisError> {
         let mut result = self.clone();
         result.c0.frobenius_map_in_place(power)?;
@@ -247,6 +252,7 @@ where
         Ok(result)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn inverse(&self) -> Result<Self, SynthesisError> {
         let cs = self.cs().get()?.clone();
         let one = Self::new_constant(cs.clone(), CubicExtField::one())?;
@@ -342,6 +348,7 @@ where
     for<'a> &'a BF: FieldOpsBounds<'a, P::BaseField, BF>,
     P: CubicExtVarParams<BF>,
 {
+    #[tracing::instrument(target = "r1cs")]
     fn is_eq(&self, other: &Self) -> Result<Boolean<P::BasePrimeField>, SynthesisError> {
         let b0 = self.c0.is_eq(&other.c0)?;
         let b1 = self.c1.is_eq(&other.c1)?;
@@ -350,6 +357,7 @@ where
     }
 
     #[inline]
+    #[tracing::instrument(target = "r1cs")]
     fn conditional_enforce_equal(
         &self,
         other: &Self,
@@ -362,6 +370,7 @@ where
     }
 
     #[inline]
+    #[tracing::instrument(target = "r1cs")]
     fn conditional_enforce_not_equal(
         &self,
         other: &Self,
@@ -380,6 +389,7 @@ where
     for<'a> &'a BF: FieldOpsBounds<'a, P::BaseField, BF>,
     P: CubicExtVarParams<BF>,
 {
+    #[tracing::instrument(target = "r1cs")]
     fn to_bits_le(&self) -> Result<Vec<Boolean<P::BasePrimeField>>, SynthesisError> {
         let mut c0 = self.c0.to_bits_le()?;
         let mut c1 = self.c1.to_bits_le()?;
@@ -389,6 +399,7 @@ where
         Ok(c0)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn to_non_unique_bits_le(&self) -> Result<Vec<Boolean<P::BasePrimeField>>, SynthesisError> {
         let mut c0 = self.c0.to_non_unique_bits_le()?;
         let mut c1 = self.c1.to_non_unique_bits_le()?;
@@ -405,6 +416,7 @@ where
     for<'a> &'a BF: FieldOpsBounds<'a, P::BaseField, BF>,
     P: CubicExtVarParams<BF>,
 {
+    #[tracing::instrument(target = "r1cs")]
     fn to_bytes(&self) -> Result<Vec<UInt8<P::BasePrimeField>>, SynthesisError> {
         let mut c0 = self.c0.to_bytes()?;
         let mut c1 = self.c1.to_bytes()?;
@@ -415,6 +427,7 @@ where
         Ok(c0)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn to_non_unique_bytes(&self) -> Result<Vec<UInt8<P::BasePrimeField>>, SynthesisError> {
         let mut c0 = self.c0.to_non_unique_bytes()?;
         let mut c1 = self.c1.to_non_unique_bytes()?;
@@ -434,6 +447,7 @@ where
     P: CubicExtVarParams<BF>,
 {
     #[inline]
+    #[tracing::instrument(target = "r1cs")]
     fn conditionally_select(
         cond: &Boolean<P::BasePrimeField>,
         true_value: &Self,
@@ -455,6 +469,7 @@ where
 {
     type TableConstant = CubicExtField<P>;
 
+    #[tracing::instrument(target = "r1cs")]
     fn two_bit_lookup(
         b: &[Boolean<P::BasePrimeField>],
         c: &[Self::TableConstant],
@@ -478,6 +493,7 @@ where
 {
     type TableConstant = CubicExtField<P>;
 
+    #[tracing::instrument(target = "r1cs")]
     fn three_bit_cond_neg_lookup(
         b: &[Boolean<P::BasePrimeField>],
         b0b1: &Boolean<P::BasePrimeField>,
@@ -517,9 +533,9 @@ where
             ),
         };
 
-        let c0 = BF::new_variable(cs.ns("c0"), || c0, mode)?;
-        let c1 = BF::new_variable(cs.ns("c1"), || c1, mode)?;
-        let c2 = BF::new_variable(cs.ns("c2"), || c2, mode)?;
+        let c0 = BF::new_variable(r1cs_core::ns!(cs, "c0"), || c0, mode)?;
+        let c1 = BF::new_variable(r1cs_core::ns!(cs, "c1"), || c1, mode)?;
+        let c2 = BF::new_variable(r1cs_core::ns!(cs, "c2"), || c2, mode)?;
         Ok(Self::new(c0, c1, c2))
     }
 }

--- a/r1cs-std/src/fields/fp/cmp.rs
+++ b/r1cs-std/src/fields/fp/cmp.rs
@@ -14,6 +14,7 @@ impl<F: PrimeField> FpVar<F> {
     /// also be checked for equality, e.g. `self <= other` instead of `self < other`, set
     /// `should_also_check_quality` to `true`. This variant verifies `self` and `other`
     /// are `<= (p-1)/2`.
+    #[tracing::instrument(target = "r1cs")]
     pub fn enforce_cmp(
         &self,
         other: &FpVar<F>,
@@ -29,6 +30,7 @@ impl<F: PrimeField> FpVar<F> {
     /// also be checked for equality, e.g. `self <= other` instead of `self < other`, set
     /// `should_also_check_quality` to `true`. This variant assumes `self` and `other`
     /// are `<= (p-1)/2` and does not generate constraints to verify that.
+    #[tracing::instrument(target = "r1cs")]
     pub fn enforce_cmp_unchecked(
         &self,
         other: &FpVar<F>,
@@ -45,6 +47,7 @@ impl<F: PrimeField> FpVar<F> {
     /// also be checked for equality, e.g. `self <= other` instead of `self < other`, set
     /// `should_also_check_quality` to `true`. This variant verifies `self` and `other`
     /// are `<= (p-1)/2`.
+    #[tracing::instrument(target = "r1cs")]
     pub fn is_cmp(
         &self,
         other: &FpVar<F>,
@@ -61,6 +64,7 @@ impl<F: PrimeField> FpVar<F> {
     /// also be checked for equality, e.g. `self <= other` instead of `self < other`, set
     /// `should_also_check_quality` to `true`. This variant assumes `self` and `other`
     /// are `<= (p-1)/2` and does not generate constraints to verify that.
+    #[tracing::instrument(target = "r1cs")]
     pub fn is_cmp_unchecked(
         &self,
         other: &FpVar<F>,
@@ -92,6 +96,7 @@ impl<F: PrimeField> FpVar<F> {
     }
 
     // Helper function to enforce `self <= (p-1)/2`.
+    #[tracing::instrument(target = "r1cs")]
     pub fn enforce_smaller_or_equal_than_mod_minus_one_div_two(
         &self,
     ) -> Result<(), SynthesisError> {
@@ -172,9 +177,9 @@ mod test {
         for i in 0..10 {
             let cs = ConstraintSystem::<Fr>::new_ref();
             let a = rand_in_range(&mut rng);
-            let a_var = FpVar::<Fr>::new_witness(cs.ns("a"), || Ok(a)).unwrap();
+            let a_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(a)).unwrap();
             let b = rand_in_range(&mut rng);
-            let b_var = FpVar::<Fr>::new_witness(cs.ns("b"), || Ok(b)).unwrap();
+            let b_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(b)).unwrap();
 
             match a.cmp(&b) {
                 Ordering::Less => {
@@ -198,9 +203,9 @@ mod test {
         for _i in 0..10 {
             let cs = ConstraintSystem::<Fr>::new_ref();
             let a = rand_in_range(&mut rng);
-            let a_var = FpVar::<Fr>::new_witness(cs.ns("a"), || Ok(a)).unwrap();
+            let a_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(a)).unwrap();
             let b = rand_in_range(&mut rng);
-            let b_var = FpVar::<Fr>::new_witness(cs.ns("b"), || Ok(b)).unwrap();
+            let b_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(b)).unwrap();
 
             match b.cmp(&a) {
                 Ordering::Less => {
@@ -220,7 +225,7 @@ mod test {
         for _i in 0..10 {
             let cs = ConstraintSystem::<Fr>::new_ref();
             let a = rand_in_range(&mut rng);
-            let a_var = FpVar::<Fr>::new_witness(cs.ns("a"), || Ok(a)).unwrap();
+            let a_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(a)).unwrap();
             a_var.enforce_cmp(&a_var, Ordering::Less, false).unwrap();
 
             assert!(!cs.is_satisfied().unwrap());
@@ -229,7 +234,7 @@ mod test {
         for _i in 0..10 {
             let cs = ConstraintSystem::<Fr>::new_ref();
             let a = rand_in_range(&mut rng);
-            let a_var = FpVar::<Fr>::new_witness(cs.ns("a"), || Ok(a)).unwrap();
+            let a_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(a)).unwrap();
             a_var.enforce_cmp(&a_var, Ordering::Less, true).unwrap();
             assert!(cs.is_satisfied().unwrap());
         }

--- a/r1cs-std/src/fields/mod.rs
+++ b/r1cs-std/src/fields/mod.rs
@@ -181,9 +181,9 @@ pub(crate) mod tests {
         let mut rng = test_rng();
         let a_native = F::rand(&mut rng);
         let b_native = F::rand(&mut rng);
-        let a = AF::new_witness(cs.ns("generate_a"), || Ok(a_native))?;
-        let b = AF::new_witness(cs.ns("generate_b"), || Ok(b_native))?;
-        let b_const = AF::new_constant(cs.ns("b_as_constant"), b_native)?;
+        let a = AF::new_witness(r1cs_core::ns!(cs, "generate_a"), || Ok(a_native))?;
+        let b = AF::new_witness(r1cs_core::ns!(cs, "generate_b"), || Ok(b_native))?;
+        let b_const = AF::new_constant(r1cs_core::ns!(cs, "b_as_constant"), b_native)?;
 
         let zero = AF::zero();
         let zero_native = zero.value()?;
@@ -318,13 +318,13 @@ pub(crate) mod tests {
 
         let f = F::from(1u128 << 64);
         let f_bits = algebra::BitIteratorLE::new(&[0u64, 1u64]).collect::<Vec<_>>();
-        let fv = AF::new_witness(cs.ns("alloc u128"), || Ok(f))?;
+        let fv = AF::new_witness(r1cs_core::ns!(cs, "alloc u128"), || Ok(f))?;
         assert_eq!(fv.to_bits_le()?.value().unwrap()[..128], f_bits[..128]);
         assert!(cs.is_satisfied().unwrap());
 
         let r_native: F = UniformRand::rand(&mut test_rng());
 
-        let r = AF::new_witness(cs.ns("r_native"), || Ok(r_native)).unwrap();
+        let r = AF::new_witness(r1cs_core::ns!(cs, "r_native"), || Ok(r_native)).unwrap();
         let _ = r.to_non_unique_bits_le()?;
         assert!(cs.is_satisfied().unwrap());
         let _ = r.to_bits_le()?;
@@ -369,7 +369,7 @@ pub(crate) mod tests {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
         for i in 0..=maxpower {
             let mut a = F::rand(&mut rng);
-            let mut a_gadget = AF::new_witness(cs.ns(format!("a_gadget_{:?}", i)), || Ok(a))?;
+            let mut a_gadget = AF::new_witness(r1cs_core::ns!(cs, "a"), || Ok(a))?;
             a_gadget.frobenius_map_in_place(i)?;
             a.frobenius_map(i);
 

--- a/r1cs-std/src/macros.rs
+++ b/r1cs-std/src/macros.rs
@@ -1,4 +1,5 @@
-// Implements AddAssign on Self by deferring to an implementation on &Self
+#[allow(unused_braces)]
+// Implements arithmetic operations with generic bounds.
 #[macro_export]
 macro_rules! impl_ops {
     (
@@ -36,6 +37,8 @@ macro_rules! impl_bounded_ops {
         {
             type Output = $type;
 
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $fn(self, other: Self) -> Self::Output {
                 $impl(self, other)
             }
@@ -47,6 +50,8 @@ macro_rules! impl_bounded_ops {
         {
             type Output = $type;
 
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $fn(self, other: $type) -> Self::Output {
                 core::ops::$trait::$fn(self, &other)
             }
@@ -58,6 +63,8 @@ macro_rules! impl_bounded_ops {
         {
             type Output = $type;
 
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $fn(self, other: &'a $type) -> Self::Output {
                 core::ops::$trait::$fn(&self, other)
             }
@@ -70,6 +77,8 @@ macro_rules! impl_bounded_ops {
         {
             type Output = $type;
 
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $fn(self, other: $type) -> Self::Output {
                 core::ops::$trait::$fn(&self, &other)
             }
@@ -80,6 +89,8 @@ macro_rules! impl_bounded_ops {
 
             $($bounds)*
         {
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $assign_fn(&mut self, other: $type) {
                 let result = core::ops::$trait::$fn(&*self, &other);
                 *self = result
@@ -91,6 +102,8 @@ macro_rules! impl_bounded_ops {
 
             $($bounds)*
         {
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $assign_fn(&mut self, other: &'a $type) {
                 let result = core::ops::$trait::$fn(&*self, other);
                 *self = result
@@ -104,6 +117,8 @@ macro_rules! impl_bounded_ops {
         {
             type Output = $type;
 
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $fn(self, other: $native) -> Self::Output {
                 $constant_impl(self, other)
             }
@@ -116,6 +131,8 @@ macro_rules! impl_bounded_ops {
         {
             type Output = $type;
 
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $fn(self, other: $native) -> Self::Output {
                 core::ops::$trait::$fn(&self, other)
             }
@@ -127,6 +144,8 @@ macro_rules! impl_bounded_ops {
             $($bounds)*
         {
 
+            #[tracing::instrument(target = "r1cs", skip(self))]
+            #[allow(unused_braces)]
             fn $assign_fn(&mut self, other: $native) {
                 let result = core::ops::$trait::$fn(&*self, other);
                 *self = result

--- a/r1cs-std/src/pairing/bls12/mod.rs
+++ b/r1cs-std/src/pairing/bls12/mod.rs
@@ -18,6 +18,7 @@ type Fp2V<P> = Fp2Var<<P as Bls12Parameters>::Fp2Params>;
 
 impl<P: Bls12Parameters> PairingVar<P> {
     // Evaluate the line function at point p.
+    #[tracing::instrument(target = "r1cs")]
     fn ell(
         f: &mut Fp12Var<P::Fp12Params>,
         coeffs: &(Fp2V<P>, Fp2V<P>),
@@ -49,6 +50,7 @@ impl<P: Bls12Parameters> PairingVar<P> {
         }
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn exp_by_x(f: &Fp12Var<P::Fp12Params>) -> Result<Fp12Var<P::Fp12Params>, SynthesisError> {
         let mut result = f.optimized_cyclotomic_exp(P::X)?;
         if P::X_IS_NEGATIVE {
@@ -65,6 +67,7 @@ impl<P: Bls12Parameters> PG<Bls12<P>, P::Fp> for PairingVar<P> {
     type G2PreparedVar = G2PreparedVar<P>;
     type GTVar = Fp12Var<P::Fp12Params>;
 
+    #[tracing::instrument(target = "r1cs")]
     fn miller_loop(
         ps: &[Self::G1PreparedVar],
         qs: &[Self::G2PreparedVar],
@@ -96,6 +99,7 @@ impl<P: Bls12Parameters> PG<Bls12<P>, P::Fp> for PairingVar<P> {
         Ok(f)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn final_exponentiation(f: &Self::GTVar) -> Result<Self::GTVar, SynthesisError> {
         // Computing the final exponentation following
         // https://eprint.iacr.org/2016/130.pdf.
@@ -152,10 +156,12 @@ impl<P: Bls12Parameters> PG<Bls12<P>, P::Fp> for PairingVar<P> {
         })
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn prepare_g1(p: &Self::G1Var) -> Result<Self::G1PreparedVar, SynthesisError> {
         Self::G1PreparedVar::from_group_var(p)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn prepare_g2(q: &Self::G2Var) -> Result<Self::G2PreparedVar, SynthesisError> {
         Self::G2PreparedVar::from_group_var(q)
     }

--- a/r1cs-std/src/pairing/mnt4/mod.rs
+++ b/r1cs-std/src/pairing/mnt4/mod.rs
@@ -22,6 +22,7 @@ type Fp4G<P> = Fp4Var<<P as MNT4Parameters>::Fp4Params>;
 pub type GTVar<P> = Fp4G<P>;
 
 impl<P: MNT4Parameters> PairingVar<P> {
+    #[tracing::instrument(target = "r1cs", skip(r))]
     pub(crate) fn doubling_step_for_flipped_miller_loop(
         r: &G2ProjectiveExtendedVar<P>,
     ) -> Result<(G2ProjectiveExtendedVar<P>, AteDoubleCoefficientsVar<P>), SynthesisError> {
@@ -57,6 +58,7 @@ impl<P: MNT4Parameters> PairingVar<P> {
         Ok((r2, coeff))
     }
 
+    #[tracing::instrument(target = "r1cs", skip(r))]
     pub(crate) fn mixed_addition_step_for_flipped_miller_loop(
         x: &Fp2G<P>,
         y: &Fp2G<P>,
@@ -89,6 +91,7 @@ impl<P: MNT4Parameters> PairingVar<P> {
         Ok((r2, coeff))
     }
 
+    #[tracing::instrument(target = "r1cs", skip(p, q))]
     pub fn ate_miller_loop(
         p: &G1PreparedVar<P>,
         q: &G2PreparedVar<P>,
@@ -138,6 +141,7 @@ impl<P: MNT4Parameters> PairingVar<P> {
         Ok(f)
     }
 
+    #[tracing::instrument(target = "r1cs", skip(value))]
     pub fn final_exponentiation(value: &Fp4G<P>) -> Result<GTVar<P>, SynthesisError> {
         let value_inv = value.inverse()?;
         let value_to_first_chunk = Self::final_exponentiation_first_chunk(value, &value_inv)?;
@@ -145,6 +149,7 @@ impl<P: MNT4Parameters> PairingVar<P> {
         Self::final_exponentiation_last_chunk(&value_to_first_chunk, &value_inv_to_first_chunk)
     }
 
+    #[tracing::instrument(target = "r1cs", skip(elt, elt_inv))]
     fn final_exponentiation_first_chunk(
         elt: &Fp4G<P>,
         elt_inv: &Fp4G<P>,
@@ -157,6 +162,7 @@ impl<P: MNT4Parameters> PairingVar<P> {
         Ok(elt_q2 * elt_inv)
     }
 
+    #[tracing::instrument(target = "r1cs", skip(elt, elt_inv))]
     fn final_exponentiation_last_chunk(
         elt: &Fp4G<P>,
         elt_inv: &Fp4G<P>,
@@ -185,6 +191,7 @@ impl<P: MNT4Parameters> PG<MNT4<P>, P::Fp> for PairingVar<P> {
     type G2PreparedVar = G2PreparedVar<P>;
     type GTVar = GTVar<P>;
 
+    #[tracing::instrument(target = "r1cs")]
     fn miller_loop(
         ps: &[Self::G1PreparedVar],
         qs: &[Self::G2PreparedVar],
@@ -197,14 +204,17 @@ impl<P: MNT4Parameters> PG<MNT4<P>, P::Fp> for PairingVar<P> {
         Ok(result)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn final_exponentiation(r: &Self::GTVar) -> Result<Self::GTVar, SynthesisError> {
         Self::final_exponentiation(r)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn prepare_g1(p: &Self::G1Var) -> Result<Self::G1PreparedVar, SynthesisError> {
         Self::G1PreparedVar::from_group_var(p)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn prepare_g2(q: &Self::G2Var) -> Result<Self::G2PreparedVar, SynthesisError> {
         Self::G2PreparedVar::from_group_var(q)
     }

--- a/r1cs-std/src/pairing/mnt6/mod.rs
+++ b/r1cs-std/src/pairing/mnt6/mod.rs
@@ -22,6 +22,7 @@ type Fp6G<P> = Fp6Var<<P as MNT6Parameters>::Fp6Params>;
 pub type GTVar<P> = Fp6G<P>;
 
 impl<P: MNT6Parameters> PairingVar<P> {
+    #[tracing::instrument(target = "r1cs", skip(r))]
     pub(crate) fn doubling_step_for_flipped_miller_loop(
         r: &G2ProjectiveExtendedVar<P>,
     ) -> Result<(G2ProjectiveExtendedVar<P>, AteDoubleCoefficientsVar<P>), SynthesisError> {
@@ -52,6 +53,7 @@ impl<P: MNT6Parameters> PairingVar<P> {
         Ok((r2, coeff))
     }
 
+    #[tracing::instrument(target = "r1cs", skip(r))]
     pub(crate) fn mixed_addition_step_for_flipped_miller_loop(
         x: &Fp3G<P>,
         y: &Fp3G<P>,
@@ -84,6 +86,7 @@ impl<P: MNT6Parameters> PairingVar<P> {
         Ok((r2, coeff))
     }
 
+    #[tracing::instrument(target = "r1cs", skip(p, q))]
     pub fn ate_miller_loop(
         p: &G1PreparedVar<P>,
         q: &G2PreparedVar<P>,
@@ -134,6 +137,7 @@ impl<P: MNT6Parameters> PairingVar<P> {
         Ok(f)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     pub fn final_exponentiation(value: &Fp6G<P>) -> Result<GTVar<P>, SynthesisError> {
         let value_inv = value.inverse()?;
         let value_to_first_chunk = Self::final_exponentiation_first_chunk(value, &value_inv)?;
@@ -141,6 +145,7 @@ impl<P: MNT6Parameters> PairingVar<P> {
         Self::final_exponentiation_last_chunk(&value_to_first_chunk, &value_inv_to_first_chunk)
     }
 
+    #[tracing::instrument(target = "r1cs", skip(elt, elt_inv))]
     fn final_exponentiation_first_chunk(
         elt: &Fp6G<P>,
         elt_inv: &Fp6G<P>,
@@ -157,6 +162,7 @@ impl<P: MNT6Parameters> PairingVar<P> {
         Ok(alpha * &elt_q3_over_elt)
     }
 
+    #[tracing::instrument(target = "r1cs", skip(elt, elt_inv))]
     fn final_exponentiation_last_chunk(
         elt: &Fp6G<P>,
         elt_inv: &Fp6G<P>,
@@ -181,6 +187,7 @@ impl<P: MNT6Parameters> PG<MNT6<P>, P::Fp> for PairingVar<P> {
     type G2PreparedVar = G2PreparedVar<P>;
     type GTVar = GTVar<P>;
 
+    #[tracing::instrument(target = "r1cs")]
     fn miller_loop(
         ps: &[Self::G1PreparedVar],
         qs: &[Self::G2PreparedVar],
@@ -193,14 +200,17 @@ impl<P: MNT6Parameters> PG<MNT6<P>, P::Fp> for PairingVar<P> {
         Ok(result)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn final_exponentiation(r: &Self::GTVar) -> Result<Self::GTVar, SynthesisError> {
         Self::final_exponentiation(r)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn prepare_g1(p: &Self::G1Var) -> Result<Self::G1PreparedVar, SynthesisError> {
         Self::G1PreparedVar::from_group_var(p)
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn prepare_g2(q: &Self::G2Var) -> Result<Self::G2PreparedVar, SynthesisError> {
         Self::G2PreparedVar::from_group_var(q)
     }

--- a/r1cs-std/src/pairing/mod.rs
+++ b/r1cs-std/src/pairing/mod.rs
@@ -33,6 +33,7 @@ pub trait PairingVar<E: PairingEngine, ConstraintF: Field = <E as PairingEngine>
 
     fn final_exponentiation(p: &Self::GTVar) -> Result<Self::GTVar, SynthesisError>;
 
+    #[tracing::instrument(target = "r1cs")]
     fn pairing(
         p: Self::G1PreparedVar,
         q: Self::G2PreparedVar,
@@ -43,6 +44,7 @@ pub trait PairingVar<E: PairingEngine, ConstraintF: Field = <E as PairingEngine>
 
     /// Computes a product of pairings.
     #[must_use]
+    #[tracing::instrument(target = "r1cs")]
     fn product_of_pairings(
         p: &[Self::G1PreparedVar],
         q: &[Self::G2PreparedVar],
@@ -84,10 +86,10 @@ pub(crate) mod tests {
         let mut sb = b;
         sb *= s;
 
-        let a_g = P::G1Var::new_witness(cs.ns("a"), || Ok(a.into_affine()))?;
-        let b_g = P::G2Var::new_witness(cs.ns("b"), || Ok(b.into_affine()))?;
-        let sa_g = P::G1Var::new_witness(cs.ns("sa"), || Ok(sa.into_affine()))?;
-        let sb_g = P::G2Var::new_witness(cs.ns("sb"), || Ok(sb.into_affine()))?;
+        let a_g = P::G1Var::new_witness(cs.clone(), || Ok(a.into_affine()))?;
+        let b_g = P::G2Var::new_witness(cs.clone(), || Ok(b.into_affine()))?;
+        let sa_g = P::G1Var::new_witness(cs.clone(), || Ok(sa.into_affine()))?;
+        let sb_g = P::G2Var::new_witness(cs.clone(), || Ok(sb.into_affine()))?;
 
         let mut preparation_num_constraints = cs.num_constraints();
         let a_prep_g = P::prepare_g1(&a_g)?;


### PR DESCRIPTION
Blocked on #186 

PR #186 improved the ergonomics of writing constraints and gadgets, but regressed the ergonomics of profiling and debugging constraints. This PR attempts to rectify that by moving to an API based on the `tracing` crate. To enter a namespace, simply annotate the relevant function with the `tracing::instrument` attribute, with `target = "r1cs"`:

```rust
#[tracing::instrument(target = "r1cs")]
fn some_gadget(...) -> Something {
	///...
}
```

See `r1cs_std` for examples.

Closes #250 