### PR TITLE
ToConstraintFieldGadget for SW ProjectiveVar

### DIFF
--- a/algebra-core/src/to_field_vec.rs
+++ b/algebra-core/src/to_field_vec.rs
@@ -23,6 +23,16 @@ impl<F: PrimeField> ToConstraintField<F> for F {
     }
 }
 
+impl<F: Field> ToConstraintField<F> for bool {
+    fn to_field_elements(&self) -> Result<Vec<F>, Error> {
+        if *self == true {
+            Ok(vec![F::one()])
+        }else{
+            Ok(vec![F::zero()])
+        }
+    }
+}
+
 // Impl for base field
 impl<F: Field> ToConstraintField<F> for [F] {
     #[inline]
@@ -69,7 +79,9 @@ where
     fn to_field_elements(&self) -> Result<Vec<ConstraintF>, Error> {
         let mut x_fe = self.x.to_field_elements()?;
         let y_fe = self.y.to_field_elements()?;
+        let infinity_fe = self.infinity.to_field_elements()?;
         x_fe.extend_from_slice(&y_fe);
+        x_fe.extend_from_slice(&infinity_fe);
         Ok(x_fe)
     }
 }

--- a/algebra-core/src/to_field_vec.rs
+++ b/algebra-core/src/to_field_vec.rs
@@ -27,7 +27,7 @@ impl<F: Field> ToConstraintField<F> for bool {
     fn to_field_elements(&self) -> Result<Vec<F>, Error> {
         if *self == true {
             Ok(vec![F::one()])
-        }else{
+        } else {
             Ok(vec![F::zero()])
         }
     }

--- a/r1cs-std/src/fields/fp/mod.rs
+++ b/r1cs-std/src/fields/fp/mod.rs
@@ -872,7 +872,7 @@ impl<F: PrimeField> ToBitsGadget<F> for FpVar<F> {
     fn to_non_unique_bits_le(&self) -> Result<Vec<Boolean<F>>, SynthesisError> {
         use algebra::BitIteratorLE;
         match self {
-            Self::Constant(c) => Ok(BitIteratorLE::without_trailing_zeros(&c.into_repr())
+            Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),
             Self::Var(v) => v.to_non_unique_bits_le(),

--- a/r1cs-std/src/fields/fp/mod.rs
+++ b/r1cs-std/src/fields/fp/mod.rs
@@ -873,6 +873,7 @@ impl<F: PrimeField> ToBitsGadget<F> for FpVar<F> {
         use algebra::BitIteratorLE;
         match self {
             Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
+                .keep(F::Params::MODULUS_BITS - 1)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),
             Self::Var(v) => v.to_non_unique_bits_le(),

--- a/r1cs-std/src/fields/fp/mod.rs
+++ b/r1cs-std/src/fields/fp/mod.rs
@@ -873,7 +873,7 @@ impl<F: PrimeField> ToBitsGadget<F> for FpVar<F> {
         use algebra::BitIteratorLE;
         match self {
             Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
-                .take((F::Params::MODULUS_BITS - 1) as usize)
+                .take((F::Params::MODULUS_BITS) as usize)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),
             Self::Var(v) => v.to_non_unique_bits_le(),

--- a/r1cs-std/src/fields/fp/mod.rs
+++ b/r1cs-std/src/fields/fp/mod.rs
@@ -873,7 +873,7 @@ impl<F: PrimeField> ToBitsGadget<F> for FpVar<F> {
         use algebra::BitIteratorLE;
         match self {
             Self::Constant(c) => Ok(BitIteratorLE::new(&c.into_repr())
-                .keep(F::Params::MODULUS_BITS - 1)
+                .take((F::Params::MODULUS_BITS - 1) as usize)
                 .map(Boolean::constant)
                 .collect::<Vec<_>>()),
             Self::Var(v) => v.to_non_unique_bits_le(),

--- a/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
@@ -106,6 +106,7 @@ where
 
         res.extend_from_slice(&self.x.to_constraint_field()?);
         res.extend_from_slice(&self.y.to_constraint_field()?);
+        res.extend_from_slice(&self.infinity.to_constraint_field()?);
 
         Ok(res)
     }
@@ -719,17 +720,7 @@ where
     fn to_constraint_field(
         &self,
     ) -> Result<Vec<FpVar<<P::BaseField as Field>::BasePrimeField>>, SynthesisError> {
-        let mut res = Vec::<FpVar<<P::BaseField as Field>::BasePrimeField>>::new();
-
-        let z_inv = self.z.inverse()?;
-
-        let x_div_by_z = &self.x * &z_inv;
-        let y_div_by_z = &self.x * &z_inv;
-
-        res.extend_from_slice(&x_div_by_z.to_constraint_field()?);
-        res.extend_from_slice(&y_div_by_z.to_constraint_field()?);
-
-        Ok(res)
+        self.to_affine()?.to_constraint_field()
     }
 }
 

--- a/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
@@ -709,6 +709,30 @@ where
     }
 }
 
+impl<P, F> ToConstraintFieldGadget<<P::BaseField as Field>::BasePrimeField> for ProjectiveVar<P, F>
+    where
+        P: SWModelParameters,
+        F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
+        for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
+        F: ToConstraintFieldGadget<<P::BaseField as Field>::BasePrimeField>,
+{
+    fn to_constraint_field(
+        &self,
+    ) -> Result<Vec<FpVar<<P::BaseField as Field>::BasePrimeField>>, SynthesisError> {
+        let mut res = Vec::<FpVar<<P::BaseField as Field>::BasePrimeField>>::new();
+
+        let z_inv = self.z.inverse()?;
+
+        let x_div_by_z = &self.x * &z_inv;
+        let y_div_by_z = &self.x * &z_inv;
+
+        res.extend_from_slice(&x_div_by_z.to_constraint_field()?);
+        res.extend_from_slice(&y_div_by_z.to_constraint_field()?);
+
+        Ok(res)
+    }
+}
+
 #[cfg(test)]
 #[allow(dead_code)]
 pub(crate) fn test<P, GG>() -> Result<(), SynthesisError>

--- a/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
+++ b/r1cs-std/src/groups/curves/short_weierstrass/mod.rs
@@ -710,11 +710,11 @@ where
 }
 
 impl<P, F> ToConstraintFieldGadget<<P::BaseField as Field>::BasePrimeField> for ProjectiveVar<P, F>
-    where
-        P: SWModelParameters,
-        F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
-        for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
-        F: ToConstraintFieldGadget<<P::BaseField as Field>::BasePrimeField>,
+where
+    P: SWModelParameters,
+    F: FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField>,
+    for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
+    F: ToConstraintFieldGadget<<P::BaseField as Field>::BasePrimeField>,
 {
     fn to_constraint_field(
         &self,


### PR DESCRIPTION
The previous PR https://github.com/scipr-lab/zexe/pull/278 does not include the case of SW `ProjectiveVar` (but only `AffineVar`), but it is used in the main implementations of `PairingVar` for SW curves.

So, when we are refactoring the Marlin gadgets, we discovered that `ToConstraintFieldGadget` for SW `ProjectiveVar` is needed. This PR provides so.