### PR TITLE
chore: fixed multiplication error in `enforce_subcircuit2`

### DIFF
--- a/relations/examples/non_satisfiable.rs
+++ b/relations/examples/non_satisfiable.rs
@@ -110,10 +110,10 @@ fn enforce_subcircuit2<F: Field>(
     // let cs = ns!(cs, "subcircuit2").cs();
 
     // Multiplication gate 1: p3 * w3
-    let product1 = enforce_multiplication(cs.clone(), p3, p4)?;
+    let product1 = enforce_multiplication(cs.clone(), p3, w3)?;
 
     // Multiplication gate 2: p4 * w4
-    let product2 = enforce_multiplication(cs.clone(), w3, w4)?;
+    let product2 = enforce_multiplication(cs.clone(), p4, w4)?;
 
     // Final addition: product1 + product2
     let result = enforce_addition(cs, product1, product2)?;


### PR DESCRIPTION
## Description

I noticed an issue in the `enforce_subcircuit2` function where `p3` was being multiplied by `p4` instead of `p3` and `w3`, as indicated in the comments. This has now been corrected by changing the multiplication to `p3 * w3`. The fix ensures the constraint system works as intended.

---

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer