### PR TITLE
fix(gr1cs): return None instead of panicking on invalid get_lc index

### DIFF
--- a/relations/src/gr1cs/constraint_system.rs
+++ b/relations/src/gr1cs/constraint_system.rs
@@ -774,16 +774,20 @@ impl<F: Field> ConstraintSystem<F> {
     }
 
     /// Get the linear combination corresponding to the given `lc_index`.
-    pub fn get_lc(&self, var: Variable) -> LinearCombination<F> {
+    ///
+    /// Returns `None` if `var` is a symbolic linear combination variable
+    /// whose index does not exist in this constraint system (e.g. it was
+    /// created by a different `ConstraintSystem`).
+    pub fn get_lc(&self, var: Variable) -> Option<LinearCombination<F>> {
         if var.is_zero() {
-            LinearCombination::zero()
+            Some(LinearCombination::zero())
         } else if var.is_lc() {
-            let idx = var.index().unwrap();
-            LinearCombination(
-                to_non_interned_lc(self.lc_map.get(idx).unwrap(), &self.field_interner).collect(),
-            )
+            let idx = var.index()?;
+            Some(LinearCombination(
+                to_non_interned_lc(self.lc_map.get(idx)?, &self.field_interner).collect(),
+            ))
         } else {
-            LinearCombination::from(var)
+            Some(LinearCombination::from(var))
         }
     }
 

--- a/relations/src/gr1cs/constraint_system_ref.rs
+++ b/relations/src/gr1cs/constraint_system_ref.rs
@@ -496,7 +496,7 @@ impl<F: Field> ConstraintSystemRef<F> {
     /// TODO: This function should ideally return a reference to the linear
     /// combination and not clone it.
     pub fn get_lc(&self, var: Variable) -> Option<LinearCombination<F>> {
-        self.inner().map(|cs| cs.borrow().get_lc(var))
+        self.inner().and_then(|cs| cs.borrow().get_lc(var))
     }
 
     /// Given a linear combination, create a row in the matrix

--- a/relations/src/gr1cs/predicate/mod.rs
+++ b/relations/src/gr1cs/predicate/mod.rs
@@ -190,6 +190,8 @@ impl<F: Field> PredicateConstraintSystem<F> {
                 .map(|v| {
                     cs.assigned_value(v).unwrap_or_else(|| {
                         cs.get_lc(v)
+                            .expect("v is an lc index registered by this predicate's own \
+                                enforce_constraint calls, so it must exist in cs's lc_map")
                             .iter()
                             .map(|&(c, v)| c * cs.assigned_value(v).unwrap_or_else(|| panic_msg(v)))
                             .sum()
@@ -208,7 +210,10 @@ impl<F: Field> PredicateConstraintSystem<F> {
         let mut matrices: Vec<Matrix<F>> = vec![Vec::new(); self.get_arity()];
         for constraint in self.iter_constraints() {
             for (matrix_ind, lc_index) in constraint.iter().enumerate() {
-                let lc = cs.get_lc(*lc_index);
+                let lc = cs.get_lc(*lc_index).expect(
+                    "lc_index is registered by this predicate's own enforce_constraint \
+                    calls, so it must exist in cs's lc_map",
+                );
                 let row = cs.make_row(lc);
                 matrices[matrix_ind].push(row);
             }


### PR DESCRIPTION
## What

`ConstraintSystem::get_lc(&self, var: Variable) -> LinearCombination<F>` unwrapped internally on both `var.index()` and `self.lc_map.get(idx)` when `var` was a symbolic linear-combination variable. Both unwraps panic if `var` carries an lc index that doesn't exist in this constraint system's `lc_map` — which happens for any `Variable` originating from a *different* `ConstraintSystem` (or a stale/reused index after the map has been rebuilt), since `get_lc` is a public method with no way to check validity beforehand.

## Fix

Changed the signature to return `Option<LinearCombination<F>>`, using `?` in place of the two unwraps.

- This composes naturally with `ConstraintSystemRef::get_lc`, which already returned `Option<LinearCombination<F>>` (previously only to represent "this ref isn't backed by an inner `ConstraintSystem` yet"). Updated its `.map(...)` to `.and_then(...)` so the panic doesn't just resurface unhandled through the wrapper.
- The two internal call sites in `PredicateConstraintSystem` (`which_constraint_is_unsatisfied` and `to_matrices`) always pass an `lc_index` that this same predicate registered via its own `enforce_constraint` calls, so the index is guaranteed present — changed both to `.expect("...")` with a comment explaining why, rather than silently unwrapping or threading `Option` further into functions whose own signatures don't support propagating a failure.
- No other call sites exist in the repo (searched for `.get_lc`).

## Testing

```
cargo build -p ark-relations
cargo test -p ark-relations
```

Both clean — 9/9 tests pass, no regressions.

(Note: `cargo clippy -p ark-relations -- -D warnings` surfaces a number of pre-existing lint issues unrelated to this change, in files this PR doesn't touch — happy to clean those up separately if useful, but didn't want to bundle unrelated fixes into this PR.)