### PR TITLE
Replace `rand` with `ark_std::rand` in `ark-snark`

### DIFF
--- a/snark/Cargo.toml
+++ b/snark/Cargo.toml
@@ -16,5 +16,3 @@ edition = "2018"
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = false }
 ark-relations = { path = "../relations", default-features = false }
-
-rand = { version = "0.7", default-features = false }

--- a/snark/src/lib.rs
+++ b/snark/src/lib.rs
@@ -12,8 +12,8 @@
 
 use ark_ff::{PrimeField, ToBytes};
 use ark_relations::r1cs::ConstraintSynthesizer;
+use ark_std::rand::{CryptoRng, RngCore};
 use core::fmt::Debug;
-use rand::{CryptoRng, RngCore};
 
 /// The basic functionality for a SNARK.
 pub trait SNARK<F: PrimeField> {


### PR DESCRIPTION
## Description

This PR replaces `rand` with `ark_std::rand` in `ark-snark`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` --- N/A as this is a change that does not affect the user
- [x] Re-reviewed `Files changed` in the Github PR explorer
