### PR TITLE
Replace ConstraintSynthesizer trait with closure type alias

### DIFF
--- a/relations/src/r1cs/constraint_system.rs
+++ b/relations/src/r1cs/constraint_system.rs
@@ -15,13 +15,9 @@ use ark_std::{
 };
 
 /// Computations are expressed in terms of rank-1 constraint systems (R1CS).
-/// The `generate_constraints` method is called to generate constraints for
-/// both CRS generation and for proving.
-// TODO: Think: should we replace this with just a closure?
-pub trait ConstraintSynthesizer<F: Field> {
-    /// Drives generation of new constraints inside `cs`.
-    fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> crate::r1cs::Result<()>;
-}
+/// The type represents a closure that generates constraints for both CRS generation
+/// and for proving.
+pub type ConstraintSynthesizer<F> = Box<dyn FnOnce(ConstraintSystemRef<F>) -> crate::r1cs::Result<()>>;
 
 /// An Rank-One `ConstraintSystem`. Enforces constraints of the form
 /// `⟨a_i, z⟩ ⋅ ⟨b_i, z⟩ = ⟨c_i, z⟩`, where `a_i`, `b_i`, and `c_i` are linear


### PR DESCRIPTION
Description:
Addresses TODO comment by replacing the ConstraintSynthesizer trait with a type alias for a boxed closure. This change:
- Simplifies the constraint system interface
- Maintains the same functionality
- Makes the code more flexible by allowing direct use of closures
- Removes unnecessary trait boilerplate since the trait only had one method

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
