### PR TITLE
Remove unintended partial differential symbol from issue templates Description

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ about: Create a report to help us squash bugs!
 v                            ✰  Thanks for opening an issue! ✰    
 v    Before smashing the submit button please review the template.
 v    Please also ensure that this is not a duplicate issue :)  
-☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->∂
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
 
 ## Summary of Bug
 


### PR DESCRIPTION
This PR removes an unintended partial differential symbol (∂) that appears at the end of the comment block in issue templates.