### PR TITLE
constraint tests correctly check is_satisfied

### DIFF
--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -1071,7 +1071,7 @@ mod tests {
         cs.enforce_constraint(lc!() + Variable::One, lc!() + e, lc!() + e)?;
 
         cs.finalize();
-        assert!(cs.is_satisfied().is_ok());
+        assert!(cs.is_satisfied().unwrap());
         let matrices = cs.to_matrices().unwrap();
         assert_eq!(matrices.a[0], vec![(Fr::one(), 1)]);
         assert_eq!(matrices.b[0], vec![(two, 2)]);
@@ -1129,7 +1129,7 @@ mod tests {
         )?;
 
         cs.finalize();
-        assert!(cs.is_satisfied().is_ok());
+        assert!(cs.is_satisfied().unwrap());
         let matrices = cs.to_matrices().unwrap();
         // There are four gates(constraints), each generating a row.
         // Resulting matrices:


### PR DESCRIPTION
## Description

The `is_satisfied()` method returns `Result<bool>` and so testing the result with
`.is_ok()` would pass for both `Ok(true)` and `Ok(false)`. `unwrap()`ping
and asserting that `true` is returned fixes this.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
      These are the unit tests.
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
