### PR TITLE
Fix the stale directory name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ rustup install stable
 After that, use `cargo`, the standard Rust build tool, to build the libraries:
 ```bash
 git clone https://github.com/arkworks-rs/snark.git
-cd algebra
+cd snark
 cargo build --release
 ```
 

--- a/relations/src/r1cs/trace.rs
+++ b/relations/src/r1cs/trace.rs
@@ -107,8 +107,7 @@ where
         let span = subscriber
             .span(id)
             .expect("registry should have a span for the current ID");
-        let parents = span.parents();
-        for span in std::iter::once(span).chain(parents) {
+        for span in span.scope() {
             let cont = f(span.metadata(), "");
             if !cont {
                 break;


### PR DESCRIPTION
It looks like this should the the target working directory for the repo, which is now `snark` rather than `algebra`.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Just following the getting started instructions. This line doesn't make sense in context.

closes: #XXXX (no issue)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
