### PR TITLE
Add `into_inner` function for `ConstraintSystemRef<F>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Pending
+
+### Breaking changes
+
+### Features
+- [\#347](https://github.com/arkworks-rs/snark/pull/347) Add `into_inner` function for `ConstraintSystemRef<F>`.
+
+### Improvements
+
+### Bug fixes
+
+
 ## v0.2.0
 
 ### Breaking changes

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -772,7 +772,7 @@ impl<F: Field> ConstraintSystemRef<F> {
     pub fn into_inner(self) -> ConstraintSystem<F> {
         match self {
             Self::CS(a) => Rc::try_unwrap(a).unwrap().into_inner(),
-            Self::None => panic!()
+            Self::None => panic!(),
         }
     }
 

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -767,12 +767,13 @@ impl<F: Field> ConstraintSystemRef<F> {
         }
     }
 
-    /// Consumes self to return the inner `ConstraintSystem<F>`. Panics if
-    /// any other references to `self` exist.
-    pub fn into_inner(self) -> ConstraintSystem<F> {
+    /// Consumes self to return the inner `ConstraintSystem<F>`. Returns 
+    /// `None` if `Self::CS` is `None` or if any other references to
+    /// `Self::CS` exist.  
+    pub fn into_inner(self) -> Option<ConstraintSystem<F>> {
         match self {
-            Self::CS(a) => Rc::try_unwrap(a).unwrap().into_inner(),
-            Self::None => panic!(),
+            Self::CS(a) => Some(Rc::try_unwrap(a).unwrap().into_inner()),
+            Self::None => None,
         }
     }
 

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -771,10 +771,10 @@ impl<F: Field> ConstraintSystemRef<F> {
     /// `None` if `Self::CS` is `None` or if any other references to
     /// `Self::CS` exist.  
     pub fn into_inner(self) -> Option<ConstraintSystem<F>> {
-		match self {
-			Self::CS(a) => Rc::try_unwrap(a).ok().map(|s| s.into_inner()),
-			Self::None => None,
-		}
+        match self {
+            Self::CS(a) => Rc::try_unwrap(a).ok().map(|s| s.into_inner()),
+            Self::None => None,
+        }
     }
 
     /// Obtain an immutable reference to the underlying `ConstraintSystem`.

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -767,7 +767,7 @@ impl<F: Field> ConstraintSystemRef<F> {
         }
     }
 
-    /// Consumes self to return the inner `ConstraintSystem<F>`. Returns 
+    /// Consumes self to return the inner `ConstraintSystem<F>`. Returns
     /// `None` if `Self::CS` is `None` or if any other references to
     /// `Self::CS` exist.  
     pub fn into_inner(self) -> Option<ConstraintSystem<F>> {

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -771,10 +771,8 @@ impl<F: Field> ConstraintSystemRef<F> {
     /// `None` if `Self::CS` is `None` or if any other references to
     /// `Self::CS` exist.  
     pub fn into_inner(self) -> Option<ConstraintSystem<F>> {
-        match self {
-            Self::CS(a) => Some(Rc::try_unwrap(a).unwrap().into_inner()),
-            Self::None => None,
-        }
+        self.inner()
+            .map(|cs| Rc::try_unwrap(cs.clone()).unwrap().into_inner())
     }
 
     /// Obtain an immutable reference to the underlying `ConstraintSystem`.

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -771,8 +771,10 @@ impl<F: Field> ConstraintSystemRef<F> {
     /// `None` if `Self::CS` is `None` or if any other references to
     /// `Self::CS` exist.  
     pub fn into_inner(self) -> Option<ConstraintSystem<F>> {
-        self.inner()
-            .map(|cs| Rc::try_unwrap(cs.clone()).unwrap().into_inner())
+		match self {
+			Self::CS(a) => Rc::try_unwrap(a).ok().map(|s| s.into_inner()),
+			Self::None => None,
+		}
     }
 
     /// Obtain an immutable reference to the underlying `ConstraintSystem`.

--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -767,6 +767,15 @@ impl<F: Field> ConstraintSystemRef<F> {
         }
     }
 
+    /// Consumes self to return the inner `ConstraintSystem<F>`. Panics if
+    /// any other references to `self` exist.
+    pub fn into_inner(self) -> ConstraintSystem<F> {
+        match self {
+            Self::CS(a) => Rc::try_unwrap(a).unwrap().into_inner(),
+            Self::None => panic!()
+        }
+    }
+
     /// Obtain an immutable reference to the underlying `ConstraintSystem`.
     ///
     /// # Panics


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds a helper function to unwrap a `ConstraintSystemRef<F>`. This is useful for managing memory in https://github.com/arkworks-rs/marlin/pull/71.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
