### PR TITLE
Fix: Use slice directly in polynomial evaluation

### DIFF
--- a/relations/src/gr1cs/predicate/polynomial_constraint.rs
+++ b/relations/src/gr1cs/predicate/polynomial_constraint.rs
@@ -38,12 +38,11 @@ impl<F: Field> PolynomialPredicate<F> {
 impl<F: Field> PolynomialPredicate<F> {
     /// Check if the predicate is satisfied by the given variables
     pub fn is_satisfied(&self, variables: &[F]) -> bool {
-        // TODO: Change the polynomial eval to get a slice as an evaluation point
-        !self.polynomial.evaluate(&variables.to_vec()).is_zero()
+        !self.polynomial.evaluate(variables).is_zero()
     }
     /// What is the evaluation of the polynomial predicate given the variables
     pub fn eval(&self, variables: &[F]) -> F {
-        self.polynomial.evaluate(&variables.to_vec())
+        self.polynomial.evaluate(variables)
     }
 
     /// Get the arity of the polynomial predicate


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This pull request addresses a TODO in the polynomial_constraint.rs file by directly passing the slice to the evaluate method instead of creating a new vector with to_vec(). This change improves efficiency by avoiding unnecessary memory allocation.

closes: # - 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
