### PR TITLE
Make PartialOrd implementation for Variable canonical by delegating t…

### DIFF
--- a/relations/src/utils/variable.rs
+++ b/relations/src/utils/variable.rs
@@ -83,28 +83,28 @@ impl Variable {
 
 impl PartialOrd for Variable {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        use Variable::*;
-        match (self, other) {
-            (Zero, Zero) => Some(Ordering::Equal),
-            (One, One) => Some(Ordering::Equal),
-            (Zero, _) => Some(Ordering::Less),
-            (One, _) => Some(Ordering::Less),
-            (_, Zero) => Some(Ordering::Greater),
-            (_, One) => Some(Ordering::Greater),
-
-            (Instance(i), Instance(j)) | (Witness(i), Witness(j)) => i.partial_cmp(j),
-            (Instance(_), Witness(_)) => Some(Ordering::Less),
-            (Witness(_), Instance(_)) => Some(Ordering::Greater),
-
-            (SymbolicLc(i), SymbolicLc(j)) => i.partial_cmp(j),
-            (_, SymbolicLc(_)) => Some(Ordering::Less),
-            (SymbolicLc(_), _) => Some(Ordering::Greater),
-        }
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Variable {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        use Variable::*;
+        match (self, other) {
+            (Zero, Zero) => Ordering::Equal,
+            (One, One) => Ordering::Equal,
+            (Zero, _) => Ordering::Less,
+            (One, _) => Ordering::Less,
+            (_, Zero) => Ordering::Greater,
+            (_, One) => Ordering::Greater,
+
+            (Instance(i), Instance(j)) | (Witness(i), Witness(j)) => i.cmp(j),
+            (Instance(_), Witness(_)) => Ordering::Less,
+            (Witness(_), Instance(_)) => Ordering::Greater,
+
+            (SymbolicLc(i), SymbolicLc(j)) => i.cmp(j),
+            (_, SymbolicLc(_)) => Ordering::Less,
+            (SymbolicLc(_), _) => Ordering::Greater,
+        }
     }
 }


### PR DESCRIPTION
…o Ord


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Refactored the PartialOrd implementation for the Variable enum to be canonical by delegating to the Ord implementation. This change replaces the custom comparison logic in PartialOrd with a simple call to self.cmp(other), wrapped in Some(...). This approach ensures consistency between PartialOrd and Ord, reduces code duplication.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
