### PR TITLE
Fix the `outline_lcs`

### DIFF
--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -238,10 +238,11 @@ impl<F: Field> ConstraintSystem<F> {
         Ok(())
     }
 
-    /// Count the number of times a given LC is used within another LC
+    /// Count the number of times each LC is used within other LCs in the constraint system
     fn lc_num_times_used(&self, count_sinks: bool) -> Vec<usize> {
         let mut num_times_used = vec![0; self.lc_map.len()];
 
+        // Iterate over every lc in constraint system
         for (index, lc) in self.lc_map.iter() {
             num_times_used[index.0] += count_sinks as usize;
 
@@ -345,6 +346,10 @@ impl<F: Field> ConstraintSystem<F> {
             let this_used_times = num_times_used[index.0] + 1;
             let this_len = outlined_lc.len();
 
+            // Cost with no outlining = `lc_len * number of usages`
+            // Cost with outlining is one constraint for `(lc_len) * 1 = {new variable}` and 
+            // using that single new variable in each of the prior usages.
+            // This has total cost `number_of_usages + lc_len + 2`
             if this_used_times * this_len > this_used_times + 2 + this_len {
                 should_outline = true;
             }

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -386,7 +386,8 @@ impl<F: Field> ConstraintSystem<F> {
                 new_witness_linear_combination.clone(),
                 LinearCombination::from(Self::one()),
                 LinearCombination::from(Variable::Witness(*new_witness_variable)),
-            ).unwrap();
+            )
+            .unwrap();
         }
     }
 

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -359,7 +359,7 @@ impl<F: Field> ConstraintSystem<F> {
                     self.witness_assignment.push(acc);
                 }
 
-                // Add a new constarint for this new witness
+                // Add a new constraint for this new witness
                 new_witness_linear_combinations.push(outlined_lc.clone());
                 new_witness_indices.push(witness_assignment);
 

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -321,7 +321,7 @@ impl<F: Field> ConstraintSystem<F> {
         // the early ones, and decides whether or not to dedicate a witness
         // variable for this LC.
         //
-        // If true, the LC is replaced with 1 * this witness variable
+        // If true, the LC is replaced with 1 * this witness variable.
         // Otherwise, the LC is inlined.
         //
         let mut new_lc_msp = BTreeMap::new();

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -385,7 +385,7 @@ impl<F: Field> ConstraintSystem<F> {
     /// Useful for SNARKs like [\[Marlin\]](https://eprint.iacr.org/2019/1047) or
     /// [\[Fractal\]](https://eprint.iacr.org/2019/1076), where addition gates
     /// are not cheap.
-    pub fn outline_lcs(&mut self) {
+    fn outline_lcs(&mut self) {
         // Only inline when a matrix representing R1CS is needed.
         if !self.should_construct_matrices() {
             return;
@@ -471,6 +471,18 @@ impl<F: Field> ConstraintSystem<F> {
             )
             .unwrap();
         }
+    }
+
+    /// Reduce the constraint weight.
+    ///
+    /// At this moment, it is a wrapper to `outline_lcs`.
+    /// More weight reductions may be added later.
+    ///
+    /// Useful for SNARKs like [\[Marlin\]](https://eprint.iacr.org/2019/1047) or
+    /// [\[Fractal\]](https://eprint.iacr.org/2019/1076), where addition gates
+    /// are not cheap.
+    pub fn reduce_constraint_weight(&mut self) {
+        self.outline_lcs();
     }
 
     /// This step must be called after constraint generation has completed, and
@@ -852,18 +864,14 @@ impl<F: Field> ConstraintSystemRef<F> {
         }
     }
 
-    /// If a `SymbolicLc` is used in more than one location and has sufficient
-    /// length, this method makes a new variable for that `SymbolicLc`, adds
-    /// a constraint ensuring the equality of the variable and the linear
-    /// combination, and then uses that variable in every location the
-    /// `SymbolicLc` is used.
+    /// Reduce the constraint weight.
     ///
     /// Useful for SNARKs like [\[Marlin\]](https://eprint.iacr.org/2019/1047) or
     /// [\[Fractal\]](https://eprint.iacr.org/2019/1076), where addition gates
     /// are not cheap.
-    pub fn outline_lcs(&self) {
+    pub fn reduce_constraint_weight(&self) {
         if let Some(cs) = self.inner() {
-            cs.borrow_mut().outline_lcs()
+            cs.borrow_mut().reduce_constraint_weight()
         }
     }
 

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -450,8 +450,8 @@ impl<F: Field> ConstraintSystem<F> {
             // Otherwise, the LC remains unchanged.
 
             // Return information about new witness variables.
-            if let Some(new_witness_index) = new_witness_index {
-                (new_witness_index, Some(new_witness_assignment))
+            if new_witness_index.is_some() {
+                (1, Some(new_witness_assignment))
             } else {
                 (0, None)
             }

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -362,7 +362,7 @@ impl<F: Field> ConstraintSystem<F> {
             let this_len = inlined_lc.len();
 
             // Cost with no outlining = `lc_len * number of usages`
-            // Cost with outlining is one constraint for `(lc_len) * 1 = {new variable}` and 
+            // Cost with outlining is one constraint for `(lc_len) * 1 = {new variable}` and
             // using that single new variable in each of the prior usages.
             // This has total cost `number_of_usages + lc_len + 2`
             if this_used_times * this_len > this_used_times + 2 + this_len {

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -262,11 +262,11 @@ impl<F: Field> ConstraintSystem<F> {
     ///
     /// This method is used as a subroutine of `inline_all_lcs` and `outline_lcs`.
     ///
-    /// The transformer function is given references of this constraint system (&self),
-    /// number of times used, and the linear combination to be transformed.
+    /// The transformer function is given a references of this constraint system (&self),
+    /// number of times used, and a mutable reference of the linear combination to be transformed.
     ///     (&ConstraintSystem<F>, usize, &mut LinearCombination<F>)
     ///
-    /// The transformer function returns numbers of new witness variables needed,
+    /// The transformer function returns the number of new witness variables needed
     /// and a vector of new witness assignments (if not in the setup mode).
     ///     (usize, Option<Vec<F>>)
     ///
@@ -331,7 +331,7 @@ impl<F: Field> ConstraintSystem<F> {
             }
             transformed_lc.compactify();
 
-            // Call the transformer.
+            // Call the transformer function.
             let (num_new_witness_variables, new_witness_assignments) =
                 transformer(&self, num_times_used[index.0], &mut transformed_lc);
 
@@ -393,7 +393,7 @@ impl<F: Field> ConstraintSystem<F> {
 
         // Store information about new witness variables created
         // for outlining. New constraints will be added after the
-        // tansformation of the LC map.
+        // transformation of the LC map.
         let mut new_witness_linear_combinations = Vec::new();
         let mut new_witness_indices = Vec::new();
 


### PR DESCRIPTION
After careful debugging, it appears that the current implementation of `outline_lcs` has two serious problems:

- It does not correctly create additional constraints. All the additional constraints should be `LC * 1 = V` where V is the new witness variable. In the end, all of them are `V * 1 = V`.

- It does not increase the count of `num_linear_combinations` correctly. So that in Marlin, when the next step wants to pad the matrices to be square, the new linear combinations go to the wrong linear combination entry, causing the outer check to fail.

This PR fixes these two problems and will close this issue in Marlin: https://github.com/arkworks-rs/marlin/issues/56