### PR TITLE
Add helper method to inline `mul_by_const` immediately under constraints optimization goal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Improvements
 - #325 Reduce memory consumption during inlining
+- #339 Reduce memory consumption under `Constraints` optimization goal
 
 ### Bug fixes
 

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -256,8 +256,8 @@ impl<F: Field> ConstraintSystem<F> {
         var: &Variable,
         other: &F,
     ) -> crate::r1cs::Result<Variable> {
-        // Create a new symbolic LC using this constant, deffering the inlining
-        // until the finalize phase
+        // Create a new symbolic LC using this constant, deferring the inlining
+        // until the finalization phase.
         #[inline]
         fn base_mul_by_constant<F: Field>(
             cs: &mut ConstraintSystem<F>,

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -256,7 +256,8 @@ impl<F: Field> ConstraintSystem<F> {
         var: &Variable,
         other: &F,
     ) -> crate::r1cs::Result<Variable> {
-        // Create a new symbolic LC using this constant
+        // Create a new symbolic LC using this constant, deffering the inlining
+        // until the finalize phase
         #[inline]
         fn base_mul_by_constant<F: Field>(
             cs: &mut ConstraintSystem<F>,
@@ -277,7 +278,8 @@ impl<F: Field> ConstraintSystem<F> {
                     || self.optimization_goal == OptimizationGoal::None
                 {
                     // In this case we are optimizing for the number of constraints,
-                    // so we Inline this multiplication by a constant immediately.
+                    // so we have no need for symbolic variables of intermediate computation steps.
+                    // Thus we inline this multiplication by a constant immediately.
                     let lc = self.lc_map.get(&index).unwrap();
                     let mut new_lc = lc.clone();
                     for i in 0..new_lc.len() {

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -273,8 +273,9 @@ impl<F: Field> ConstraintSystem<F> {
             Variable::Instance(_) => base_mul_by_constant(self, var, *other),
             Variable::Witness(_) => base_mul_by_constant(self, var, *other),
             Variable::SymbolicLc(index) => {
-                if self.optimization_goal == OptimizationGoal::Constraints ||
-                    self.optimization_goal == OptimizationGoal::None {
+                if self.optimization_goal == OptimizationGoal::Constraints
+                    || self.optimization_goal == OptimizationGoal::None
+                {
                     // In this case we are optimizing for the number of constraints,
                     // so we Inline this multiplication by a constant immediately.
                     let lc = self.lc_map.get(&index).unwrap();
@@ -284,8 +285,7 @@ impl<F: Field> ConstraintSystem<F> {
                     }
                     let variable = self.new_lc(new_lc).unwrap();
                     return Ok(variable);
-                }
-                else {
+                } else {
                     // In this case we are optimizing for constraint density,
                     // so we want to know when a symbolic LC is being re-used.
                     base_mul_by_constant(self, var, *other)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This adds a method to constraint system that gadgets such as FpVar would call to do multiplication by a constant. It handles inlining immediately when under the `Constraints` Optimization goal, and doesn't create additional symbolic variables when the variable is `Zero`. This could cause speed losses to constraint-optimized circuits when doing two mul by consts in a row, but I think such a case isn't that likely.

This is intended to be used here: https://github.com/arkworks-rs/r1cs-std/blob/master/src/fields/fp/mod.rs#L192

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests - its hard to write unit tests in this repo
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
