### PR TITLE
Allow creation of group element by raw X and Y coordinates

### DIFF
--- a/algebra-core/src/curves/mod.rs
+++ b/algebra-core/src/curves/mod.rs
@@ -257,6 +257,9 @@ pub trait AffineCurve:
     /// `Self::ScalarField`.
     #[must_use]
     fn mul_by_cofactor_inv(&self) -> Self;
+
+    // Creates a point from raw X and Y coordinates. On-curve check is performed.
+    fn from_xy_checked(x: Self::BaseField, y: Self::BaseField) -> Result<Self, ()>;
 }
 
 impl<C: ProjectiveCurve> Group for C {

--- a/algebra-core/src/curves/models/short_weierstrass_jacobian.rs
+++ b/algebra-core/src/curves/models/short_weierstrass_jacobian.rs
@@ -202,6 +202,22 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     fn mul_by_cofactor_inv(&self) -> Self {
         self.mul(P::COFACTOR_INV).into()
     }
+
+    fn from_xy_checked(x: Self::BaseField, y: Self::BaseField) -> Result<Self, ()> {
+        let infinity = x.is_zero() && y.is_zero();
+        let affine = Self {
+            x,
+            y,
+            infinity,
+            _params: PhantomData,
+        };
+
+        if !affine.is_on_curve() {
+            Err(())
+        } else {
+            Ok(affine)
+        }
+    }
 }
 
 impl<P: Parameters> Neg for GroupAffine<P> {

--- a/algebra-core/src/curves/models/short_weierstrass_projective.rs
+++ b/algebra-core/src/curves/models/short_weierstrass_projective.rs
@@ -196,6 +196,22 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     fn mul_by_cofactor_inv(&self) -> Self {
         self.mul(P::COFACTOR_INV).into()
     }
+
+    fn from_xy_checked(x: Self::BaseField, y: Self::BaseField) -> Result<Self, ()> {
+        let infinity = x.is_zero() && y.is_zero();
+        let affine = Self {
+            x,
+            y,
+            infinity,
+            _params: PhantomData,
+        };
+
+        if !affine.is_on_curve() {
+            Err(())
+        } else {
+            Ok(affine)
+        }
+    }
 }
 
 impl<P: Parameters> Neg for GroupAffine<P> {

--- a/algebra-core/src/curves/models/twisted_edwards_extended.rs
+++ b/algebra-core/src/curves/models/twisted_edwards_extended.rs
@@ -162,6 +162,20 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     fn mul_by_cofactor_inv(&self) -> Self {
         self.mul(P::COFACTOR_INV).into()
     }
+
+    fn from_xy_checked(x: Self::BaseField, y: Self::BaseField) -> Result<Self, ()> {
+        let affine = Self {
+            x,
+            y,
+            _params: PhantomData,
+        };
+
+        if !affine.is_on_curve() {
+            Err(())
+        } else {
+            Ok(affine)
+        }
+    }
 }
 
 impl<P: Parameters> Neg for GroupAffine<P> {


### PR DESCRIPTION
This PR adds `from_xy_checked` function to `AffineCurve` trait which can be used to create a point from raw X and Y coordinates. This function returns a `Result` as on-curve check is performed.

We are in process of adding zexe as a backend to [ZoKrates](https://github.com/Zokrates/ZoKrates) project and this is currently a  block for us. As we work with raw x and y coordinates we need to have a way to construct associated `G1Affine` and `G2Affine` types from `PairingEngine` trait. This change would enables us to do so.

As a reference, this is supported for bellman in the [pairing_ce](https://docs.rs/pairing_ce/0.24.1/pairing_ce/trait.CurveAffine.html#tymethod.from_xy_checked) crate. Any feedback is appreciated on this.