### PR TITLE
Some optimizations in constraint synthesis.

### DIFF
--- a/relations/examples/bench-no-finalize.rs
+++ b/relations/examples/bench-no-finalize.rs
@@ -29,13 +29,13 @@ impl ConstraintSynthesizer<Fr> for BenchCircuit {
         variables.reserve(3 * self.num_constraints);
         let mut lcs = Vec::with_capacity(self.num_constraints);
 
-        let mut rng_a = ark_std::rand::rngs::StdRng::seed_from_u64(0 as u64);
+        let mut rng_a = ark_std::rand::rngs::StdRng::seed_from_u64(0_u64);
         let mut rng_b = ark_std::rand::rngs::StdRng::seed_from_u64(rng_a.gen::<u64>());
         let mut rng_c = ark_std::rand::rngs::StdRng::seed_from_u64(rng_a.gen::<u64>());
 
         for i in 0..self.num_constraints {
             let cur_num_vars = ark_std::cmp::min(variables.len(), 10);
-            let lower = variables.len().checked_sub(cur_num_vars).unwrap_or(0);
+            let lower = variables.len().saturating_sub(cur_num_vars);
             let upper = variables.len();
 
             let a_i_lc_size = rng_a.gen_range(1..=NUM_COEFFS_IN_LC);

--- a/relations/examples/bench.rs
+++ b/relations/examples/bench.rs
@@ -34,7 +34,7 @@ impl ConstraintSynthesizer<Fr> for BenchCircuit {
 
         for i in 0..self.num_constraints {
             let cur_num_vars = ark_std::cmp::min(variables.len(), 10);
-            let lower = variables.len().checked_sub(cur_num_vars).unwrap_or(0);
+            let lower = variables.len().saturating_sub(cur_num_vars);
             let upper = variables.len();
 
             let a_i_lc_size = rng_a.gen_range(1..=NUM_COEFFS_IN_LC);

--- a/relations/src/gr1cs/assignment.rs
+++ b/relations/src/gr1cs/assignment.rs
@@ -43,13 +43,11 @@ impl<F: Field> Assignments<F> {
         lc_map: &LcMap<F>,
         f_interner: &FieldInterner<F>,
     ) -> Option<F> {
-        let acc = lc_map
-            .get(lc)
-            .unwrap()
-            .map(|(&coeff, &var)| {
+        lc_map.get(lc).map(|lc| {
+            lc.map(|(&coeff, &var)| {
                 f_interner.value(coeff).unwrap() * self.assigned_value(var).unwrap()
             })
-            .sum();
-        Some(acc)
+            .sum()
+        })
     }
 }

--- a/relations/src/gr1cs/assignment.rs
+++ b/relations/src/gr1cs/assignment.rs
@@ -1,0 +1,55 @@
+use ark_ff::Field;
+use ark_std::vec::Vec;
+
+use crate::{
+    gr1cs::{field_interner::FieldInterner, lc_map::LcMap, Variable},
+    utils::variable::VarKind,
+};
+
+/// Assignments for a GR1CS constraint system.
+#[derive(Debug, Clone)]
+pub struct Assignments<F> {
+    /// Assignments to the public input variables. This is empty if `self.mode
+    /// == SynthesisMode::Setup`.
+    pub instance_assignment: Vec<F>,
+    /// Assignments to the private input variables. This is empty if `self.mode
+    /// == SynthesisMode::Setup`.
+    pub witness_assignment: Vec<F>,
+    /// A cache for the linear combination assignments. It shows evaluation
+    /// result of each linear combination
+    pub lc_assignment: Vec<F>,
+}
+
+impl<F: Field> Assignments<F> {
+    /// Obtain the assignment corresponding to the `Variable` `v`.
+    #[inline]
+    pub fn assigned_value(&self, v: Variable) -> Option<F> {
+        let idx = v.index();
+        match v.kind() {
+            VarKind::Zero => Some(F::ZERO),
+            VarKind::One => Some(F::ONE),
+            VarKind::Instance => self.instance_assignment.get(idx?).copied(),
+            VarKind::Witness => self.witness_assignment.get(idx?).copied(),
+            VarKind::SymbolicLc => self.lc_assignment.get(idx?).copied(),
+        }
+    }
+
+    /// Evaluate the linear combination `lc` with the assigned values and return
+    /// the result.
+    #[inline]
+    pub(super) fn eval_lc(
+        &self,
+        lc: usize,
+        lc_map: &LcMap<F>,
+        f_interner: &FieldInterner<F>,
+    ) -> Option<F> {
+        let acc = lc_map
+            .get(lc)
+            .unwrap()
+            .map(|(&coeff, &var)| {
+                f_interner.value(coeff).unwrap() * self.assigned_value(var).unwrap()
+            })
+            .sum();
+        Some(acc)
+    }
+}

--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -784,7 +784,7 @@ impl<F: Field> ConstraintSystem<F> {
                 }
             }
             out.compactify();
-            inlined_lcs.push_by_ref(&out);
+            inlined_lcs.push(out.clone());
             out.0.clear();
         }
         self.lc_map = inlined_lcs;
@@ -950,7 +950,6 @@ impl<F: Field> core::ops::Index<usize> for LcMap<F> {
 
     #[inline(always)]
     fn index(&self, index: usize) -> &Self::Output {
-        self.get(index)
-            .expect(&format!("Index out of bounds {index}"))
+        &self.0[index]
     }
 }

--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -811,13 +811,9 @@ impl<F: Field> ConstraintSystem<F> {
         if var.is_zero() {
             LinearCombination::zero()
         } else if var.is_lc() {
-            // If the variable is a symbolic linear combination, we return the
-            // linear combination corresponding to that index.
             let lc_index = var.index().unwrap();
             LinearCombination(self.lc_map[lc_index].to_vec())
         } else {
-            // If the variable is not a linear combination, we convert it to a
-            // linear combination.
             LinearCombination::from(var)
         }
     }

--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -849,8 +849,13 @@ impl<F: Field> ConstraintSystem<F> {
 
         // Now, Go over all the linear combinations and create a new witness for each
         // instance variable you see
-        cfg_iter_mut!(self.lc_map).for_each(|lc| {
-            for (_, var) in lc {
+        #[cfg(feature = "parallel")]
+        let lc_vars_iter_mut = self.lc_map.lc_vars_iter_mut();
+        #[cfg(not(feature = "parallel"))]
+        let lc_vars_iter_mut = self.lc_map.lc_vars_iter_mut();
+
+        lc_vars_iter_mut.for_each(|lc| {
+            for var in lc {
                 if var.is_instance() {
                     *var = instance_to_witness_map[var.index().unwrap()];
                 } else if var.is_one() {

--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -468,7 +468,7 @@ impl<F: Field> ConstraintSystem<F> {
     fn new_lc_without_adding(&mut self) -> crate::gr1cs::Result<Variable> {
         let index = self.num_linear_combinations;
         self.num_linear_combinations += 1;
-        Ok(Variable::SymbolicLc(index))
+        Ok(Variable::symbolic_lc(index))
     }
 
     fn new_lc_add_helper(
@@ -481,7 +481,7 @@ impl<F: Field> ConstraintSystem<F> {
     ) -> crate::gr1cs::Result<Variable> {
         match lc.0.as_slice() {
             // If the linear combination is empty, we return a symbolic LC with index 0.
-            [] | [(_, Variable::Zero)] => Ok(Variable::SymbolicLc(0)),
+            [] | [(_, Variable::Zero)] => Ok(Variable::symbolic_lc(0)),
             // If the linear combination is just another variable
             // with a coefficient of 1, we return the variable directly.
             [(c, var)] if c.is_one() => Ok(*var),
@@ -495,7 +495,7 @@ impl<F: Field> ConstraintSystem<F> {
                     let value = assignments.eval_lc(index, lc_map, field_interner).unwrap();
                     assignments.lc_assignment.push(value)
                 }
-                Ok(Variable::SymbolicLc(index))
+                Ok(Variable::symbolic_lc(index))
             },
         }
     }
@@ -606,7 +606,7 @@ impl<F: Field> ConstraintSystem<F> {
         if !self.is_in_setup_mode() {
             self.assignments.instance_assignment.push(f()?);
         }
-        Ok(Variable::Instance(index))
+        Ok(Variable::instance(index))
     }
 
     /// Obtain a variable representing a new private witness input.
@@ -621,7 +621,7 @@ impl<F: Field> ConstraintSystem<F> {
         if !self.is_in_setup_mode() {
             self.assignments.witness_assignment.push(f()?);
         }
-        Ok(Variable::Witness(index))
+        Ok(Variable::witness(index))
     }
 
     /// Register a predicate in the constraint system with a given label.

--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -784,7 +784,7 @@ impl<F: Field> ConstraintSystem<F> {
                 }
             }
             out.compactify();
-            inlined_lcs.push(out.clone());
+            inlined_lcs.push_by_ref(&out);
             out.0.clear();
         }
         self.lc_map = inlined_lcs;
@@ -950,6 +950,6 @@ impl<F: Field> core::ops::Index<usize> for LcMap<F> {
 
     #[inline(always)]
     fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
+        self.get(index).unwrap()
     }
 }

--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -488,7 +488,7 @@ impl<F: Field> ConstraintSystem<F> {
             // In all other cases, we create a new linear combination
             _ => {
                 let index = *cur_num_lcs;
-                assert_eq!(*cur_num_lcs, lc_map.len());
+                debug_assert_eq!(*cur_num_lcs, lc_map.num_lcs());
                 lc_map.push(lc, field_interner);
                 *cur_num_lcs += 1;
                 if should_generate_lc_assignments {
@@ -732,7 +732,8 @@ impl<F: Field> ConstraintSystem<F> {
             return;
         }
         let old_lc_map = core::mem::take(&mut self.lc_map);
-        let mut inlined_lcs = LcMap::<F>::with_capacity(old_lc_map.len());
+        let mut inlined_lcs =
+            LcMap::<F>::with_capacity(old_lc_map.num_lcs(), old_lc_map.total_lc_size());
 
         let mut out = LinearCombination(Vec::with_capacity(10));
         for lc in old_lc_map.iter() {

--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -1,6 +1,6 @@
 //! This module contains the implementation of the `ConstraintSystem` struct.
 //! a constraint system contains multiple predicate constraint systems,
-//! each of which enforce have separate predicates and constraints. For more information about the terminology and the structure of the constraint system, refer to section 3.3 of https://eprint.iacr.org/2024/1245
+//! each of which enforce have separate predicates and constraints. For more information about the terminology and the structure of the constraint system, refer to section 3.3 of <https://eprint.iacr.org/2024/1245>
 
 use super::{
     instance_outliner::InstanceOutliner,
@@ -35,9 +35,11 @@ use crate::utils::IndexMap;
 use rayon::prelude::*;
 ///////////////////////////////////////////////////////////////////////////////////////
 
-/// A GR1CS `ConstraintSystem`. Enforces constraints of the form  
-/// `L_i(⟨M_{i,1}, z⟩ , ⟨M_{i,2}, z⟩ , ..., ⟨M_{i,t_i}, z⟩)=0`
-/// More Information: https://eprint.iacr.org/2024/1245
+/// A GR1CS `ConstraintSystem`. Enforces constraints of the form
+///
+/// `L_i(⟨M_{i,1}, z⟩ , ⟨M_{i,2}, z⟩ , ..., ⟨M_{i,t_i}, z⟩) = 0`
+///
+/// More Information: <https://eprint.iacr.org/2024/1245>
 #[derive(Debug, Clone)]
 pub struct ConstraintSystem<F: Field> {
     /// The mode in which the constraint system is operating. `self` can either
@@ -65,7 +67,7 @@ pub struct ConstraintSystem<F: Field> {
     /// number of constraints or their total weight).
     optimization_goal: OptimizationGoal,
 
-    /// If true, the constraint system will outline the instances. Outlining the instances is a technique used for verification succinctness in some SNARKs like Polymath, Garuda, and Pari. For more information, refer to https://eprint.iacr.org/2024/1245
+    /// If true, the constraint system will outline the instances. Outlining the instances is a technique used for verification succinctness in some SNARKs like Polymath, Garuda, and Pari. For more information, refer to <https://eprint.iacr.org/2024/1245>.
     /// It assigns a witness variable to each instance variable and enforces the
     /// equality of the instance and witness variables. Then only uses the
     /// witness variables in the constraints.
@@ -265,7 +267,6 @@ impl<F: Field> ConstraintSystem<F> {
                     assignments,
                     field_interner,
                 )
-                .unwrap()
             });
 
             let predicate = self
@@ -299,8 +300,8 @@ impl<F: Field> ConstraintSystem<F> {
         }
 
         if self.should_construct_matrices() {
-            let a = self.new_constraint_lc(a)?;
-            let b = self.new_constraint_lc(b)?;
+            let a = self.new_constraint_lc(a);
+            let b = self.new_constraint_lc(b);
 
             let predicate = self
                 .predicate_constraint_systems
@@ -331,9 +332,9 @@ impl<F: Field> ConstraintSystem<F> {
         }
 
         if self.should_construct_matrices() {
-            let a = self.new_constraint_lc(a)?;
-            let b = self.new_constraint_lc(b)?;
-            let c = self.new_constraint_lc(c)?;
+            let a = self.new_constraint_lc(a);
+            let b = self.new_constraint_lc(b);
+            let c = self.new_constraint_lc(c);
 
             let predicate = self
                 .predicate_constraint_systems
@@ -365,10 +366,10 @@ impl<F: Field> ConstraintSystem<F> {
         }
 
         if self.should_construct_matrices() {
-            let a = self.new_constraint_lc(a)?;
-            let b = self.new_constraint_lc(b)?;
-            let c = self.new_constraint_lc(c)?;
-            let d = self.new_constraint_lc(d)?;
+            let a = self.new_constraint_lc(a);
+            let b = self.new_constraint_lc(b);
+            let c = self.new_constraint_lc(c);
+            let d = self.new_constraint_lc(d);
 
             let predicate = self
                 .predicate_constraint_systems
@@ -401,11 +402,11 @@ impl<F: Field> ConstraintSystem<F> {
         }
 
         if self.should_construct_matrices() {
-            let a = self.new_constraint_lc(a)?;
-            let b = self.new_constraint_lc(b)?;
-            let c = self.new_constraint_lc(c)?;
-            let d = self.new_constraint_lc(d)?;
-            let e = self.new_constraint_lc(e)?;
+            let a = self.new_constraint_lc(a);
+            let b = self.new_constraint_lc(b);
+            let c = self.new_constraint_lc(c);
+            let d = self.new_constraint_lc(d);
+            let e = self.new_constraint_lc(e);
 
             let predicate = self
                 .predicate_constraint_systems
@@ -451,10 +452,7 @@ impl<F: Field> ConstraintSystem<F> {
     /// Add a new linear combination to the constraint system.
     /// This linear combination is to be used only for constraints, not for variables.
     #[inline]
-    fn new_constraint_lc(
-        &mut self,
-        lc: impl FnOnce() -> LinearCombination<F>,
-    ) -> crate::gr1cs::Result<Variable> {
+    fn new_constraint_lc(&mut self, lc: impl FnOnce() -> LinearCombination<F>) -> Variable {
         if self.should_construct_matrices() {
             self.new_lc_helper(lc)
         } else {
@@ -465,10 +463,10 @@ impl<F: Field> ConstraintSystem<F> {
     /// Creates a new index for the linear combination without adding the concrete LC expression
     /// to the map.
     #[inline]
-    fn new_lc_without_adding(&mut self) -> crate::gr1cs::Result<Variable> {
+    fn new_lc_without_adding(&mut self) -> Variable {
         let index = self.num_linear_combinations;
         self.num_linear_combinations += 1;
-        Ok(Variable::symbolic_lc(index))
+        Variable::symbolic_lc(index)
     }
 
     fn new_lc_add_helper(
@@ -478,13 +476,13 @@ impl<F: Field> ConstraintSystem<F> {
         should_generate_lc_assignments: bool,
         assignments: &mut Assignments<F>,
         field_interner: &mut FieldInterner<F>,
-    ) -> crate::gr1cs::Result<Variable> {
+    ) -> Variable {
         match lc.0.as_slice() {
             // If the linear combination is empty, we return a symbolic LC with index 0.
-            [] | [(_, Variable::Zero)] => Ok(Variable::symbolic_lc(0)),
+            [] | [(_, Variable::Zero)] => Variable::symbolic_lc(0),
             // If the linear combination is just another variable
             // with a coefficient of 1, we return the variable directly.
-            [(c, var)] if c.is_one() => Ok(*var),
+            [(c, var)] if c.is_one() => *var,
             // In all other cases, we create a new linear combination
             _ => {
                 let index = *cur_num_lcs;
@@ -493,19 +491,16 @@ impl<F: Field> ConstraintSystem<F> {
                 *cur_num_lcs += 1;
                 if should_generate_lc_assignments {
                     let value = assignments.eval_lc(index, lc_map, field_interner).unwrap();
-                    assignments.lc_assignment.push(value)
+                    assignments.lc_assignment.push(value);
                 }
-                Ok(Variable::symbolic_lc(index))
+                Variable::symbolic_lc(index)
             },
         }
     }
 
     /// Helper function to add a new linear combination to the constraint system.
     #[inline]
-    fn new_lc_helper(
-        &mut self,
-        lc: impl FnOnce() -> LinearCombination<F>,
-    ) -> crate::gr1cs::Result<Variable> {
+    fn new_lc_helper(&mut self, lc: impl FnOnce() -> LinearCombination<F>) -> Variable {
         let should_push = self.should_construct_matrices() || self.should_generate_lc_assignments();
         let should_generate_lc_assignments = self.should_generate_lc_assignments();
         if should_push {
@@ -533,7 +528,7 @@ impl<F: Field> ConstraintSystem<F> {
         // we need to ensure that it is added to the lc_map whenever
         // `self.should_construct_matrices()` is true.
         // `self.new_lc_helper` will handle this.
-        self.new_lc_helper(lc)
+        Ok(self.new_lc_helper(lc))
     }
 
     /// Set `self.mode` to `mode`.
@@ -591,10 +586,7 @@ impl<F: Field> ConstraintSystem<F> {
         }
     }
 
-    /// Obtain a variable representing a new public instance input
-    /// This function takes a closure, this closure returns `Result<F>`
-    /// Internally, this function calls new_input_variable of the constraint
-    /// system to which it's pointing
+    /// Obtain a variable representing a new public instance input.
     #[inline]
     pub fn new_input_variable<Func>(&mut self, f: Func) -> crate::utils::Result<Variable>
     where
@@ -670,7 +662,7 @@ impl<F: Field> ConstraintSystem<F> {
         if self.is_in_setup_mode() {
             Err(SynthesisError::AssignmentMissing)
         } else {
-            for (label, predicate) in self.predicate_constraint_systems.iter() {
+            for (label, predicate) in &self.predicate_constraint_systems {
                 if let Some(unsatisfied_constraint) =
                     predicate.which_constraint_is_unsatisfied(self)
                 {
@@ -775,7 +767,7 @@ impl<F: Field> ConstraintSystem<F> {
     /// corresponding set of matrices
     pub fn to_matrices(&self) -> crate::gr1cs::Result<BTreeMap<Label, Vec<Matrix<F>>>> {
         let mut matrices = BTreeMap::new();
-        for (label, predicate) in self.predicate_constraint_systems.iter() {
+        for (label, predicate) in &self.predicate_constraint_systems {
             matrices.insert(label.clone(), predicate.to_matrices(self));
         }
         Ok(matrices)
@@ -822,13 +814,15 @@ impl<F: Field> ConstraintSystem<F> {
         self.instance_outliner.is_some()
     }
 
-    /// Outlines the instances in the constraint system
+    /// Outlines the instances in the constraint system.
+    ///
     /// This function creates a new witness variable for each instance
     /// variable and uses these witness variables in the constraints
     /// instead of instance variables. This technique is useful for
     /// verifier succinctness in some SNARKs like Garuda, Pari and
-    /// PolyMath After the function call, The instances are only
-    /// used in the `c` matrix of r1cs
+    /// PolyMath.
+    /// After the function call, instances are only
+    /// used in the `C` matrix of r1cs
     pub fn perform_instance_outlining(
         &mut self,
         outliner: InstanceOutliner<F>,

--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -878,10 +878,10 @@ impl<F: Field> ConstraintSystem<F> {
                 if var.is_instance() {
                     *var = instance_to_witness_map[var.index().unwrap()];
                 } else if var.is_one() {
-                        *var = one_witness_var;
-                    }
+                    *var = one_witness_var;
                 }
-            });
+            }
+        });
         (outliner.func)(self, &instance_to_witness_map)?;
         Ok(())
     }
@@ -924,9 +924,7 @@ impl<F: Field> LcMap<F> {
 
     #[inline(always)]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut [(F, Variable)]> {
-        self.0
-            .iter_mut()
-            .map(|lc| lc.0.as_mut_slice())
+        self.0.iter_mut().map(|lc| lc.0.as_mut_slice())
     }
 
     #[cfg(feature = "parallel")]

--- a/relations/src/gr1cs/constraint_system_ref.rs
+++ b/relations/src/gr1cs/constraint_system_ref.rs
@@ -284,7 +284,7 @@ impl<F: Field> ConstraintSystemRef<F> {
     }
 
     /// Set `self.mode` to `mode`.
-    /// Sets the mode if there exists an underlying ConstraintSystem.
+    /// Sets the mode if there exists an underlying `ConstraintSystem`.
     pub fn set_mode(&self, mode: SynthesisMode) {
         self.inner().map_or((), |cs| cs.borrow_mut().set_mode(mode))
     }
@@ -328,10 +328,9 @@ impl<F: Field> ConstraintSystemRef<F> {
     /// Specify the strategy for how the instance should be outlined.
     /// This should be compatible with the predicates in the constraint system.
     #[inline]
-    pub fn set_instance_outliner(&self, instance_outliner: InstanceOutliner<F>) {
-        self.inner().map_or((), |cs| {
-            cs.borrow_mut().set_instance_outliner(instance_outliner)
-        })
+    pub fn set_instance_outliner(&self, outliner: InstanceOutliner<F>) {
+        self.inner()
+            .map_or((), |cs| cs.borrow_mut().set_instance_outliner(outliner))
     }
 
     /// Check whether or not `self` will construct matrices.
@@ -341,10 +340,7 @@ impl<F: Field> ConstraintSystemRef<F> {
             .is_some_and(|cs| cs.borrow().should_construct_matrices())
     }
 
-    /// Obtain a variable representing a new public instance input
-    /// This function takes a closure, this closure returns `Result<F>`
-    /// Internally, this function calls new_input_variable of the constraint
-    /// system to which it's pointing
+    /// Obtain a variable representing a new public instance input.
     #[inline]
     pub fn new_input_variable<Func>(&self, f: Func) -> crate::utils::Result<Variable>
     where
@@ -353,13 +349,13 @@ impl<F: Field> ConstraintSystemRef<F> {
         self.inner()
             .ok_or(SynthesisError::MissingCS)
             .and_then(|cs| {
-                if !self.is_in_setup_mode() {
+                if self.is_in_setup_mode() {
+                    cs.borrow_mut().new_input_variable(f)
+                } else {
                     // This is needed to avoid double-borrows, because `f`
                     // might itself mutably borrow `cs` (eg: `f = || g.value()`).
                     let value = f();
                     cs.borrow_mut().new_input_variable(|| value)
-                } else {
-                    cs.borrow_mut().new_input_variable(f)
                 }
             })
     }
@@ -374,13 +370,13 @@ impl<F: Field> ConstraintSystemRef<F> {
             .inner()
             .ok_or(SynthesisError::MissingCS)
             .and_then(|cs| {
-                if !self.is_in_setup_mode() {
+                if self.is_in_setup_mode() {
+                    cs.borrow_mut().new_witness_variable(f)
+                } else {
                     // This is needed to avoid double-borrows, because `f`
                     // might itself mutably borrow `cs` (eg: `f = || g.value()`).
                     let value = f();
                     cs.borrow_mut().new_witness_variable(|| value)
-                } else {
-                    cs.borrow_mut().new_witness_variable(f)
                 }
             });
         a
@@ -389,21 +385,18 @@ impl<F: Field> ConstraintSystemRef<F> {
     /// Register a  predicate in the constraint system with a given label.
     pub fn register_predicate(
         &self,
-        predicate_label: &str,
+        label: &str,
         predicate: PredicateConstraintSystem<F>,
     ) -> crate::utils::Result<()> {
         self.inner()
             .ok_or(SynthesisError::MissingCS)
-            .and_then(|cs| {
-                cs.borrow_mut()
-                    .register_predicate(predicate_label, predicate)
-            })
+            .and_then(|cs| cs.borrow_mut().register_predicate(label, predicate))
     }
 
-    /// Remove a predicate with the given label from the constraint system.
-    pub fn remove_predicate(&self, predicate_label: &str) {
+    /// Remove a predicate with the given `label` from the constraint system.
+    pub fn remove_predicate(&self, label: &str) {
         self.inner()
-            .map_or((), |cs| cs.borrow_mut().remove_predicate(predicate_label))
+            .map_or((), |cs| cs.borrow_mut().remove_predicate(label))
     }
 
     /// Checks if there is a predicate with the given label in the constraint
@@ -441,7 +434,7 @@ impl<F: Field> ConstraintSystemRef<F> {
     /// if an optimization goal is set).
     pub fn finalize(&self) {
         if let Some(cs) = self.inner() {
-            cs.borrow_mut().finalize()
+            cs.borrow_mut().finalize();
         }
     }
 
@@ -455,15 +448,16 @@ impl<F: Field> ConstraintSystemRef<F> {
     /// is the dominating cost.
     pub fn inline_all_lcs(&self) {
         if let Some(cs) = self.inner() {
-            cs.borrow_mut().inline_all_lcs()
+            cs.borrow_mut().inline_all_lcs();
         }
     }
 
     /// Returns `self` if `!self.is_none()`, otherwise returns `other`.
+    #[must_use]
     pub fn or(self, other: Self) -> Self {
         match self {
             ConstraintSystemRef::None => other,
-            _ => self,
+            ConstraintSystemRef::CS(_) => self,
         }
     }
 

--- a/relations/src/gr1cs/constraint_system_ref.rs
+++ b/relations/src/gr1cs/constraint_system_ref.rs
@@ -3,7 +3,7 @@
 //! inner struct. Most of the functions of `ConstraintSystemRef` are just
 //! wrappers around the functions of `ConstraintSystem`.
 
-use crate::utils::{HashBuilder, IndexMap};
+use crate::utils::IndexMap;
 use ark_std::boxed::Box;
 use ark_std::collections::BTreeMap;
 use core::cell::{Ref, RefCell, RefMut};
@@ -53,10 +53,9 @@ impl<F: Field> ConstraintSystemRef<F> {
 
     /// Returns the number of constraints in each predicate
     pub fn get_all_predicates_num_constraints(&self) -> IndexMap<Label, usize> {
-        self.inner()
-            .map_or(IndexMap::with_hasher(HashBuilder::default()), |cs| {
-                cs.borrow().get_all_predicates_num_constraints()
-            })
+        self.inner().map_or_else(IndexMap::default, |cs| {
+            cs.borrow().get_all_predicates_num_constraints()
+        })
     }
 
     /// Returns the number of constraints in the predicate with the given label
@@ -67,7 +66,7 @@ impl<F: Field> ConstraintSystemRef<F> {
 
     /// Returns the arity of each predicate
     pub fn get_all_predicate_arities(&self) -> IndexMap<Label, usize> {
-        self.inner().map_or(IndexMap::default(), |cs| {
+        self.inner().map_or_else(IndexMap::default, |cs| {
             cs.borrow().get_all_predicate_arities()
         })
     }

--- a/relations/src/gr1cs/field_interner.rs
+++ b/relations/src/gr1cs/field_interner.rs
@@ -59,7 +59,7 @@ impl<F: Field> FieldInterner<F> {
     #[inline(always)]
     pub(crate) fn value(&self, id: InternedField) -> Option<F> {
         if id == InternedField(0) {
-            return Some(F::ONE);
+            Some(F::ONE)
         } else if id == InternedField(1) {
             return Some(-F::ONE);
         } else {

--- a/relations/src/gr1cs/field_interner.rs
+++ b/relations/src/gr1cs/field_interner.rs
@@ -1,0 +1,69 @@
+use ark_std::vec::Vec;
+
+use ark_ff::Field;
+
+use crate::utils::IndexMap;
+
+/// Interned field element:
+///
+/// * bit 0   – tag: 0 = inline constant, 1 = pooled
+/// * bits 1-23  (23 b) – signed small constant (two’s complement)
+/// * bits 24-63 (40 b) – index into the coefficient pool
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct InternedField(u32);
+
+/// An interner for field elements.
+#[derive(Debug, Clone, Default)]
+pub struct FieldInterner<F: Field> {
+    /// The map from field elements to their interned representation.
+    pub map: IndexMap<F, InternedField>,
+    /// The vector of field elements in the order they were added.
+    pub vec: Vec<F>,
+}
+
+impl<F: Field> FieldInterner<F> {
+    /// Creates a new field interner.
+    #[inline]
+    pub(super) fn new() -> Self {
+        let mut result = Self {
+            map: IndexMap::default(),
+            vec: Vec::new(),
+        };
+        result.intern(F::ONE);
+        result.intern(-F::ONE);
+        result
+    }
+
+    #[inline(always)]
+    fn intern(&mut self, value: F) -> InternedField {
+        let index = self.vec.len();
+        let interned = InternedField(index as u32);
+        self.map.insert(value, interned);
+        self.vec.push(value);
+        interned
+    }
+
+    /// Interns a field element, returning its unique identifier.
+    #[inline]
+    pub(crate) fn get_or_intern(&mut self, value: F) -> InternedField {
+        if value == F::ONE {
+            InternedField(0)
+        } else if let Some(&index) = self.map.get(&value) {
+            index
+        } else {
+            self.intern(value)
+        }
+    }
+
+    /// Returns the field element corresponding to the given identifier.
+    #[inline(always)]
+    pub(crate) fn value(&self, id: InternedField) -> Option<F> {
+        if id == InternedField(0) {
+            return Some(F::ONE);
+        } else if id == InternedField(1) {
+            return Some(-F::ONE);
+        } else {
+            self.vec.get(id.0 as usize).copied()
+        }
+    }
+}

--- a/relations/src/gr1cs/field_interner.rs
+++ b/relations/src/gr1cs/field_interner.rs
@@ -35,6 +35,7 @@ impl<F: Field> FieldInterner<F> {
     }
 
     #[inline(always)]
+    #[allow(clippy::cast_possible_truncation)]
     fn intern(&mut self, value: F) -> InternedField {
         let index = self.vec.len();
         let interned = InternedField(index as u32);

--- a/relations/src/gr1cs/instance_outliner.rs
+++ b/relations/src/gr1cs/instance_outliner.rs
@@ -21,8 +21,11 @@ pub struct InstanceOutliner<F: Field> {
     /// The strategy for outlining the instance variables
     /// It takes as input the constraint system, and a map from the new
     /// instance variables to the new witness variables.
-    pub func: Rc<dyn Fn(&mut ConstraintSystem<F>, &[Variable]) -> Result<(), SynthesisError>>,
+    pub func: OutliningFunc<F>,
 }
+
+type OutliningFunc<F> =
+    Rc<dyn Fn(&mut ConstraintSystem<F>, &[Variable]) -> Result<(), SynthesisError>>;
 
 impl<F: Field> Debug for InstanceOutliner<F> {
     fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {

--- a/relations/src/gr1cs/instance_outliner.rs
+++ b/relations/src/gr1cs/instance_outliner.rs
@@ -50,7 +50,7 @@ pub fn outline_r1cs<F: Field>(
         cs.enforce_r1cs_constraint(
             || lc![one],
             || lc![*witness],
-            || lc![Variable::Instance(instance)],
+            || lc![Variable::instance(instance)],
         )?;
     }
 
@@ -69,7 +69,7 @@ pub fn outline_sr1cs<F: Field>(
     // constraint system has a default r1cs predicate registered
     for (instance, witness) in instance_witness_map.iter().enumerate() {
         cs.enforce_sr1cs_constraint(
-            || lc_diff![Variable::Instance(instance), *witness],
+            || lc_diff![Variable::instance(instance), *witness],
             || lc![],
         )?;
     }

--- a/relations/src/gr1cs/lc_map.rs
+++ b/relations/src/gr1cs/lc_map.rs
@@ -75,11 +75,11 @@ impl<F: Field> LcMap<F> {
     }
 
     #[inline(always)]
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub fn with_capacity(expected_num_lcs: usize, expected_total_lc_size: usize) -> Self {
         let mut result = Self::new();
-        result.vars.reserve(capacity * 2);
-        result.coeffs.reserve(capacity * 2);
-        result.offsets.reserve(capacity + 1);
+        result.vars.reserve(expected_total_lc_size);
+        result.coeffs.reserve(expected_total_lc_size);
+        result.offsets.reserve(expected_num_lcs + 1);
         result
     }
 
@@ -162,14 +162,19 @@ impl<F: Field> LcMap<F> {
     }
 
     #[inline(always)]
-    pub fn len(&self) -> usize {
+    pub fn num_lcs(&self) -> usize {
         self.offsets.len() - 1
+    }
+
+    #[inline(always)]
+    pub fn total_lc_size(&self) -> usize {
+        self.vars.len()
     }
 
     #[allow(unsafe_code)]
     #[inline(always)]
     pub fn get(&self, idx: usize) -> Option<LcMapIterItem<'_>> {
-        if idx >= self.len() || self.offsets.len() < 2 {
+        if idx >= self.num_lcs() || self.offsets.len() < 2 {
             return cold();
         } else {
             unsafe {

--- a/relations/src/gr1cs/lc_map.rs
+++ b/relations/src/gr1cs/lc_map.rs
@@ -222,7 +222,7 @@ unsafe fn windowed_access<'a>(
         // By precondition 1, `w` is a slice of length 2, so these accesses are within bounds.
         let start = *w.get_unchecked(0);
         let end = *w.get_unchecked(1);
-        // By precondition 2, `start..end` is not an empty range.
+        // By precondition 2, `start..end` is always valid.
         // By precondition 3, `end` is within bounds of `coeffs` and `vars`.
         coeffs
             .get_unchecked(start..end)

--- a/relations/src/gr1cs/lc_map.rs
+++ b/relations/src/gr1cs/lc_map.rs
@@ -23,7 +23,7 @@ use crate::gr1cs::{
 /// 5. `self.coeffs` and `self.vars` are interleaved such that for each linear combination `i`,
 ///    the coefficients and variables are stored in the same order, i.e.,
 ///    letting `start = self.offsets[i]` and `end = self.offsets[i + 1]`, then
-///    `self.vars[start..end]` corresponds to `self.coeffs[start..end]
+///    `self.vars[start..end]` corresponds to `self.coeffs[start..end]`.
 ///
 /// Invariants 2 and 3 imply the following lemma:
 /// Lemma 1. `self.offsets[i] <= self.offsets[i + 1]` for all `i` in `0..n`.

--- a/relations/src/gr1cs/lc_map.rs
+++ b/relations/src/gr1cs/lc_map.rs
@@ -477,14 +477,14 @@ mod tests {
         lcmap.push(
             [
                 (1u8.into(), Variable::One),
-                (2u8.into(), Variable::Instance(2)),
+                (2u8.into(), Variable::instance(2)),
             ],
             &mut interner,
         );
         lcmap.push(
             [
-                (3u8.into(), Variable::Witness(4)),
-                (4u8.into(), Variable::Instance(4)),
+                (3u8.into(), Variable::witness(4)),
+                (4u8.into(), Variable::instance(4)),
             ],
             &mut interner,
         );
@@ -493,7 +493,7 @@ mod tests {
         lcmap.lc_vars_par_iter_mut().for_each(|chunk| {
             for v in chunk {
                 if v.is_instance() {
-                    *v = Variable::Instance(v.index().unwrap() + 1);
+                    *v = Variable::instance(v.index().unwrap() + 1);
                 }
             }
         });
@@ -506,9 +506,9 @@ mod tests {
 
         let expected = vec![
             (1u8.into(), Variable::One),
-            (2u8.into(), Variable::Instance(3)),
-            (3u8.into(), Variable::Witness(4)),
-            (4u8.into(), Variable::Instance(5)),
+            (2u8.into(), Variable::instance(3)),
+            (3u8.into(), Variable::witness(4)),
+            (4u8.into(), Variable::instance(5)),
         ];
 
         assert_eq!(flattened, expected);
@@ -523,14 +523,14 @@ mod tests {
         lcmap.push(
             [
                 (1u8.into(), Variable::One),
-                (2u8.into(), Variable::Instance(2)),
+                (2u8.into(), Variable::instance(2)),
             ],
             &mut interner,
         );
         lcmap.push(
             [
-                (3u8.into(), Variable::Witness(4)),
-                (4u8.into(), Variable::Instance(4)),
+                (3u8.into(), Variable::witness(4)),
+                (4u8.into(), Variable::instance(4)),
             ],
             &mut interner,
         );
@@ -539,7 +539,7 @@ mod tests {
         lcmap.lc_vars_iter_mut().for_each(|chunk| {
             for v in chunk {
                 if v.is_instance() {
-                    *v = Variable::Instance(v.index().unwrap() + 1);
+                    *v = Variable::instance(v.index().unwrap() + 1);
                 }
             }
         });
@@ -552,9 +552,9 @@ mod tests {
 
         let expected = vec![
             (1u8.into(), Variable::One),
-            (2u8.into(), Variable::Instance(3)),
-            (3u8.into(), Variable::Witness(4)),
-            (4u8.into(), Variable::Instance(5)),
+            (2u8.into(), Variable::instance(3)),
+            (3u8.into(), Variable::witness(4)),
+            (4u8.into(), Variable::instance(5)),
         ];
 
         assert_eq!(flattened, expected);

--- a/relations/src/gr1cs/lc_map.rs
+++ b/relations/src/gr1cs/lc_map.rs
@@ -175,7 +175,7 @@ impl<F: Field> LcMap<F> {
     #[inline(always)]
     pub fn get(&self, idx: usize) -> Option<LcMapIterItem<'_>> {
         if idx >= self.num_lcs() || self.offsets.len() < 2 {
-            return cold();
+            cold()
         } else {
             unsafe {
                 // SAFETY:
@@ -240,8 +240,8 @@ unsafe fn windowed_access<'a>(
 /// and the second part is the remaining variables.
 /// `vars` is updated to point to the second part.
 #[inline(always)]
-unsafe fn windowed_access_mut<'a, 'b>(
-    w: &'a [usize],
+unsafe fn windowed_access_mut<'b>(
+    w: &[usize],
     vars: &mut &'b mut [Variable],
 ) -> LcVarsIterMutItem<'b> {
     debug_assert!(w.len() == 2, "Expected a slice of length 2");

--- a/relations/src/gr1cs/lc_map.rs
+++ b/relations/src/gr1cs/lc_map.rs
@@ -1,0 +1,297 @@
+#![allow(unsafe_code)]
+
+use ark_ff::Field;
+use ark_std::vec::*;
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use crate::gr1cs::{
+    field_interner::{FieldInterner, InternedField},
+    Variable,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct LcMap<F: Field> {
+    vars: Vec<Variable>,
+    coeffs: Vec<InternedField>,
+    offsets: Vec<usize>, // Starting indices of each inner slice in `vars` and `coeffs``
+    _f: core::marker::PhantomData<F>,
+}
+
+pub(crate) fn to_non_interned_lc<'a, F: Field>(
+    lc: impl Iterator<Item = (&'a InternedField, &'a Variable)> + 'a,
+    f_interner: &'a FieldInterner<F>,
+) -> impl Iterator<Item = (F, Variable)> + 'a {
+    lc.map(|(&c, &v)| (f_interner.value(c).unwrap(), v))
+}
+
+type LcMapIterItem<'a> =
+    core::iter::Zip<core::slice::Iter<'a, InternedField>, core::slice::Iter<'a, Variable>>;
+type LcMapIterMutItem<'a> =
+    core::iter::Zip<core::slice::IterMut<'a, InternedField>, core::slice::IterMut<'a, Variable>>;
+
+impl<F: Field> LcMap<F> {
+    #[inline(always)]
+    pub fn new() -> Self {
+        Self {
+            vars: Vec::new(),
+            coeffs: Vec::new(),
+            offsets: vec![0],
+            _f: core::marker::PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut result = Self::new();
+        result.vars.reserve(capacity * 2);
+        result.coeffs.reserve(capacity * 2);
+        result.offsets.reserve(capacity + 1);
+        result
+    }
+
+    #[inline(always)]
+    pub fn push(
+        &mut self,
+        v: impl IntoIterator<Item = (F, Variable)>,
+        f_interner: &mut FieldInterner<F>,
+    ) {
+        for (coeff, var) in v {
+            self.coeffs.push(f_interner.get_or_intern(coeff));
+            self.vars.push(var);
+        }
+        self.offsets.push(self.coeffs.len());
+    }
+
+    #[inline(always)]
+    pub fn push_by_ref<'a>(
+        &mut self,
+        v: impl IntoIterator<Item = &'a (F, Variable)>,
+        f_interner: &mut FieldInterner<F>,
+    ) {
+        for (coeff, var) in v {
+            self.coeffs.push(f_interner.get_or_intern(*coeff));
+            self.vars.push(*var);
+        }
+        self.offsets.push(self.coeffs.len());
+    }
+
+    #[inline(always)]
+    pub fn iter(&self) -> impl Iterator<Item = LcMapIterItem<'_>> {
+        self.offsets
+            .windows(2)
+            .map(|w| windowed_access(w, &self.coeffs, &self.vars))
+    }
+
+    #[cfg(feature = "parallel")]
+    #[inline(always)]
+    pub fn par_iter(&self) -> impl ParallelIterator<Item = LcMapIterItem<'_>> {
+        self.offsets
+            .par_windows(2)
+            .map(|w| windowed_access(w, &self.coeffs, &self.vars))
+    }
+
+    #[inline(always)]
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = LcMapIterMutItem<'_>> {
+        LcMapIterMut {
+            coeffs: &mut self.coeffs,
+            vars: &mut self.vars,
+            offsets: self.offsets.windows(2),
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[inline(always)]
+    pub fn par_iter_mut(&mut self) -> LcMapParIterMut<'_> {
+        LcMapParIterMut {
+            coeffs: self.coeffs.as_mut_ptr(),
+            vars: self.vars.as_mut_ptr(),
+            offsets: &self.offsets,
+        }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
+    #[allow(unsafe_code)]
+    #[inline(always)]
+    pub fn get(&self, idx: usize) -> Option<LcMapIterItem<'_>> {
+        if idx >= self.len() {
+            return cold();
+        } else {
+            Some(windowed_access(
+                unsafe { self.offsets.get_unchecked(idx..=(idx + 1)) },
+                &self.coeffs,
+                &self.vars,
+            ))
+        }
+    }
+}
+
+///
+fn windowed_access<'a>(
+    w: &'a [usize],
+    coeffs: &'a [InternedField],
+    vars: &'a [Variable],
+) -> LcMapIterItem<'a> {
+    unsafe {
+        // SAFETY:
+        // by construction, `self.offsets` always has an odd number of elements,
+        // and so `w` always has two elements
+        let start = *w.get_unchecked(0);
+        let end = *w.get_unchecked(1);
+        // `start` and `end` are guaranteed to be within bounds of `self.coeffs` and `self.vars`
+        coeffs
+            .get_unchecked(start..end)
+            .iter()
+            .zip(vars.get_unchecked(start..end))
+    }
+}
+
+#[cold]
+fn cold<'a>() -> Option<LcMapIterItem<'a>> {
+    None
+}
+
+pub struct LcMapIterMut<'a> {
+    coeffs: &'a mut [InternedField],
+    vars: &'a mut [Variable],
+    offsets: core::slice::Windows<'a, usize>,
+}
+
+impl<'a> Iterator for LcMapIterMut<'a> {
+    type Item = LcMapIterMutItem<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some([start, end]) = self.offsets.next() else {
+            return None;
+        };
+
+        let len = end - start;
+        // SAFETY:
+        // * By construction, `start <= end` (we only append something larger than `start` to `offsets`)
+        // * `since `end = start + length_of_lc`, `len` is guaranteed to be within bounds
+        //    of `self.coeffs` and `self.vars`.
+        //    This is because the latter two are always appended to together.
+        #[allow(unsafe_code)]
+        unsafe {
+            let (c_head, c_tail) = core::mem::take(&mut self.coeffs).split_at_mut_unchecked(len);
+            let (v_head, v_tail) = core::mem::take(&mut self.vars).split_at_mut_unchecked(len);
+            self.coeffs = c_tail;
+            self.vars = v_tail;
+            Some(c_head.iter_mut().zip(v_head))
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.offsets.len() - 1;
+        (len, Some(len))
+    }
+}
+
+#[cfg(feature = "parallel")]
+pub struct LcMapParIterMut<'a> {
+    coeffs: *mut InternedField,
+    vars: *mut Variable,
+    offsets: &'a [usize],
+}
+
+#[cfg(feature = "parallel")]
+#[allow(unsafe_code)]
+unsafe impl<'a> Send for LcMapParIterMut<'a> {}
+
+#[cfg(feature = "parallel")]
+#[allow(unsafe_code)]
+unsafe impl<'a> Sync for LcMapParIterMut<'a> {}
+
+#[cfg(feature = "parallel")]
+impl<'a> ParallelIterator for LcMapParIterMut<'a> {
+    type Item = LcMapIterMutItem<'a>;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        rayon::iter::plumbing::bridge(self, consumer)
+    }
+}
+
+#[cfg(feature = "parallel")]
+impl<'a> IndexedParallelIterator for LcMapParIterMut<'a> {
+    fn len(&self) -> usize {
+        self.offsets.len().saturating_sub(1)
+    }
+
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::Consumer<Self::Item>,
+    {
+        rayon::iter::plumbing::bridge(self, consumer)
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: rayon::iter::plumbing::ProducerCallback<Self::Item>,
+    {
+        struct Producer<'a> {
+            coeffs: *mut InternedField,
+            vars: *mut Variable,
+            offsets: &'a [usize],
+        }
+
+        #[allow(unsafe_code)]
+        unsafe impl<'a> Send for Producer<'a> {}
+        impl<'a> rayon::iter::plumbing::Producer for Producer<'a> {
+            type Item = LcMapIterMutItem<'a>;
+            type IntoIter = IntoIter<LcMapIterMutItem<'a>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.offsets
+                    .windows(2)
+                    .map(|window| {
+                        // SAFETY: See logic from `LcMapIterMut::next`
+                        let start = unsafe { *window.get_unchecked(0) };
+                        let end = unsafe { *window.get_unchecked(1) };
+                        let len = end - start;
+                        #[allow(unsafe_code)]
+                        unsafe {
+                            let coeffs_ptr = self.coeffs.add(start);
+                            let coeffs_slice = core::slice::from_raw_parts_mut(coeffs_ptr, len);
+                            let vars_ptr = self.vars.add(start);
+                            let vars_slice = core::slice::from_raw_parts_mut(vars_ptr, len);
+                            coeffs_slice.iter_mut().zip(vars_slice)
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .into_iter()
+            }
+
+            fn split_at(self, index: usize) -> (Self, Self) {
+                let (left, right) = self.offsets.split_at(index + 1);
+                (
+                    Producer {
+                        coeffs: self.coeffs,
+                        vars: self.vars,
+                        offsets: left,
+                    },
+                    Producer {
+                        coeffs: self.coeffs,
+                        vars: self.vars,
+                        offsets: right,
+                    },
+                )
+            }
+        }
+
+        callback.callback(Producer {
+            coeffs: self.coeffs,
+            vars: self.vars,
+            offsets: self.offsets,
+        })
+    }
+}

--- a/relations/src/gr1cs/lc_map.rs
+++ b/relations/src/gr1cs/lc_map.rs
@@ -12,14 +12,18 @@ use crate::gr1cs::{
 };
 
 /// The following invariant must always be maintained:
-/// 1. `self.offsets` is a non-empty vector of length `n + 1`, where `n` is the number of linear combinations.
-/// 2. `self.offsets[i]` is the index in `self.coeffs` and `self.vars` where the `i`-th linear combination starts.
-/// 3. `self.offsets[i + 1]` is the index in `self.coeffs` and `self.vars` where the `i`-th linear combination ends.
-/// 4. `self.coeffs` and `self.vars` are of the same length, and they contain the coefficients and variables of the linear combinations respectively.
+/// 1. `self.offsets` is a non-empty vector of length `n + 1`, where
+///    `n` is the number of linear combinations.
+/// 2. `self.offsets[i]` is the index in `self.coeffs` and `self.vars`
+///    where the `i`-th linear combination starts.
+/// 3. `self.offsets[i + 1]` is the index in `self.coeffs` and `self.vars`
+///    where the `i`-th linear combination ends.
+/// 4. `self.coeffs` and `self.vars` are of the same length,
+///    and they contain the coefficients and variables of the linear combinations respectively.
 /// 5. `self.coeffs` and `self.vars` are interleaved such that for each linear combination `i`,
-/// the coefficients and variables are stored in the same order, i.e.,
-/// letting `start = self.offsets[i]` and `end = self.offsets[i + 1]`, then
-/// `self.vars[start..end]` corresponds to `self.coeffs[start..end]
+///    the coefficients and variables are stored in the same order, i.e.,
+///    letting `start = self.offsets[i]` and `end = self.offsets[i + 1]`, then
+///    `self.vars[start..end]` corresponds to `self.coeffs[start..end]
 ///
 /// Invariants 2 and 3 imply the following lemma:
 /// Lemma 1. `self.offsets[i] <= self.offsets[i + 1]` for all `i` in `0..n`.
@@ -39,6 +43,7 @@ use crate::gr1cs::{
 ///   Assume not. Then there exists an `i` such that either
 ///   * `self.offsets[i + 1] - self.offsets[i] > self.vars.len()`
 ///   * `self.offsets[i + 1] - self.offsets[i] > self.coeffs.len()`
+///
 ///   In both cases, this would imply that the `i`-th linear combination
 ///   has more variables or coefficients than the total number of variables or coefficients,
 ///   which contradicts invariant 5.
@@ -228,8 +233,8 @@ unsafe fn windowed_access<'a>(
 
 /// Preconditions:
 /// 1. `w` is a slice of length 2.
-/// 2.`w[0] <= w[1]`.
-/// 3.`w[1] - w[0] < vars.len()`.
+/// 2. `w[0] <= w[1]`.
+/// 3. `w[1] - w[0] < vars.len()`.
 ///
 /// Note that precondition 3 here differs from that in `windowed_access`;
 /// instead of requiring that `w[1] < vars.len()`,

--- a/relations/src/gr1cs/lc_map.rs
+++ b/relations/src/gr1cs/lc_map.rs
@@ -234,7 +234,7 @@ unsafe fn windowed_access<'a>(
 /// Preconditions:
 /// 1. `w` is a slice of length 2.
 /// 2. `w[0] <= w[1]`.
-/// 3. `w[1] - w[0] < vars.len()`.
+/// 3. `w[1] - w[0] <= vars.len()`.
 ///
 /// Note that precondition 3 here differs from that in `windowed_access`;
 /// instead of requiring that `w[1] < vars.len()`,
@@ -251,10 +251,7 @@ unsafe fn windowed_access_mut<'b>(
 ) -> LcVarsIterMutItem<'b> {
     debug_assert!(w.len() == 2, "Expected a slice of length 2");
     debug_assert!(w[0] <= w[1], "Expected w[0] <= w[1]");
-    debug_assert!(
-        w[1] - w[0] < vars.len(),
-        "Expected w[1] - w[0] < vars.len()"
-    );
+    debug_assert!(w[1] - w[0] <= vars.len(), "`w[1] - w[0] > vars.len()`");
     #[allow(unsafe_code)]
     unsafe {
         let start = *w.get_unchecked(0);

--- a/relations/src/gr1cs/mod.rs
+++ b/relations/src/gr1cs/mod.rs
@@ -1,23 +1,24 @@
 //! Core interface for working with Generalized Rank-1 Constraint Systems
 //! (GR1CS).
 mod constraint_system_ref;
+mod namespace;
+#[macro_use]
+mod constraint_system;
+mod assignment;
+
+pub(crate) mod field_interner;
+mod lc_map;
 
 /// Interface for specifying strategies for reducing the number of constraints
 /// that public input/instance variables are involved in.
 pub mod instance_outliner;
-
-mod namespace;
-
 pub mod predicate;
-
-#[macro_use]
-mod constraint_system;
-
-#[cfg(test)]
-mod tests;
 
 #[cfg(feature = "std")]
 pub mod trace;
+
+#[cfg(test)]
+mod tests;
 ///////////////////////////////////////////////////////////////////////////////////////
 
 #[cfg(feature = "std")]
@@ -30,7 +31,8 @@ pub use ark_ff::{Field, ToConstraintField};
 
 pub use crate::{
     gr1cs::{
-        constraint_system::ConstraintSystem, constraint_system_ref::ConstraintSystemRef,
+        assignment::Assignments, constraint_system::ConstraintSystem,
+        constraint_system_ref::ConstraintSystemRef,
         predicate::polynomial_constraint::R1CS_PREDICATE_LABEL,
     },
     lc,

--- a/relations/src/gr1cs/mod.rs
+++ b/relations/src/gr1cs/mod.rs
@@ -53,6 +53,10 @@ pub use namespace::Namespace;
 // TODO: Think: should we replace this with just a closure?
 pub trait ConstraintSynthesizer<F: Field> {
     /// Drives generation of new constraints inside `cs`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if constraints cannot be generated successfully.
     fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> crate::gr1cs::Result<()>;
 }
 

--- a/relations/src/gr1cs/mod.rs
+++ b/relations/src/gr1cs/mod.rs
@@ -36,7 +36,7 @@ pub use crate::{
     lc,
     utils::{
         error::SynthesisError,
-        linear_combination::{LcIndex, LinearCombination},
+        linear_combination::LinearCombination,
         matrix::{mat_vec_mul, transpose, Matrix},
         variable::Variable,
         Result,

--- a/relations/src/gr1cs/namespace.rs
+++ b/relations/src/gr1cs/namespace.rs
@@ -30,14 +30,14 @@ impl<F: Field> Namespace<F> {
 
     /// Manually leave the namespace.
     pub fn leave_namespace(self) {
-        drop(self)
+        drop(self);
     }
 }
 
 impl<F: Field> Drop for Namespace<F> {
     fn drop(&mut self) {
         if let Some(id) = self.id.as_ref() {
-            tracing::dispatcher::get_default(|dispatch| dispatch.exit(id))
+            tracing::dispatcher::get_default(|dispatch| dispatch.exit(id));
         }
         let _ = self.inner;
     }

--- a/relations/src/gr1cs/predicate/mod.rs
+++ b/relations/src/gr1cs/predicate/mod.rs
@@ -1,4 +1,4 @@
-//! This module contains the implementation of a general  predicate, defined in https://eprint.iacr.org/2024/1245
+//! This module contains the implementation of a general  predicate, defined in <https://eprint.iacr.org/2024/1245>.
 //! A  predicate is a function from t (arity) variables to a boolean
 //! variable A predicate can be as simple as f(a,b,c)=a.b-c=0 or as
 //! complex as a lookup table
@@ -181,7 +181,7 @@ impl<F: Field> PredicateConstraintSystem<F> {
     }
 
     /// Check if the constraints enforced by this predicate are satisfied
-    /// i.e. L(x_1, x_2, ..., x_n) = 0.
+    /// i.e. `L(x_1, x_2, ..., x_n) == 0`.
     pub fn which_constraint_is_unsatisfied(&self, cs: &ConstraintSystem<F>) -> Option<usize> {
         for (i, constraint) in self.iter_constraints().enumerate() {
             let variables: Vec<F> = constraint

--- a/relations/src/gr1cs/predicate/polynomial_constraint.rs
+++ b/relations/src/gr1cs/predicate/polynomial_constraint.rs
@@ -1,5 +1,5 @@
 //! This module contains the implementation of the Polynomial Predicate struct.
-//! A polynomial predicate is a kind of  predicate which is defined in https://eprint.iacr.org/2024/1245.
+//! A polynomial predicate is a kind of predicate which is defined in <https://eprint.iacr.org/2024/1245>.
 //! Other kinds of  predicates can be added in the future such as lookup
 //! table predicates.
 

--- a/relations/src/lib.rs
+++ b/relations/src/lib.rs
@@ -1,15 +1,16 @@
 //! Core interface for working with various relations that are useful in
 //! zkSNARKs. At the moment, we only implement APIs for working with Generalized
-//! Rank-1 Constraint Systems (R1CS) (See https://eprint.iacr.org/2024/1245.pdf).
+//! Rank-1 Constraint Systems (R1CS) (See <https://eprint.iacr.org/2024/1245.pdf>).
 //!
 //! # Compatibility with R1CS
-//! In previous versions, this crate only supported R1CS. For ease of migration,
-//! a GR1CS instance is equipped with an R1CS predicate by default. Also, there
-//! is a separate
-//! [enforce_r1cs_constraint](`crate::gr1cs::ConstraintSystemRef::enforce_r1cs_constraint`) function that has the same API as the [enforce_constraint](https://docs.rs/ark-relations/latest/ark_relations/r1cs/enum.ConstraintSystemRef.html#method.enforce_constraint) function in
-//! previous versions. Hence, by replacing [enforce_constraint](https://docs.rs/ark-relations/latest/ark_relations/r1cs/enum.ConstraintSystemRef.html#method.enforce_constraint) with
-//! [enforce_r1cs_constraint](`crate::gr1cs::ConstraintSystemRef::enforce_r1cs_constraint`) and updating the `use` statements, you can migrate
-//! your code to the new version.
+//!
+//! In previous versions, this crate only supported R1CS.
+//! For ease of migration, a GR1CS instance is equipped with an R1CS predicate by default.
+//! Also, there is a separate
+//! [`enforce_r1cs_constraint`](`crate::gr1cs::ConstraintSystemRef::enforce_r1cs_constraint`) function that has the same API as the `enforce_constraint` function
+//! in previous versions.
+//! Hence, by replacing the latter with the former and updating `use` statements,
+//! you can migrate your code to the new version.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
@@ -17,7 +18,15 @@
     future_incompatible,
     nonstandard_style,
     rust_2018_idioms,
-    missing_docs
+    missing_docs,
+    clippy::pedantic
+)]
+#![allow(
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc,
+    clippy::must_use_candidate,
+    clippy::inline_always,
+    clippy::redundant_closure_for_method_calls
 )]
 #![deny(unsafe_code)]
 

--- a/relations/src/sr1cs/mod.rs
+++ b/relations/src/sr1cs/mod.rs
@@ -116,6 +116,11 @@ impl<F: Field> Sr1csAdapter<F> {
     }
 
     /// Converts an R1CS constraint system to an SR1CS constraint system.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the constraint system does not have the R1CS predicate registered or
+    /// if there is more than one predicate registered.
     pub fn r1cs_to_sr1cs(
         cs: &ConstraintSystemRef<F>,
     ) -> Result<ConstraintSystemRef<F>, SynthesisError> {
@@ -179,6 +184,10 @@ impl<F: Field> Sr1csAdapter<F> {
 
     /// Converts an R1CS constraint system to an SR1CS constraint system,
     /// while also converting the R1CS assignment to an equivalent SR1CS assignment.
+    ///
+    /// # Panics
+    ///
+    /// Panics is the constraint system does not have the R1CS predicate registered.
     pub fn r1cs_to_sr1cs_with_assignment(
         cs: &mut ConstraintSystem<F>,
     ) -> Result<ConstraintSystemRef<F>, SynthesisError> {

--- a/relations/src/sr1cs/mod.rs
+++ b/relations/src/sr1cs/mod.rs
@@ -263,7 +263,7 @@ mod tests {
     use ark_test_curves::bls12_381::Fr;
 
     use super::*;
-    #[derive(Copy)]
+
     struct DummyCircuit<F: PrimeField> {
         pub a: Option<F>,
         pub b: Option<F>,
@@ -274,14 +274,15 @@ mod tests {
     impl<F: PrimeField> Clone for DummyCircuit<F> {
         fn clone(&self) -> Self {
             DummyCircuit {
-                a: self.a.clone(),
-                b: self.b.clone(),
-                num_variables: self.num_variables.clone(),
-                num_constraints: self.num_constraints.clone(),
+                a: self.a,
+                b: self.b,
+                num_variables: self.num_variables,
+                num_constraints: self.num_constraints,
             }
         }
     }
 
+    impl<F: PrimeField> Copy for DummyCircuit<F> {}
     impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
         fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
             let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;

--- a/relations/src/utils/linear_combination.rs
+++ b/relations/src/utils/linear_combination.rs
@@ -9,10 +9,6 @@ use ark_std::{
 
 use super::variable::Variable;
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-/// An opaque counter for symbolic linear combinations.
-pub struct LcIndex(pub usize);
-
 /// A linear combination of variables according to associated coefficients.
 #[derive(Debug, Clone, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct LinearCombination<F: Field>(pub Vec<(F, Variable)>);
@@ -149,6 +145,16 @@ impl<F: Field> From<Variable> for LinearCombination<F> {
         } else {
             LinearCombination::from((F::one(), var))
         }
+    }
+}
+
+impl<F: Field> IntoIterator for LinearCombination<F> {
+    type Item = (F, Variable);
+    type IntoIter = ark_std::vec::IntoIter<(F, Variable)>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/relations/src/utils/linear_combination.rs
+++ b/relations/src/utils/linear_combination.rs
@@ -52,6 +52,7 @@ impl<F: Field> LinearCombination<F> {
     }
 
     /// Deduplicate entries in `self` by combining coefficients of identical variables.
+    #[inline]
     pub fn compactify(&mut self) {
         // For 0 or 1 element, there is nothing to do.
         if self.len() <= 1 {

--- a/relations/src/utils/linear_combination.rs
+++ b/relations/src/utils/linear_combination.rs
@@ -11,6 +11,7 @@ use super::variable::Variable;
 
 /// A linear combination of variables according to associated coefficients.
 #[derive(Debug, Clone, PartialEq, Eq, Default, PartialOrd, Ord)]
+#[must_use]
 pub struct LinearCombination<F: Field>(pub Vec<(F, Variable)>);
 
 /// Generate a `LinearCombination` from arithmetic expressions involving
@@ -39,7 +40,7 @@ macro_rules! lc_diff {
 impl<F: Field> LinearCombination<F> {
     /// Create a new empty linear combination.
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// Create a new empty linear combination.
@@ -166,6 +167,9 @@ impl<F: Field> LinearCombination<F> {
     }
 
     /// Get the location of a variable in `self`.
+    ///
+    /// # Errors
+    /// If the variable is not found, returns the index where it would be inserted.
     #[inline]
     pub fn get_var_loc(&self, search_var: &Variable) -> Result<usize, usize> {
         if self.0.len() < 6 {
@@ -303,9 +307,10 @@ where
     let mut i = 0;
     let mut j = 0;
     while i < cur.len() && j < other.len() {
+        use core::cmp::Ordering;
+
         let self_cur = &cur[i];
         let other_cur = &other[j];
-        use core::cmp::Ordering;
         match self_cur.1.cmp(&other_cur.1) {
             Ordering::Greater => {
                 new_vec.push((push_fn(other[j].0), other[j].1));
@@ -320,7 +325,7 @@ where
                 i += 1;
                 j += 1;
             },
-        };
+        }
     }
     new_vec.extend_from_slice(&cur[i..]);
     while j < other.0.len() {

--- a/relations/src/utils/linear_combination.rs
+++ b/relations/src/utils/linear_combination.rs
@@ -103,7 +103,7 @@ impl<F: Field> LinearCombination<F> {
     /// Create a new linear combination from the difference of two variables.
     pub fn diff_vars(a: Variable, b: Variable) -> Self {
         if a == b {
-            return LinearCombination::zero();
+            LinearCombination::zero()
         } else {
             LinearCombination(vec![(F::one(), a), (-F::one(), b)])
         }
@@ -130,7 +130,7 @@ impl<F: Field> From<(F, Variable)> for LinearCombination<F> {
     #[inline]
     fn from(input: (F, Variable)) -> Self {
         if input.0.is_zero() || input.1.is_zero() {
-            return LinearCombination::zero();
+            LinearCombination::zero()
         } else {
             LinearCombination(vec![input])
         }

--- a/relations/src/utils/matrix.rs
+++ b/relations/src/utils/matrix.rs
@@ -4,6 +4,7 @@ use ark_std::vec::Vec;
 pub type Matrix<F> = Vec<Vec<(F, usize)>>;
 
 /// Transpose a matrix of field elements.
+#[must_use]
 pub fn transpose<F: Field>(matrix: &Matrix<F>, num_col: usize) -> Matrix<F> {
     // Initialize the transposed matrix with empty vectors
     let mut transposed: Matrix<F> = vec![Vec::new(); num_col];

--- a/relations/src/utils/variable.rs
+++ b/relations/src/utils/variable.rs
@@ -82,29 +82,32 @@ impl Variable {
 }
 
 impl PartialOrd for Variable {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        use Variable::*;
-        match (self, other) {
-            (Zero, Zero) => Some(Ordering::Equal),
-            (One, One) => Some(Ordering::Equal),
-            (Zero, _) => Some(Ordering::Less),
-            (One, _) => Some(Ordering::Less),
-            (_, Zero) => Some(Ordering::Greater),
-            (_, One) => Some(Ordering::Greater),
-
-            (Instance(i), Instance(j)) | (Witness(i), Witness(j)) => i.partial_cmp(j),
-            (Instance(_), Witness(_)) => Some(Ordering::Less),
-            (Witness(_), Instance(_)) => Some(Ordering::Greater),
-
-            (SymbolicLc(i), SymbolicLc(j)) => i.partial_cmp(j),
-            (_, SymbolicLc(_)) => Some(Ordering::Less),
-            (SymbolicLc(_), _) => Some(Ordering::Greater),
-        }
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Variable {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        use Variable::*;
+        match (self, other) {
+            (Zero, Zero) => Ordering::Equal,
+            (One, One) => Ordering::Equal,
+            (Zero, _) => Ordering::Less,
+            (One, _) => Ordering::Less,
+            (_, Zero) => Ordering::Greater,
+            (_, One) => Ordering::Greater,
+
+            (Instance(i), Instance(j)) | (Witness(i), Witness(j)) => i.cmp(j),
+            (Instance(_), Witness(_)) => Ordering::Less,
+            (Witness(_), Instance(_)) => Ordering::Greater,
+
+            (SymbolicLc(i), SymbolicLc(j)) => i.cmp(j),
+            (_, SymbolicLc(_)) => Ordering::Less,
+            (SymbolicLc(_), _) => Ordering::Greater,
+        }
+
     }
 }

--- a/relations/src/utils/variable.rs
+++ b/relations/src/utils/variable.rs
@@ -143,7 +143,7 @@ impl Variable {
     /// Does not check that the tag and payload are valid.
     const fn pack_unchecked(tag: u64, payload: u64) -> Self {
         debug_assert!(payload <= Self::PAYLOAD_MASK);
-        Variable(((tag as u64) << Self::TAG_SHIFT) | payload & Self::PAYLOAD_MASK)
+        Variable((tag << Self::TAG_SHIFT) | payload & Self::PAYLOAD_MASK)
     }
 
     #[cfg(test)]

--- a/relations/src/utils/variable.rs
+++ b/relations/src/utils/variable.rs
@@ -1,5 +1,6 @@
 /// Variables in [`ConstraintSystem`]s
 #[derive(Copy, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[must_use]
 pub struct Variable(u64);
 
 impl Variable {
@@ -28,12 +29,14 @@ impl Variable {
 
     /// Is `self` the zero variable?
     #[inline(always)]
+    #[must_use]
     pub const fn is_zero(&self) -> bool {
         self.0 == 0
     }
 
     /// Is `self` the one variable?
     #[inline(always)]
+    #[must_use]
     pub const fn is_one(&self) -> bool {
         self.0 == Self::One.0
     }
@@ -52,6 +55,7 @@ impl Variable {
 
     /// Is `self` an instance variable?
     #[inline(always)]
+    #[must_use]
     pub const fn is_instance(self) -> bool {
         self.tag() == VarKind::Instance as u8
     }
@@ -64,6 +68,7 @@ impl Variable {
 
     /// Is `self` a witness variable?
     #[inline(always)]
+    #[must_use]
     pub const fn is_witness(self) -> bool {
         self.tag() == VarKind::Witness as u8
     }
@@ -76,12 +81,15 @@ impl Variable {
 
     /// Is `self` a symbolic linear combination variable?
     #[inline(always)]
+    #[must_use]
     pub const fn is_lc(self) -> bool {
         self.tag() == VarKind::SymbolicLc as u8
     }
 
     /// Get the `usize` in `self` if `self.is_lc()`.
     #[inline(always)]
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     pub const fn get_lc_index(&self) -> Option<usize> {
         if self.is_lc() {
             Some(self.payload() as usize)
@@ -92,6 +100,8 @@ impl Variable {
 
     /// Returns `Some(usize)` if `!self.is_lc()`, and `None` otherwise.
     #[inline(always)]
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     pub const fn get_variable_index(&self, witness_offset: usize) -> Option<usize> {
         match self.kind() {
             // The one variable always has index 0
@@ -133,6 +143,8 @@ impl Variable {
     /// If `self` is an instance, witness, or symbolic linear combination,
     /// returns the index of that variable.
     #[inline(always)]
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     pub const fn index(self) -> Option<usize> {
         match self.kind() {
             VarKind::Zero | VarKind::One => None,
@@ -161,6 +173,7 @@ impl Variable {
 /// The kinds of variables that can be used in a constraint system.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[allow(missing_docs)]
+#[must_use]
 pub enum VarKind {
     Zero = 0,
     One = 1,

--- a/relations/src/utils/variable.rs
+++ b/relations/src/utils/variable.rs
@@ -42,7 +42,7 @@ impl Variable {
 
     /// Construct an instance variable.
     #[inline(always)]
-    pub const fn Instance(i: usize) -> Self {
+    pub const fn instance(i: usize) -> Self {
         Self::pack(0b010, i as u64)
     }
 
@@ -54,7 +54,7 @@ impl Variable {
 
     /// Construct a new witness variable.
     #[inline(always)]
-    pub const fn Witness(i: usize) -> Self {
+    pub const fn witness(i: usize) -> Self {
         Self::pack(0b011, i as u64)
     }
 
@@ -66,7 +66,7 @@ impl Variable {
 
     /// Construct a symbolic linear combination variable.
     #[inline(always)]
-    pub const fn SymbolicLc(i: usize) -> Self {
+    pub const fn symbolic_lc(i: usize) -> Self {
         Self::pack(0b100, i as u64)
     }
 

--- a/relations/src/utils/variable.rs
+++ b/relations/src/utils/variable.rs
@@ -85,7 +85,7 @@ impl Variable {
             None
         }
     }
-    
+
     /// Returns `Some(usize)` if `!self.is_lc()`, and `None` otherwise.
     #[inline(always)]
     pub const fn get_variable_index(&self, witness_offset: usize) -> Option<usize> {
@@ -97,13 +97,13 @@ impl Variable {
             _ => None,
         }
     }
-    
+
     /// Returns the tag of the variable.
     #[inline(always)]
     const fn tag(self) -> u8 {
         (self.0 & Self::TAG_MASK) as u8
     }
-    
+
     /// Unconditionally returns the payload of the variable.
     /// Note that when `self.tag() == 0` or `self.tag() == 1`, the data
     /// value is not meaningful.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- Switch around `PartialOrd` and `Ord` impls to avoid wrapping and then unwrapping `Some`.
- Pack `Variable` into `u64` instead of current `enum` which requires `128` bits due to alignment.
- Create a new `LcMap` struct to abstract storage of `LinearCombination`s.
	- The new `LcMap` uses a more-cache-friendly storage backend.
- Introduces a new `FieldInterner` that avoids duplication of field elements in `LinearCombination`s in the `ConstraintSystem`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
