### PR TITLE
Switch to panic='abort' for safety across FFI boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - #325 Reduce memory consumption during inlining
 
 ### Bug fixes
+- #340 Compile with `panic='abort'` in release mode, for safety of the library across FFI boundaries.
 
 ## v0.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 opt-level = 3
 lto = "thin"
 incremental = true
+panic = 'abort'
 
 [profile.bench]
 opt-level = 3
@@ -20,6 +21,7 @@ debug-assertions = false
 
 [profile.dev]
 opt-level = 0
+panic = 'abort'
 
 [profile.test]
 opt-level = 3


### PR DESCRIPTION
cref https://github.com/arkworks-rs/algebra/issues/183

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
