### PR TITLE
feat: Allow skipping of constraint generation during proving

### DIFF
--- a/relations/src/gr1cs/constraint_system_ref.rs
+++ b/relations/src/gr1cs/constraint_system_ref.rs
@@ -502,4 +502,20 @@ impl<F: Field> ConstraintSystemRef<F> {
             None
         }
     }
+
+    /// Set the witness mapping from an external source.
+    /// This is used to avoid regenerating constraints during proving.
+    /// The mapping should be between unoptimized instance variables and optimized witness variables.
+    #[inline]
+    pub fn set_witness_mapping(&self, mapping: BTreeMap<usize, usize>) {
+        self.inner()
+            .map_or((), |cs| cs.borrow_mut().set_witness_mapping(mapping))
+    }
+
+    /// Get the current witness mapping.
+    /// This can be used to store the mapping in an index file.
+    #[inline]
+    pub fn get_witness_mapping(&self) -> Option<BTreeMap<usize, usize>> {
+        self.inner().map(|cs| cs.borrow().get_witness_mapping().clone())
+    }
 }


### PR DESCRIPTION
## Description

This PR implements a mechanism to skip constraint generation during proving by storing a mapping between unoptimized and optimized witnesses. When the prover runs with construct_matrices=false, it can use this mapping to directly evaluate linear combinations without reconstructing the full constraint matrices, significantly improving proving performance.
The implementation adds a new witness_mapping field to the ConstraintSystem structure, updates the enforce_constraint method to use this mapping when appropriate, and adds methods to get/set the mapping through both ConstraintSystem and ConstraintSystemRef. A benchmark example is also updated to demonstrate the performance improvement.

closes: #328

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
