### PR TITLE
fix: address clippy warnings to improve code quality

### DIFF
--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -596,8 +596,7 @@ impl<F: Field> ConstraintSystem<F> {
     pub fn get_lc(&self, lc_index: LcIndex) -> crate::gr1cs::Result<&LinearCombination<F>> {
         self.lc_map
             .get(lc_index.0)
-            .map(|e| e.as_ref())
-            .flatten()
+            .and_then(|e| e.as_ref())
             .ok_or(SynthesisError::LcNotFound(lc_index))
     }
 

--- a/relations/src/gr1cs/constraint_system_ref.rs
+++ b/relations/src/gr1cs/constraint_system_ref.rs
@@ -423,7 +423,7 @@ impl<F: Field> ConstraintSystemRef<F> {
     pub fn get_lc(&self, lc_index: LcIndex) -> crate::utils::Result<LinearCombination<F>> {
         self.inner()
             .ok_or(SynthesisError::MissingCS)
-            .and_then(|cs| cs.borrow().get_lc(lc_index).map(|x| x.clone()))
+            .and_then(|cs| cs.borrow().get_lc(lc_index).cloned())
     }
 
     /// Given a linear combination, create a row in the matrix

--- a/relations/src/gr1cs/instance_outliner.rs
+++ b/relations/src/gr1cs/instance_outliner.rs
@@ -7,6 +7,9 @@ use super::{
 use ark_std::rc::Rc;
 use core::fmt::Debug;
 
+/// A type alias for the instance outlining function
+pub type InstanceOutliningFunction<F> = dyn Fn(&mut ConstraintSystem<F>, &[Variable]) -> Result<(), SynthesisError>;
+
 /// An instance outliner is a strategy for reducing the number of constraints
 /// that public input/instance variables are involved in.
 /// It does this as follows:
@@ -22,7 +25,7 @@ pub struct InstanceOutliner<F: Field> {
     /// The strategy for outlining the instance variables
     /// It takes as input the constraint system, and a map from the new
     /// instance variables to the new witness variables.
-    pub func: Rc<dyn Fn(&mut ConstraintSystem<F>, &[Variable]) -> Result<(), SynthesisError>>,
+    pub func: Rc<InstanceOutliningFunction<F>>,
 }
 
 impl<F: Field> Debug for InstanceOutliner<F> {
@@ -82,4 +85,4 @@ pub fn outline_sr1cs<F: Field>(
     }
 
     Ok(())
-}
+} 

--- a/relations/src/utils/variable.rs
+++ b/relations/src/utils/variable.rs
@@ -83,28 +83,28 @@ impl Variable {
 
 impl PartialOrd for Variable {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        use Variable::*;
-        match (self, other) {
-            (Zero, Zero) => Some(Ordering::Equal),
-            (One, One) => Some(Ordering::Equal),
-            (Zero, _) => Some(Ordering::Less),
-            (One, _) => Some(Ordering::Less),
-            (_, Zero) => Some(Ordering::Greater),
-            (_, One) => Some(Ordering::Greater),
-
-            (Instance(i), Instance(j)) | (Witness(i), Witness(j)) => i.partial_cmp(j),
-            (Instance(_), Witness(_)) => Some(Ordering::Less),
-            (Witness(_), Instance(_)) => Some(Ordering::Greater),
-
-            (SymbolicLc(i), SymbolicLc(j)) => i.partial_cmp(j),
-            (_, SymbolicLc(_)) => Some(Ordering::Less),
-            (SymbolicLc(_), _) => Some(Ordering::Greater),
-        }
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Variable {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        use Variable::*;
+        match (self, other) {
+            (Zero, Zero) => Ordering::Equal,
+            (One, One) => Ordering::Equal,
+            (Zero, _) => Ordering::Less,
+            (One, _) => Ordering::Less,
+            (_, Zero) => Ordering::Greater,
+            (_, One) => Ordering::Greater,
+
+            (Instance(i), Instance(j)) | (Witness(i), Witness(j)) => i.cmp(j),
+            (Instance(_), Witness(_)) => Ordering::Less,
+            (Witness(_), Instance(_)) => Ordering::Greater,
+
+            (SymbolicLc(i), SymbolicLc(j)) => i.cmp(j),
+            (_, SymbolicLc(_)) => Ordering::Less,
+            (SymbolicLc(_), _) => Ordering::Greater,
+        }
     }
 }

--- a/snark/src/lib.rs
+++ b/snark/src/lib.rs
@@ -102,6 +102,12 @@ pub enum UniversalSetupIndexError<Bound, E> {
     Other(E),
 }
 
+/// A type alias for the index result
+pub type IndexResult<PK, VK, Bound, E> = Result<
+    (PK, VK),
+    UniversalSetupIndexError<Bound, E>,
+>;
+
 /// A SNARK with universal setup. That is, a SNARK where the trusted setup is
 /// circuit-independent.
 pub trait UniversalSetupSNARK<F: PrimeField>: SNARK<F> {
@@ -126,8 +132,5 @@ pub trait UniversalSetupSNARK<F: PrimeField>: SNARK<F> {
         pp: &Self::PublicParameters,
         circuit: C,
         rng: &mut R,
-    ) -> Result<
-        (Self::ProvingKey, Self::VerifyingKey),
-        UniversalSetupIndexError<Self::ComputationBound, Self::Error>,
-    >;
+    ) -> IndexResult<Self::ProvingKey, Self::VerifyingKey, Self::ComputationBound, Self::Error>;
 }


### PR DESCRIPTION
## Description

This PR addresses several Clippy warnings throughout the codebase to improve code quality and readability:

1. In `constraint_system_ref.rs`, replaced `map(|x| x.clone())` with more idiomatic `cloned()` method
2. In `instance_outliner.rs`, introduced a type alias `InstanceOutliningFunction<F>` for the complex function type to improve code readability
3. In `constraint_system.rs`, replaced `map().flatten()` pattern with the more efficient `and_then()` method
4. In `variable.rs`, fixed non-canonical implementation of `PartialOrd` for `Variable` by using the canonical pattern that leverages the already implemented `Ord` trait
5. In `snark/src/lib.rs`, introduced a type alias `IndexResult` for the complex return type in the `UniversalSetupSNARK` trait

These changes make the code more idiomatic, more readable, and follow Rust best practices. The changes are purely refactoring and don't affect functionality.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
